### PR TITLE
rt: abstract away the buffer backing of acceleration structures

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -304,8 +304,9 @@ impl crate::traits::TransferEncoder for super::PassEncoder<'_, ()> {
     }
 }
 
-impl super::PassEncoder<'_, ()> {
-    pub fn build_bottom_level(
+#[hidden_trait::expose]
+impl crate::traits::AccelerationStructureEncoder for super::PassEncoder<'_, ()> {
+    fn build_bottom_level(
         &mut self,
         _acceleration_structure: super::AccelerationStructure,
         _meshes: &[crate::AccelerationStructureMesh],
@@ -314,7 +315,7 @@ impl super::PassEncoder<'_, ()> {
         unimplemented!()
     }
 
-    pub fn build_top_level(
+    fn build_top_level(
         &mut self,
         _acceleration_structure: super::AccelerationStructure,
         _instance_count: u32,

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -22,20 +22,6 @@ impl super::Context {
     ) -> super::Buffer {
         unimplemented!()
     }
-
-    pub fn create_acceleration_structure(
-        &self,
-        _desc: crate::AccelerationStructureDesc,
-    ) -> super::AccelerationStructure {
-        unimplemented!()
-    }
-
-    pub fn destroy_acceleration_structure(
-        &self,
-        _acceleration_structure: super::AccelerationStructure,
-    ) {
-        unimplemented!()
-    }
 }
 
 #[hidden_trait::expose]
@@ -44,6 +30,7 @@ impl crate::traits::ResourceDevice for super::Context {
     type Texture = super::Texture;
     type TextureView = super::TextureView;
     type Sampler = super::Sampler;
+    type AccelerationStructure = super::AccelerationStructure;
 
     fn create_buffer(&self, desc: crate::BufferDesc) -> super::Buffer {
         let gl = self.lock();
@@ -314,6 +301,20 @@ impl crate::traits::ResourceDevice for super::Context {
     fn destroy_sampler(&self, sampler: super::Sampler) {
         let gl = self.lock();
         unsafe { gl.delete_sampler(sampler.raw) };
+    }
+
+    fn create_acceleration_structure(
+        &self,
+        _desc: crate::AccelerationStructureDesc,
+    ) -> super::AccelerationStructure {
+        unimplemented!()
+    }
+
+    fn destroy_acceleration_structure(
+        &self,
+        _acceleration_structure: super::AccelerationStructure,
+    ) {
+        unimplemented!()
     }
 }
 

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -46,7 +46,6 @@ pub mod limits {
     pub const PLAIN_DATA_SIZE: u32 = 256;
     pub const RESOURCES_IN_GROUP: u32 = 8;
     pub const STORAGE_BUFFER_ALIGNMENT: u64 = 256;
-    pub const ACCELERATION_STRUCTURE_BUFFER_ALIGNMENT: u64 = 256;
     pub const ACCELERATION_STRUCTURE_SCRATCH_ALIGNMENT: u64 = 256;
 }
 
@@ -349,10 +348,6 @@ pub enum AccelerationStructureType {
 pub struct AccelerationStructureDesc<'a> {
     pub name: &'a str,
     pub ty: AccelerationStructureType,
-    pub buffer: Buffer,
-    /// Offset into the buffer where AS is placed.
-    /// Must be a multiple of `limits::ACCELERATION_STRUCTURE_BUFFER_ALIGNMENT`.
-    pub offset: u64,
     pub size: u64,
 }
 

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -301,9 +301,11 @@ impl Drop for super::TransferCommandEncoder<'_> {
     }
 }
 
-impl<'a> super::AccelerationStructureCommandEncoder<'a> {
-    //TODO: move into the trait
-    pub fn build_bottom_level(
+#[hidden_trait::expose]
+impl crate::traits::AccelerationStructureEncoder
+    for super::AccelerationStructureCommandEncoder<'_>
+{
+    fn build_bottom_level(
         &mut self,
         _acceleration_structure: super::AccelerationStructure,
         _meshes: &[crate::AccelerationStructureMesh],
@@ -312,7 +314,7 @@ impl<'a> super::AccelerationStructureCommandEncoder<'a> {
         unimplemented!()
     }
 
-    pub fn build_top_level(
+    fn build_top_level(
         &mut self,
         _acceleration_structure: super::AccelerationStructure,
         _instance_count: u32,

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -85,20 +85,6 @@ impl super::Context {
     ) -> super::Buffer {
         unimplemented!()
     }
-
-    pub fn create_acceleration_structure(
-        &self,
-        _desc: crate::AccelerationStructureDesc,
-    ) -> super::AccelerationStructure {
-        unimplemented!()
-    }
-
-    pub fn destroy_acceleration_structure(
-        &self,
-        _acceleration_structure: super::AccelerationStructure,
-    ) {
-        unimplemented!()
-    }
 }
 
 #[hidden_trait::expose]
@@ -107,6 +93,7 @@ impl crate::traits::ResourceDevice for super::Context {
     type Texture = super::Texture;
     type TextureView = super::TextureView;
     type Sampler = super::Sampler;
+    type AccelerationStructure = super::AccelerationStructure;
 
     fn create_buffer(&self, desc: crate::BufferDesc) -> super::Buffer {
         let options = match desc.memory {
@@ -276,5 +263,19 @@ impl crate::traits::ResourceDevice for super::Context {
         unsafe {
             let () = msg_send![sampler.raw, release];
         }
+    }
+
+    fn create_acceleration_structure(
+        &self,
+        _desc: crate::AccelerationStructureDesc,
+    ) -> super::AccelerationStructure {
+        unimplemented!()
+    }
+
+    fn destroy_acceleration_structure(
+        &self,
+        _acceleration_structure: super::AccelerationStructure,
+    ) {
+        unimplemented!()
     }
 }

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -4,6 +4,7 @@ pub trait ResourceDevice {
     type Texture: Clone + Copy + Debug + Hash + PartialEq;
     type TextureView: Clone + Copy + Debug + Hash + PartialEq;
     type Sampler: Clone + Copy + Debug + Hash + PartialEq;
+    type AccelerationStructure: Clone + Copy + Debug + Hash + PartialEq;
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
     fn sync_buffer(&self, buffer: Self::Buffer);
@@ -14,6 +15,11 @@ pub trait ResourceDevice {
     fn destroy_texture_view(&self, view: Self::TextureView);
     fn create_sampler(&self, desc: super::SamplerDesc) -> Self::Sampler;
     fn destroy_sampler(&self, sampler: Self::Sampler);
+    fn create_acceleration_structure(
+        &self,
+        desc: super::AccelerationStructureDesc,
+    ) -> Self::AccelerationStructure;
+    fn destroy_acceleration_structure(&self, acceleration_structure: Self::AccelerationStructure);
 }
 
 pub trait CommandDevice {
@@ -55,6 +61,23 @@ pub trait TransferEncoder {
         dst: super::BufferPiece,
         bytes_per_row: u32,
         size: super::Extent,
+    );
+}
+
+pub trait AccelerationStructureEncoder {
+    fn build_bottom_level(
+        &mut self,
+        acceleration_structure: crate::AccelerationStructure,
+        meshes: &[super::AccelerationStructureMesh],
+        scratch_data: super::BufferPiece,
+    );
+
+    fn build_top_level(
+        &mut self,
+        acceleration_structure: crate::AccelerationStructure,
+        instance_count: u32,
+        instance_data: super::BufferPiece,
+        scratch_data: super::BufferPiece,
     );
 }
 

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -426,9 +426,11 @@ impl crate::traits::TransferEncoder for super::TransferCommandEncoder<'_> {
     }
 }
 
-impl<'a> super::AccelerationStructureCommandEncoder<'a> {
-    //TODO: move into the trait
-    pub fn build_bottom_level(
+#[hidden_trait::expose]
+impl crate::traits::AccelerationStructureEncoder
+    for super::AccelerationStructureCommandEncoder<'_>
+{
+    fn build_bottom_level(
         &mut self,
         acceleration_structure: super::AccelerationStructure,
         meshes: &[crate::AccelerationStructureMesh],
@@ -450,7 +452,7 @@ impl<'a> super::AccelerationStructureCommandEncoder<'a> {
         }
     }
 
-    pub fn build_top_level(
+    fn build_top_level(
         &mut self,
         acceleration_structure: super::AccelerationStructure,
         instance_count: u32,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -151,6 +151,8 @@ pub struct Sampler {
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct AccelerationStructure {
     raw: vk::AccelerationStructureKHR,
+    buffer: vk::Buffer,
+    memory_handle: usize,
 }
 
 #[derive(Debug, Default)]

--- a/examples/ray-trace/main.rs
+++ b/examples/ray-trace/main.rs
@@ -24,9 +24,7 @@ struct ShaderData {
 struct Example {
     start_time: time::Instant,
     blas: blade::AccelerationStructure,
-    blas_buffer: blade::Buffer,
     tlas: blade::AccelerationStructure,
-    tlas_buffer: blade::Buffer,
     pipeline: blade::RenderPipeline,
     command_encoder: blade::CommandEncoder,
     prev_sync_point: Option<blade::SyncPoint>,
@@ -122,16 +120,9 @@ impl Example {
             is_opaque: true,
         }];
         let blas_sizes = context.get_bottom_level_acceleration_structure_sizes(&meshes);
-        let blas_buffer = context.create_buffer(blade::BufferDesc {
-            name: "BLAS",
-            size: blas_sizes.data,
-            memory: blade::Memory::Device,
-        });
         let blas = context.create_acceleration_structure(blade::AccelerationStructureDesc {
             name: "triangle",
             ty: blade::AccelerationStructureType::BottomLevel,
-            buffer: blas_buffer,
-            offset: 0,
             size: blas_sizes.data,
         });
 
@@ -162,16 +153,9 @@ impl Example {
         ];
         let tlas_sizes = context.get_top_level_acceleration_structure_sizes(instances.len() as u32);
         let instance_buffer = context.create_acceleration_structure_instance_buffer(&instances);
-        let tlas_buffer = context.create_buffer(blade::BufferDesc {
-            name: "TLAS",
-            size: tlas_sizes.data,
-            memory: blade::Memory::Device,
-        });
         let tlas = context.create_acceleration_structure(blade::AccelerationStructureDesc {
             name: "TLAS",
             ty: blade::AccelerationStructureType::TopLevel,
-            buffer: tlas_buffer,
-            offset: 0,
             size: tlas_sizes.data,
         });
         let tlas_scratch_offset = (blas_sizes.scratch
@@ -211,9 +195,7 @@ impl Example {
         Self {
             start_time: time::Instant::now(),
             blas,
-            blas_buffer,
             tlas,
-            tlas_buffer,
             pipeline,
             command_encoder,
             prev_sync_point: None,
@@ -227,8 +209,7 @@ impl Example {
             self.context.wait_for(&sp, !0);
         }
         self.context.destroy_acceleration_structure(self.blas);
-        self.context.destroy_buffer(self.blas_buffer);
-        self.context.destroy_buffer(self.tlas_buffer);
+        self.context.destroy_acceleration_structure(self.tlas);
     }
 
     fn render(&mut self) {


### PR DESCRIPTION
Follow-up to #7 
Makes the creation of acceleration structures nicer, also aligns better with Metal.