### PR TITLE
Asset manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 .DS_Store
+cooked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ egui = "0.20"
 glam = { version = "0.23", features = ["mint"] }
 log = "0.4"
 mint = "0.5"
-naga = { git = "https://github.com/kvark/naga", branch = "storage-array", features = ["wgsl-in", "span", "validate"] }
+naga = { git = "https://github.com/gfx-rs/naga", rev = "9befaed7e985fb9a23322e9f19baf2a95bfd8b9c", features = ["wgsl-in", "span", "validate"] }
 web-sys = "0.3.60"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "blade-asset",
     "blade-egui",
     "blade-graphics",
     "blade-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "blade-graphics",
     "blade-macros",
     "blade-render",
-    "run-wasm",
 ]
 exclude = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ readme = "docs/README.md"
 [features]
 
 [dependencies]
+blade-asset = { version = "0.1.0", path = "blade-asset" }
 blade-macros = { version = "0.2.0", path = "blade-macros" }
 blade-graphics = { version = "0.2.0", path = "blade-graphics" }
 blade-render = { version = "0.1.0", path = "blade-render" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = []
 
 [workspace.dependencies]
 bytemuck = { version = "1", features = ["derive"] }
+choir = { version = "0.5", git = "https://github.com/kvark/choir", rev = "7a4c6534953553dd12d8ec58ada579c083dce68c" }
 egui = "0.20"
 glam = { version = "0.23", features = ["mint"] }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ blade-render = { version = "0.1.0", path = "blade-render" }
 [dev-dependencies]
 blade-egui = { version = "0.1.0", path = "blade-egui" }
 bytemuck = { workspace = true }
+choir = { workspace = true }
 egui = { workspace = true }
 del-msh = "0.1"
 glam = { workspace = true }

--- a/blade-asset/Cargo.toml
+++ b/blade-asset/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/kvark/blade"
 [dependencies]
 base64 = "0.21"
 bytemuck = { workspace = true }
-choir = { version = "0.5", git = "https://github.com/kvark/choir" }
+choir = { workspace = true }
 log = { workspace = true }

--- a/blade-asset/Cargo.toml
+++ b/blade-asset/Cargo.toml
@@ -11,5 +11,6 @@ repository = "https://github.com/kvark/blade"
 
 [dependencies]
 base64 = "0.21"
+bytemuck = { workspace = true }
 choir = { version = "0.5", git = "https://github.com/kvark/choir" }
 log = { workspace = true }

--- a/blade-asset/Cargo.toml
+++ b/blade-asset/Cargo.toml
@@ -10,5 +10,6 @@ repository = "https://github.com/kvark/blade"
 [lib]
 
 [dependencies]
+base64 = "0.21"
 choir = { version = "0.5", git = "https://github.com/kvark/choir" }
 log = { workspace = true }

--- a/blade-asset/Cargo.toml
+++ b/blade-asset/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "blade-asset"
+version = "0.1.0"
+edition = "2021"
+description = "Asset manager for Blade"
+keywords = ["asset"]
+license = "MIT"
+repository = "https://github.com/kvark/blade"
+
+[lib]
+
+[dependencies]
+choir = { version = "0.5", git = "https://github.com/kvark/choir" }
+log = { workspace = true }

--- a/blade-asset/src/arena.rs
+++ b/blade-asset/src/arena.rs
@@ -1,0 +1,75 @@
+use std::{
+    marker::PhantomData,
+    num::NonZeroU32,
+    ops,
+    sync::{
+        atomic::{AtomicPtr, Ordering},
+        Mutex,
+    },
+};
+
+#[repr(C)]
+struct Address {
+    index: NonZeroU32,
+    chunk: u8,
+}
+
+pub struct Handle<T>(Address, PhantomData<T>);
+
+const MAX_CHUNKS: usize = 30;
+
+#[derive(Default)]
+struct FreeManager<T> {
+    chunk_bases: Vec<*mut [T]>,
+    free_list: Vec<Address>,
+}
+
+pub struct Arena<T> {
+    init_size: usize,
+    chunks: [AtomicPtr<T>; MAX_CHUNKS],
+    freeman: Mutex<FreeManager<T>>,
+}
+
+impl<T> ops::Index<Handle<T>> for Arena<T> {
+    type Output = T;
+    fn index(&self, handle: Handle<T>) -> &T {
+        let first_ptr = &self.chunks[handle.0.chunk as usize].load(Ordering::Acquire);
+        unsafe { &*first_ptr.add(handle.0.index.get() as usize) }
+    }
+}
+
+impl<T: Default> Arena<T> {
+    pub fn new(init_size: usize) -> Self {
+        Self {
+            init_size,
+            chunks: Default::default(),
+            freeman: Mutex::default(),
+        }
+    }
+
+    pub fn alloc(&self) -> Handle<T> {
+        let mut freeman = self.freeman.lock().unwrap();
+        let address = match freeman.free_list.pop() {
+            Some(address) => address,
+            None => {
+                let address = Address {
+                    index: NonZeroU32::new(1).unwrap(),
+                    chunk: freeman.chunk_bases.len() as _,
+                };
+                let size = self.init_size << freeman.chunk_bases.len();
+                let mut data = (0..size).map(|_| T::default()).collect::<Box<[T]>>();
+                self.chunks[address.chunk as usize]
+                    .store(data.first_mut().unwrap(), Ordering::Release);
+                freeman.chunk_bases.push(Box::into_raw(data));
+                address
+            }
+        };
+        Handle(address, PhantomData)
+    }
+}
+
+// Ensure the `Option<Handle>` doesn't have any overhead
+#[cfg(test)]
+unsafe fn test_option_handle<A>(handle: Handle<A>) -> Option<Handle<A>> {
+    std::mem::transmute(handle)
+}

--- a/blade-asset/src/arena.rs
+++ b/blade-asset/src/arena.rs
@@ -1,7 +1,7 @@
 use std::{
     marker::PhantomData,
-    num::NonZeroU32,
-    ops,
+    num::NonZeroU8,
+    ops, ptr,
     sync::{
         atomic::{AtomicPtr, Ordering},
         Mutex,
@@ -9,12 +9,19 @@ use std::{
 };
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Hash)]
 struct Address {
-    index: NonZeroU32,
-    chunk: u8,
+    index: u32,
+    chunk: NonZeroU8,
 }
 
 pub struct Handle<T>(Address, PhantomData<T>);
+impl<T> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        Handle(self.0, PhantomData)
+    }
+}
+impl<T> Copy for Handle<T> {}
 
 const MAX_CHUNKS: usize = 30;
 
@@ -25,7 +32,7 @@ struct FreeManager<T> {
 }
 
 pub struct Arena<T> {
-    init_size: usize,
+    min_size: usize,
     chunks: [AtomicPtr<T>; MAX_CHUNKS],
     freeman: Mutex<FreeManager<T>>,
 }
@@ -33,43 +40,69 @@ pub struct Arena<T> {
 impl<T> ops::Index<Handle<T>> for Arena<T> {
     type Output = T;
     fn index(&self, handle: Handle<T>) -> &T {
-        let first_ptr = &self.chunks[handle.0.chunk as usize].load(Ordering::Acquire);
-        unsafe { &*first_ptr.add(handle.0.index.get() as usize) }
+        let first_ptr = &self.chunks[handle.0.chunk.get() as usize].load(Ordering::Acquire);
+        unsafe { &*first_ptr.add(handle.0.index as usize) }
     }
 }
 
 impl<T: Default> Arena<T> {
-    pub fn new(init_size: usize) -> Self {
+    pub fn new(min_size: usize) -> Self {
+        assert_ne!(min_size, 0);
+        let dummy_data = Some(T::default()).into_iter().collect::<Box<[T]>>();
         Self {
-            init_size,
+            min_size,
             chunks: Default::default(),
-            freeman: Mutex::default(),
+            freeman: Mutex::new(FreeManager {
+                chunk_bases: vec![Box::into_raw(dummy_data)],
+                free_list: Vec::new(),
+            }),
         }
     }
 
-    pub fn alloc(&self) -> Handle<T> {
+    pub fn alloc(&self, value: T) -> Handle<T> {
         let mut freeman = self.freeman.lock().unwrap();
-        let address = match freeman.free_list.pop() {
-            Some(address) => address,
+        let (address, chunk_start) = match freeman.free_list.pop() {
+            Some(address) => {
+                let chunk_start = self.chunks[address.chunk.get() as usize].load(Ordering::Acquire);
+                (address, chunk_start)
+            }
             None => {
                 let address = Address {
-                    index: NonZeroU32::new(1).unwrap(),
-                    chunk: freeman.chunk_bases.len() as _,
+                    index: 0,
+                    chunk: NonZeroU8::new(freeman.chunk_bases.len() as _).unwrap(),
                 };
-                let size = self.init_size << freeman.chunk_bases.len();
+                let size = self.min_size << freeman.chunk_bases.len();
                 let mut data = (0..size).map(|_| T::default()).collect::<Box<[T]>>();
-                self.chunks[address.chunk as usize]
-                    .store(data.first_mut().unwrap(), Ordering::Release);
+                let chunk_start = data.first_mut().unwrap() as *mut T;
+                self.chunks[address.chunk.get() as usize].store(chunk_start, Ordering::Release);
                 freeman.chunk_bases.push(Box::into_raw(data));
-                address
+                (address, chunk_start)
             }
         };
+        unsafe {
+            ptr::write(chunk_start.add(address.index as usize), value);
+        }
         Handle(address, PhantomData)
+    }
+}
+
+impl<T> Drop for FreeManager<T> {
+    fn drop(&mut self) {
+        for base in self.chunk_bases.drain(..) {
+            let _ = unsafe { Box::from_raw(base) };
+        }
     }
 }
 
 // Ensure the `Option<Handle>` doesn't have any overhead
 #[cfg(test)]
-unsafe fn test_option_handle<A>(handle: Handle<A>) -> Option<Handle<A>> {
+unsafe fn _test_option_handle<A>(handle: Handle<A>) -> Option<Handle<A>> {
     std::mem::transmute(handle)
+}
+
+#[test]
+fn test_single_thread() {
+    let arena = Arena::<usize>::new(1);
+    let _ = arena.alloc(3);
+    let _ = arena.alloc(4);
 }

--- a/blade-asset/src/arena.rs
+++ b/blade-asset/src/arena.rs
@@ -84,6 +84,16 @@ impl<T: Default> Arena<T> {
         }
         Handle(address, PhantomData)
     }
+
+    pub fn alloc_default(&self) -> (Handle<T>, *mut T) {
+        let handle = self.alloc(T::default());
+        (handle, self.get_mut_ptr(handle))
+    }
+
+    pub fn get_mut_ptr(&self, handle: Handle<T>) -> *mut T {
+        let first_ptr = &self.chunks[handle.0.chunk.get() as usize].load(Ordering::Acquire);
+        unsafe { first_ptr.add(handle.0.index as usize) }
+    }
 }
 
 impl<T> Drop for FreeManager<T> {

--- a/blade-asset/src/flat.rs
+++ b/blade-asset/src/flat.rs
@@ -1,0 +1,88 @@
+use std::{mem, num::NonZeroUsize, ptr, slice};
+
+pub trait Flat {
+    /// Type alignment, must be a power of two.
+    const ALIGNMENT: usize;
+    /// Size of the type, only if it's fixed.
+    const FIXED_SIZE: Option<NonZeroUsize>;
+    /// Size of the object.
+    fn size(&self) -> usize {
+        Self::FIXED_SIZE.unwrap().get()
+    }
+    /// Write self at the specified pointer.
+    /// The pointer is guaranteed to be valid and aligned accordingly.
+    unsafe fn write(&self, ptr: *mut u8);
+    /// Read self from the specified pointer.
+    /// The pointer is guaranteed to be valid and aligned accordingly.
+    unsafe fn read(ptr: *const u8) -> Self;
+}
+
+macro_rules! impl_basic {
+    ($ty: ident) => {
+        impl Flat for $ty {
+            const ALIGNMENT: usize = mem::align_of::<Self>();
+            const FIXED_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(mem::size_of::<Self>());
+            unsafe fn write(&self, ptr: *mut u8) {
+                ptr::write(ptr as *mut Self, *self);
+            }
+            unsafe fn read(ptr: *const u8) -> Self {
+                ptr::read(ptr as *const Self)
+            }
+        }
+    };
+}
+
+impl_basic!(u32);
+impl_basic!(f32);
+
+/*
+impl<T: bytemuck::Pod> Flat for T {
+    const ALIGNMENT: usize = mem::align_of::<T>();
+    const FIXED_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(mem::size_of::<T>());
+    unsafe fn write(&self, ptr: *mut u8) {
+        ptr::write(ptr as *mut T, *self);
+    }
+    unsafe fn read(ptr: *const u8) {
+        ptr::read(ptr as *const T)
+    }
+}*/
+
+pub fn round_up(size: usize, alignment: usize) -> usize {
+    (size + alignment - 1) & !(alignment - 1)
+}
+
+impl<T: bytemuck::Pod, const C: usize> Flat for [T; C] {
+    const ALIGNMENT: usize = mem::align_of::<T>();
+    const FIXED_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(mem::size_of::<Self>());
+    unsafe fn write(&self, ptr: *mut u8) {
+        ptr::copy_nonoverlapping(self.as_ptr(), ptr as *mut T, C);
+    }
+    unsafe fn read(ptr: *const u8) -> Self {
+        ptr::read(ptr as *const Self)
+    }
+}
+
+impl<'a, T: bytemuck::Pod> Flat for &'a [T] {
+    const ALIGNMENT: usize = mem::align_of::<T>();
+    const FIXED_SIZE: Option<NonZeroUsize> = None;
+    fn size(&self) -> usize {
+        let elem_size = round_up(mem::size_of::<T>(), mem::align_of::<T>());
+        round_up(mem::size_of::<usize>(), mem::align_of::<T>()) + elem_size * self.len()
+    }
+    unsafe fn write(&self, ptr: *mut u8) {
+        ptr::write(ptr as *mut usize, self.len());
+        if !self.is_empty() {
+            let offset = round_up(mem::size_of::<usize>(), mem::align_of::<T>());
+            ptr::copy_nonoverlapping(self.as_ptr(), ptr.add(offset) as *mut T, self.len());
+        }
+    }
+    unsafe fn read(ptr: *const u8) -> Self {
+        let counter = ptr::read(ptr as *const usize);
+        if counter != 0 {
+            let offset = round_up(mem::size_of::<usize>(), mem::align_of::<T>());
+            slice::from_raw_parts(ptr.add(offset) as *const T, counter)
+        } else {
+            &[]
+        }
+    }
+}

--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -1,0 +1,18 @@
+use std::{mem, path::PathBuf};
+
+mod arena;
+
+pub use arena::Handle;
+
+struct Slot<A> {
+    load_task: Option<choir::RunningTask>,
+    iteration: usize,
+    asset: A,
+}
+
+struct AssetManager<A> {
+    root: PathBuf,
+    slots: arena::Arena<Slot<A>>,
+}
+
+impl<A> AssetManager<A> {}

--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -1,18 +1,75 @@
-use std::{mem, path::PathBuf};
+use std::{
+    collections::hash_map::{Entry, HashMap},
+    ops,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
 
 mod arena;
 
-pub use arena::Handle;
+pub struct Handle<A> {
+    inner: arena::Handle<Slot<A>>,
+    generation: u32,
+}
+impl<A> Clone for Handle<A> {
+    fn clone(&self) -> Self {
+        Handle {
+            inner: self.inner,
+            generation: self.generation,
+        }
+    }
+}
+impl<A> Copy for Handle<A> {}
 
+#[derive(Default)]
 struct Slot<A> {
     load_task: Option<choir::RunningTask>,
-    iteration: usize,
+    generation: u32,
     asset: A,
 }
 
 struct AssetManager<A> {
     root: PathBuf,
     slots: arena::Arena<Slot<A>>,
+    paths: Mutex<HashMap<PathBuf, Handle<A>>>,
 }
 
-impl<A> AssetManager<A> {}
+impl<A> ops::Index<Handle<A>> for AssetManager<A> {
+    type Output = A;
+    fn index(&self, handle: Handle<A>) -> &A {
+        let slot = &self.slots[handle.inner];
+        assert_eq!(handle.generation, slot.generation);
+        &slot.asset
+    }
+}
+
+impl<A: Default> AssetManager<A> {
+    pub fn new(root: &Path) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            slots: arena::Arena::new(64),
+            paths: Mutex::default(),
+        }
+    }
+
+    pub fn load(&self, path: &Path, choir: &choir::Choir) -> (Handle<A>, &choir::RunningTask) {
+        let mut paths = self.paths.lock().unwrap();
+        let handle = match paths.entry(path.to_path_buf()) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let generation = 0;
+                let handle = self.slots.alloc(Slot {
+                    load_task: None, //TODO
+                    generation,
+                    asset: A::default(),
+                });
+                *e.insert(Handle {
+                    inner: handle,
+                    generation,
+                })
+            }
+        };
+        let task = self.slots[handle.inner].load_task.as_ref().unwrap();
+        (handle, task)
+    }
+}

--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -1,72 +1,149 @@
 use std::{
-    collections::hash_map::{Entry, HashMap},
-    ops,
+    collections::hash_map::{DefaultHasher, Entry, HashMap},
+    fs, ops,
     path::{Path, PathBuf},
-    sync::Mutex,
+    sync::{Arc, Mutex},
 };
 
 mod arena;
 
-pub struct Handle<A> {
-    inner: arena::Handle<Slot<A>>,
-    generation: u32,
+type Version = u32;
+
+pub struct Handle<T> {
+    inner: arena::Handle<Slot<T>>,
+    version: Version,
 }
-impl<A> Clone for Handle<A> {
+impl<T> Clone for Handle<T> {
     fn clone(&self) -> Self {
         Handle {
             inner: self.inner,
-            generation: self.generation,
+            version: self.version,
         }
     }
 }
-impl<A> Copy for Handle<A> {}
+impl<T> Copy for Handle<T> {}
+
+struct DataRef<T>(*mut T, *mut Version);
+unsafe impl<T> Send for DataRef<T> {}
 
 #[derive(Default)]
-struct Slot<A> {
+struct Slot<T> {
     load_task: Option<choir::RunningTask>,
-    generation: u32,
-    asset: A,
+    version: Version,
+    data: T,
 }
 
-struct AssetManager<A> {
+pub trait Baker: Send + Sync + 'static {
+    type Meal: Default + Send;
+    fn cook(&self, input: &[u8]) -> Box<[u8]>;
+    fn serve(&self, cooked: &[u8]) -> Self::Meal;
+}
+
+pub struct AssetManager<B: Baker> {
     root: PathBuf,
-    slots: arena::Arena<Slot<A>>,
-    paths: Mutex<HashMap<PathBuf, Handle<A>>>,
+    target: PathBuf,
+    slots: arena::Arena<Slot<B::Meal>>,
+    paths: Mutex<HashMap<PathBuf, Handle<B::Meal>>>,
+    choir: Arc<choir::Choir>,
+    baker: Arc<B>,
 }
 
-impl<A> ops::Index<Handle<A>> for AssetManager<A> {
-    type Output = A;
-    fn index(&self, handle: Handle<A>) -> &A {
+impl<B: Baker> ops::Index<Handle<B::Meal>> for AssetManager<B> {
+    type Output = B::Meal;
+    fn index(&self, handle: Handle<B::Meal>) -> &Self::Output {
         let slot = &self.slots[handle.inner];
-        assert_eq!(handle.generation, slot.generation);
-        &slot.asset
+        assert_eq!(handle.version, slot.version);
+        &slot.data
     }
 }
 
-impl<A: Default> AssetManager<A> {
-    pub fn new(root: &Path) -> Self {
+impl<B: Baker> AssetManager<B> {
+    pub fn new(root: &Path, target: &Path, choir: &Arc<choir::Choir>, baker: B) -> Self {
+        if !target.is_dir() {
+            log::info!("Creating target {}", target.display());
+            fs::create_dir_all(target).unwrap();
+        }
         Self {
             root: root.to_path_buf(),
+            target: target.to_path_buf(),
             slots: arena::Arena::new(64),
             paths: Mutex::default(),
+            choir: Arc::clone(choir),
+            baker: Arc::new(baker),
         }
     }
 
-    pub fn load(&self, path: &Path, choir: &choir::Choir) -> (Handle<A>, &choir::RunningTask) {
+    fn create(&self, relative_path: &Path) -> Handle<B::Meal> {
+        use base64::engine::{general_purpose::URL_SAFE as ENCODING_ENGINE, Engine as _};
+        use std::hash::{Hash as _, Hasher as _};
+
+        let source_path = self.root.join(relative_path);
+        let metadata = fs::metadata(&source_path).unwrap();
+        assert!(metadata.is_file());
+        let mut hasher = DefaultHasher::new();
+        metadata.modified().unwrap().hash(&mut hasher);
+        let target_path = {
+            let hash = hasher.finish().to_le_bytes();
+            let mut file_name = format!("{}-", relative_path.display());
+            ENCODING_ENGINE.encode_string(hash, &mut file_name);
+            file_name += ".raw";
+            self.target.join(file_name)
+        };
+
+        let (handle, slot_ptr) = self.slots.alloc_default();
+        let (task_option, data_ref) = unsafe {
+            let slot = &mut *slot_ptr;
+            (
+                &mut slot.load_task,
+                DataRef(&mut slot.data, &mut slot.version),
+            )
+        };
+        let version = 1;
+
+        let mut load_task = {
+            let baker = Arc::clone(&self.baker);
+            let target_path = target_path.clone();
+            self.choir
+                .spawn(&format!("load {}", relative_path.display()))
+                .init(move |_| {
+                    let cooked = fs::read(target_path).unwrap();
+                    let target = baker.serve(&cooked);
+                    let dr = data_ref;
+                    unsafe {
+                        *dr.0 = target;
+                        *dr.1 = version;
+                    }
+                })
+        };
+
+        if !target_path.is_file() {
+            log::info!("Cooking {}", relative_path.display());
+            let baker = Arc::clone(&self.baker);
+            let bake_task = self
+                .choir
+                .spawn(&format!("cook {}", relative_path.display()))
+                .init(move |_| {
+                    let source = fs::read(source_path).unwrap();
+                    let dish = baker.cook(&source);
+                    fs::write(target_path, &dish).unwrap();
+                });
+            load_task.depend_on(&bake_task);
+        };
+
+        *task_option = Some(load_task.run());
+        Handle {
+            inner: handle,
+            version,
+        }
+    }
+
+    pub fn load(&self, path: &Path) -> (Handle<B::Meal>, &choir::RunningTask) {
         let mut paths = self.paths.lock().unwrap();
         let handle = match paths.entry(path.to_path_buf()) {
             Entry::Occupied(e) => *e.get(),
             Entry::Vacant(e) => {
-                let generation = 0;
-                let handle = self.slots.alloc(Slot {
-                    load_task: None, //TODO
-                    generation,
-                    asset: A::default(),
-                });
-                *e.insert(Handle {
-                    inner: handle,
-                    generation,
-                })
+                let handle = self.create(e.key());
+                *e.insert(handle)
             }
         };
         let task = self.slots[handle.inner].load_task.as_ref().unwrap();

--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -61,12 +61,12 @@ pub trait Baker: Send + Sync + 'static {
 }
 
 pub struct AssetManager<B: Baker> {
-    root: PathBuf,
+    pub root: PathBuf,
     target: PathBuf,
     slots: arena::Arena<Slot<B::Output>>,
     paths: Mutex<HashMap<(PathBuf, B::Meta), Handle<B::Output>>>,
     choir: Arc<choir::Choir>,
-    baker: Arc<B>,
+    pub baker: Arc<B>,
 }
 
 impl<B: Baker> ops::Index<Handle<B::Output>> for AssetManager<B> {

--- a/blade-asset/tests/main.rs
+++ b/blade-asset/tests/main.rs
@@ -1,9 +1,13 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 struct Baker;
 impl blade_asset::Baker for Baker {
     type Meal = usize;
-    fn cook(&self, _input: &[u8]) -> Box<[u8]> {
+    fn cook(&self, _input: impl Read, _path: &Path) -> Box<[u8]> {
         (0..1).map(|_| 2u8).collect()
     }
     fn serve(&self, cooked: &[u8]) -> usize {
@@ -20,4 +24,17 @@ fn test_asset() {
     let (handle, task) = am.load(Path::new("Cargo.toml"));
     task.clone().join();
     assert_eq!(am[handle], 1);
+}
+
+fn flat_roundtrip<F: blade_asset::Flat + PartialEq + fmt::Debug>(data: F) {
+    let mut vec = vec![0u8; data.size()];
+    unsafe { data.write(vec.as_mut_ptr()) };
+    let other = unsafe { F::read(vec.as_ptr()) };
+    assert_eq!(data, other);
+}
+
+#[test]
+fn test_flatten() {
+    flat_roundtrip([0u32, 1u32, 2u32]);
+    flat_roundtrip(&[2u32, 4u32, 6u32][..]);
 }

--- a/blade-asset/tests/main.rs
+++ b/blade-asset/tests/main.rs
@@ -1,0 +1,23 @@
+use std::path::{Path, PathBuf};
+
+struct Baker;
+impl blade_asset::Baker for Baker {
+    type Meal = usize;
+    fn cook(&self, _input: &[u8]) -> Box<[u8]> {
+        (0..1).map(|_| 2u8).collect()
+    }
+    fn serve(&self, cooked: &[u8]) -> usize {
+        cooked.len()
+    }
+}
+
+#[test]
+fn test_asset() {
+    let choir = choir::Choir::new();
+    let _w1 = choir.add_worker("main");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let am = blade_asset::AssetManager::<Baker>::new(&root, &root.join("cooked"), &choir, Baker);
+    let (handle, task) = am.load(Path::new("Cargo.toml"));
+    task.clone().join();
+    assert_eq!(am[handle], 1);
+}

--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/kvark/blade"
 
 [dependencies]
 bitflags = "1"
-bytemuck = "1"
+bytemuck = { workspace = true }
 codespan-reporting = "0.11"
 hidden-trait = "0.1"
 log = { workspace = true }

--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -35,7 +35,7 @@ naga = { workspace = true, features = ["spv-out"] }
 slab = "0.4"
 
 [target.'cfg(any(gles, target_arch = "wasm32"))'.dependencies]
-glow = { git = "https://github.com/kvark/glow", branch = "get-program-resource" }
+glow = { git = "https://github.com/grovesNL/glow", rev = "ee22f3e920e0ccd1752a9ecb80f86a495ca48708" }
 naga = { workspace = true, features = ["glsl-out"] }
 
 [target.'cfg(all(gles, not(target_arch = "wasm32")))'.dependencies]

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -30,6 +30,9 @@ pub struct Buffer {
     data: *mut u8,
 }
 
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
+
 impl Buffer {
     pub fn data(&self) -> *mut u8 {
         self.data

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -455,6 +455,16 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
         Tf::Rgba16Float => (glow::RGBA16F, glow::RGBA, glow::FLOAT),
         Tf::R32Float => (glow::R32F, glow::RED, glow::FLOAT),
         Tf::Depth32Float => (glow::DEPTH_COMPONENT32F, glow::DEPTH_COMPONENT, glow::FLOAT),
+        Tf::Bc1Unorm => (glow::COMPRESSED_RGBA_S3TC_DXT1_EXT, glow::RGBA, 0),
+        Tf::Bc1UnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT, glow::RGBA, 0),
+        Tf::Bc2Unorm => (glow::COMPRESSED_RGBA_S3TC_DXT3_EXT, glow::RGBA, 0),
+        Tf::Bc2UnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT, glow::RGBA, 0),
+        Tf::Bc3Unorm => (glow::COMPRESSED_RGBA_S3TC_DXT5_EXT, glow::RGBA, 0),
+        Tf::Bc3UnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT, glow::RGBA, 0),
+        Tf::Bc4Unorm => (glow::COMPRESSED_RED_RGTC1, glow::RED, 0),
+        Tf::Bc4Snorm => (glow::COMPRESSED_SIGNED_RED_RGTC1, glow::RED, 0),
+        Tf::Bc5Unorm => (glow::COMPRESSED_RG_RGTC2, glow::RG, 0),
+        Tf::Bc5Snorm => (glow::COMPRESSED_SIGNED_RG_RGTC2, glow::RG, 0),
     };
     FormatInfo {
         internal,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -192,13 +192,26 @@ impl From<Texture> for TexturePiece {
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub enum TextureFormat {
+    // color
     Rgba8Unorm,
     Rgba8UnormSrgb,
     Bgra8UnormSrgb,
     Rgba8Snorm,
     Rgba16Float,
     R32Float,
+    // depth and stencil
     Depth32Float,
+    // S3TC block compression
+    Bc1Unorm,
+    Bc1UnormSrgb,
+    Bc2Unorm,
+    Bc2UnormSrgb,
+    Bc3Unorm,
+    Bc3UnormSrgb,
+    Bc4Unorm,
+    Bc4Snorm,
+    Bc5Unorm,
+    Bc5Snorm,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -250,6 +250,7 @@ pub enum ViewDimension {
     D3,
 }
 
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Extent {
     pub width: u32,

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -18,6 +18,9 @@ struct Surface {
     format: crate::TextureFormat,
 }
 
+unsafe impl Send for Surface {}
+unsafe impl Sync for Surface {}
+
 pub struct Frame {
     drawable: metal::MetalDrawable,
     texture: metal::Texture,
@@ -54,6 +57,9 @@ pub struct Buffer {
     raw: *mut metal::MTLBuffer,
 }
 
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
+
 impl Default for Buffer {
     fn default() -> Self {
         Self {
@@ -77,6 +83,9 @@ pub struct Texture {
     raw: *mut metal::MTLTexture,
 }
 
+unsafe impl Send for Texture {}
+unsafe impl Sync for Texture {}
+
 impl Default for Texture {
     fn default() -> Self {
         Self {
@@ -95,6 +104,9 @@ impl Texture {
 pub struct TextureView {
     raw: *mut metal::MTLTexture,
 }
+
+unsafe impl Send for TextureView {}
+unsafe impl Sync for TextureView {}
 
 impl Default for TextureView {
     fn default() -> Self {
@@ -115,6 +127,9 @@ pub struct Sampler {
     raw: *mut metal::MTLSamplerState,
 }
 
+unsafe impl Send for Sampler {}
+unsafe impl Sync for Sampler {}
+
 impl Default for Sampler {
     fn default() -> Self {
         Self {
@@ -133,6 +148,9 @@ impl Sampler {
 pub struct AccelerationStructure {
     raw: *mut metal::MTLAccelerationStructure,
 }
+
+unsafe impl Send for AccelerationStructure {}
+unsafe impl Sync for AccelerationStructure {}
 
 impl Default for AccelerationStructure {
     fn default() -> Self {

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -267,6 +267,16 @@ fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {
         Tf::Rgba16Float => RGBA16Float,
         Tf::R32Float => R32Float,
         Tf::Depth32Float => Depth32Float,
+        Tf::Bc1Unorm => BC1_RGBA,
+        Tf::Bc1UnormSrgb => BC1_RGBA_sRGB,
+        Tf::Bc2Unorm => BC2_RGBA,
+        Tf::Bc2UnormSrgb => BC2_RGBA_sRGB,
+        Tf::Bc3Unorm => BC3_RGBA,
+        Tf::Bc3UnormSrgb => BC3_RGBA_sRGB,
+        Tf::Bc4Unorm => BC4_RUnorm,
+        Tf::Bc4Snorm => BC4_RSnorm,
+        Tf::Bc5Unorm => BC5_RGUnorm,
+        Tf::Bc5Snorm => BC5_RGSnorm,
     }
 }
 

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Debug, hash::Hash};
 pub trait ResourceDevice {
-    type Buffer: Clone + Copy + Debug + Hash + PartialEq;
-    type Texture: Clone + Copy + Debug + Hash + PartialEq;
-    type TextureView: Clone + Copy + Debug + Hash + PartialEq;
-    type Sampler: Clone + Copy + Debug + Hash + PartialEq;
-    type AccelerationStructure: Clone + Copy + Debug + Hash + PartialEq;
+    type Buffer: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
+    type Texture: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
+    type TextureView: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
+    type Sampler: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
+    type AccelerationStructure: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
     fn sync_buffer(&self, buffer: Self::Buffer);

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -49,6 +49,12 @@ impl super::TextureFormat {
                 size,
             }
         }
+        fn cx_bc(size: u8) -> super::TexelBlockInfo {
+            super::TexelBlockInfo {
+                dimensions: (4, 4),
+                size,
+            }
+        }
         match *self {
             Self::Rgba8Unorm => uncompressed(4),
             Self::Rgba8UnormSrgb => uncompressed(4),
@@ -57,6 +63,16 @@ impl super::TextureFormat {
             Self::Rgba16Float => uncompressed(8),
             Self::R32Float => uncompressed(4),
             Self::Depth32Float => uncompressed(4),
+            Self::Bc1Unorm => cx_bc(8),
+            Self::Bc1UnormSrgb => cx_bc(8),
+            Self::Bc2Unorm => cx_bc(16),
+            Self::Bc2UnormSrgb => cx_bc(16),
+            Self::Bc3Unorm => cx_bc(16),
+            Self::Bc3UnormSrgb => cx_bc(16),
+            Self::Bc4Unorm => cx_bc(8),
+            Self::Bc4Snorm => cx_bc(8),
+            Self::Bc5Unorm => cx_bc(16),
+            Self::Bc5Snorm => cx_bc(16),
         }
     }
 

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -121,6 +121,9 @@ impl Buffer {
     }
 }
 
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct BlockInfo {
     bytes: u8,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -433,6 +433,16 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::Rgba16Float => vk::Format::R16G16B16A16_SFLOAT,
         Tf::R32Float => vk::Format::R32_SFLOAT,
         Tf::Depth32Float => vk::Format::D32_SFLOAT,
+        Tf::Bc1Unorm => vk::Format::BC1_RGBA_SRGB_BLOCK,
+        Tf::Bc1UnormSrgb => vk::Format::BC1_RGBA_UNORM_BLOCK,
+        Tf::Bc2Unorm => vk::Format::BC2_UNORM_BLOCK,
+        Tf::Bc2UnormSrgb => vk::Format::BC2_SRGB_BLOCK,
+        Tf::Bc3Unorm => vk::Format::BC3_UNORM_BLOCK,
+        Tf::Bc3UnormSrgb => vk::Format::BC3_SRGB_BLOCK,
+        Tf::Bc4Unorm => vk::Format::BC4_UNORM_BLOCK,
+        Tf::Bc4Snorm => vk::Format::BC4_SNORM_BLOCK,
+        Tf::Bc5Unorm => vk::Format::BC5_UNORM_BLOCK,
+        Tf::Bc5Snorm => vk::Format::BC5_SNORM_BLOCK,
     }
 }
 

--- a/blade-macros/Cargo.toml
+++ b/blade-macros/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/kvark/blade"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1"
 quote = "1.0"
 

--- a/blade-macros/Cargo.toml
+++ b/blade-macros/Cargo.toml
@@ -14,3 +14,8 @@ proc-macro = true
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1"
 quote = "1.0"
+
+[dev-dependencies]
+blade = { package = "blade-graphics", version = "0.2", path = "../blade-graphics" }
+blade-asset = { version = "0.1", path = "../blade-asset" }
+bytemuck = { workspace = true }

--- a/blade-macros/src/flat.rs
+++ b/blade-macros/src/flat.rs
@@ -3,45 +3,8 @@ use quote::quote;
 
 pub fn generate(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStream> {
     let item_struct = syn::parse::<syn::ItemStruct>(input_stream)?;
-    let fields = match item_struct.fields {
-        syn::Fields::Named(ref fields) => fields,
-        _ => {
-            return Err(syn::Error::new(
-                item_struct.struct_token.span,
-                "Structure fields must be named",
-            ))
-        }
-    };
 
-    let mut expr_alignment = quote!(0);
-    let mut expr_size = quote!(0);
-    let mut st_write = Vec::new();
-    let mut init_read = Vec::new();
-    for field in fields.named.iter() {
-        let name = field.ident.as_ref().unwrap();
-        let ty = &field.ty;
-        let align = quote! { <#ty as blade_asset::Flat>::ALIGNMENT };
-        expr_alignment = quote! {
-            [#expr_alignment, #align][(#expr_alignment < #align) as usize]
-        };
-        expr_size = quote! {
-            blade_asset::round_up(#expr_size, #align) + self.#name.size()
-        };
-        st_write.push(quote! {
-            ptr = ptr.add(ptr.align_offset(#align));
-            self.#name.write(ptr);
-            ptr = ptr.add(self.#name.size());
-        });
-        init_read.push(quote! {
-            #name: {
-                ptr = ptr.add(ptr.align_offset(#align));
-                let value = <#ty as blade_asset::Flat>::read(ptr);
-                ptr = ptr.add(blade_asset::Flat::size(&value));
-                value
-            },
-        });
-    }
-
+    let struct_name = item_struct.ident;
     let mut generics = Vec::new();
     for param in item_struct.generics.params {
         match param {
@@ -57,23 +20,91 @@ pub fn generate(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStre
         }
     }
 
-    let struct_name = item_struct.ident;
-    Ok(quote! {
-        impl<#(#generics),*> blade_asset::Flat for #struct_name<#(#generics),*> {
-            const ALIGNMENT: usize = #expr_alignment;
-            //Note: this could be improved if we see all fields being `FIXED_SIZE`
-            const FIXED_SIZE: Option<std::num::NonZeroUsize> = None;
-            fn size(&self) -> usize {
-                #expr_size
+    Ok(match item_struct.fields {
+        syn::Fields::Unnamed(_) => {
+            let is_transparent = item_struct.attrs.iter().any(|attr| {
+                if !attr.path().is_ident("repr") {
+                    return false;
+                }
+                let value = attr.parse_args::<syn::Ident>().unwrap();
+                value == "transparent"
+            });
+            if !is_transparent {
+                return Err(syn::Error::new(
+                    item_struct.struct_token.span,
+                    "Only `repr(transparent)` wrappers are supported",
+                ));
             }
-            unsafe fn write(&self, mut ptr: *mut u8) {
-                #(#st_write)*
-            }
-            unsafe fn read(mut ptr: *const u8) -> Self {
-                Self {
-                    #(#init_read)*
+
+            quote! {
+                impl<#(#generics),*> blade_asset::Flat for #struct_name<#(#generics),*> {
+                    const ALIGNMENT: usize = std::mem::size_of::<Self>();
+                    const FIXED_SIZE: Option<std::num::NonZeroUsize> = std::num::NonZeroUsize::new(std::mem::size_of::<Self>());
+                    unsafe fn write(&self, mut ptr: *mut u8) {
+                        std::ptr::write(ptr as *mut Self, *self);
+                    }
+                    unsafe fn read(mut ptr: *const u8) -> Self {
+                        std::ptr::read(ptr as *const Self)
+                    }
                 }
             }
+        }
+        syn::Fields::Named(ref fields) => {
+            let mut expr_alignment = quote!(0);
+            let mut expr_size = quote!(0);
+            let mut st_write = Vec::new();
+            let mut init_read = Vec::new();
+
+            for field in fields.named.iter() {
+                let name = field.ident.as_ref().unwrap();
+                let ty = &field.ty;
+
+                let align = quote! { <#ty as blade_asset::Flat>::ALIGNMENT };
+                expr_alignment = quote! {
+                    [#expr_alignment, #align][(#expr_alignment < #align) as usize]
+                };
+                expr_size = quote! {
+                    blade_asset::round_up(#expr_size, #align) + self.#name.size()
+                };
+                st_write.push(quote! {
+                    ptr = ptr.add(ptr.align_offset(#align));
+                    self.#name.write(ptr);
+                    ptr = ptr.add(self.#name.size());
+                });
+                init_read.push(quote! {
+                    #name: {
+                        ptr = ptr.add(ptr.align_offset(#align));
+                        let value = <#ty as blade_asset::Flat>::read(ptr);
+                        ptr = ptr.add(blade_asset::Flat::size(&value));
+                        value
+                    },
+                });
+            }
+
+            quote! {
+                impl<#(#generics),*> blade_asset::Flat for #struct_name<#(#generics),*> {
+                    const ALIGNMENT: usize = #expr_alignment;
+                    //Note: this could be improved if we see all fields being `FIXED_SIZE`
+                    const FIXED_SIZE: Option<std::num::NonZeroUsize> = None;
+                    fn size(&self) -> usize {
+                        #expr_size
+                    }
+                    unsafe fn write(&self, mut ptr: *mut u8) {
+                        #(#st_write)*
+                    }
+                    unsafe fn read(mut ptr: *const u8) -> Self {
+                        Self {
+                            #(#init_read)*
+                        }
+                    }
+                }
+            }
+        }
+        _ => {
+            return Err(syn::Error::new(
+                item_struct.struct_token.span,
+                "Structure fields must be named",
+            ))
         }
     })
 }

--- a/blade-macros/src/flat.rs
+++ b/blade-macros/src/flat.rs
@@ -1,0 +1,79 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+pub fn generate(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let item_struct = syn::parse::<syn::ItemStruct>(input_stream)?;
+    let fields = match item_struct.fields {
+        syn::Fields::Named(ref fields) => fields,
+        _ => {
+            return Err(syn::Error::new(
+                item_struct.struct_token.span,
+                "Structure fields must be named",
+            ))
+        }
+    };
+
+    let mut expr_alignment = quote!(0);
+    let mut expr_size = quote!(0);
+    let mut st_write = Vec::new();
+    let mut init_read = Vec::new();
+    for field in fields.named.iter() {
+        let name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        let align = quote! { <#ty as blade_asset::Flat>::ALIGNMENT };
+        expr_alignment = quote! {
+            [#expr_alignment, #align][(#expr_alignment < #align) as usize]
+        };
+        expr_size = quote! {
+            blade_asset::round_up(#expr_size, #align) + self.#name.size()
+        };
+        st_write.push(quote! {
+            ptr = ptr.add(ptr.align_offset(#align));
+            self.#name.write(ptr);
+            ptr = ptr.add(self.#name.size());
+        });
+        init_read.push(quote! {
+            #name: {
+                ptr = ptr.add(ptr.align_offset(#align));
+                let value = <#ty as blade_asset::Flat>::read(ptr);
+                ptr = ptr.add(blade_asset::Flat::size(&value));
+                value
+            },
+        });
+    }
+
+    let mut generics = Vec::new();
+    for param in item_struct.generics.params {
+        match param {
+            syn::GenericParam::Lifetime(lt) => {
+                generics.push(lt.lifetime);
+            }
+            syn::GenericParam::Type(_) | syn::GenericParam::Const(_) => {
+                return Err(syn::Error::new(
+                    item_struct.struct_token.span,
+                    "Unsupported generic parameters",
+                ))
+            }
+        }
+    }
+
+    let struct_name = item_struct.ident;
+    Ok(quote! {
+        impl<#(#generics),*> blade_asset::Flat for #struct_name<#(#generics),*> {
+            const ALIGNMENT: usize = #expr_alignment;
+            //Note: this could be improved if we see all fields being `FIXED_SIZE`
+            const FIXED_SIZE: Option<std::num::NonZeroUsize> = None;
+            fn size(&self) -> usize {
+                #expr_size
+            }
+            unsafe fn write(&self, mut ptr: *mut u8) {
+                #(#st_write)*
+            }
+            unsafe fn read(mut ptr: *const u8) -> Self {
+                Self {
+                    #(#init_read)*
+                }
+            }
+        }
+    })
+}

--- a/blade-macros/src/lib.rs
+++ b/blade-macros/src/lib.rs
@@ -1,66 +1,20 @@
+mod flat;
+mod shader_data;
+
 use proc_macro::TokenStream;
-use quote::quote;
-
-fn impl_shader_data(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStream> {
-    let item_struct = syn::parse::<syn::ItemStruct>(input_stream)?;
-    let fields = match item_struct.fields {
-        syn::Fields::Named(ref fields) => fields,
-        _ => {
-            return Err(syn::Error::new(
-                item_struct.struct_token.span,
-                "Structure fields must be named",
-            ))
-        }
-    };
-
-    let mut bindings = Vec::new();
-    let mut assignments = Vec::new();
-    for (index_usize, field) in fields.named.iter().enumerate() {
-        let index = index_usize as u32;
-        let name = field.ident.as_ref().unwrap();
-        let ty = &field.ty;
-        bindings.push(quote! {
-            (stringify!(#name), <#ty as blade::HasShaderBinding>::TYPE)
-        });
-        assignments.push(quote! {
-            self.#name.bind_to(&mut ctx, #index);
-        });
-    }
-
-    let mut generics = Vec::new();
-    for param in item_struct.generics.params {
-        match param {
-            syn::GenericParam::Lifetime(lt) => {
-                generics.push(lt.lifetime);
-            }
-            syn::GenericParam::Type(_) | syn::GenericParam::Const(_) => {
-                return Err(syn::Error::new(
-                    item_struct.struct_token.span,
-                    "Unsupported generic parameters",
-                ))
-            }
-        }
-    }
-
-    let struct_name = item_struct.ident;
-    Ok(quote! {
-        impl<#(#generics),*> blade::ShaderData for #struct_name<#(#generics),*> {
-            fn layout() -> blade::ShaderDataLayout {
-                blade::ShaderDataLayout {
-                    bindings: vec![#(#bindings),*],
-                }
-            }
-            fn fill(&self, mut ctx: blade::PipelineContext) {
-                use blade::ShaderBindable as _;
-                #(#assignments)*
-            }
-        }
-    })
-}
 
 #[proc_macro_derive(ShaderData)]
 pub fn shader_data_derive(input: TokenStream) -> TokenStream {
-    let stream = match impl_shader_data(input) {
+    let stream = match shader_data::generate(input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.into_compile_error(),
+    };
+    stream.into()
+}
+
+#[proc_macro_derive(Flat)]
+pub fn flat_derive(input: TokenStream) -> TokenStream {
+    let stream = match flat::generate(input) {
         Ok(tokens) => tokens,
         Err(err) => err.into_compile_error(),
     };

--- a/blade-macros/src/shader_data.rs
+++ b/blade-macros/src/shader_data.rs
@@ -1,0 +1,59 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+pub fn generate(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let item_struct = syn::parse::<syn::ItemStruct>(input_stream)?;
+    let fields = match item_struct.fields {
+        syn::Fields::Named(ref fields) => fields,
+        _ => {
+            return Err(syn::Error::new(
+                item_struct.struct_token.span,
+                "Structure fields must be named",
+            ))
+        }
+    };
+
+    let mut bindings = Vec::new();
+    let mut assignments = Vec::new();
+    for (index_usize, field) in fields.named.iter().enumerate() {
+        let index = index_usize as u32;
+        let name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        bindings.push(quote! {
+            (stringify!(#name), <#ty as blade::HasShaderBinding>::TYPE)
+        });
+        assignments.push(quote! {
+            self.#name.bind_to(&mut ctx, #index);
+        });
+    }
+
+    let mut generics = Vec::new();
+    for param in item_struct.generics.params {
+        match param {
+            syn::GenericParam::Lifetime(lt) => {
+                generics.push(lt.lifetime);
+            }
+            syn::GenericParam::Type(_) | syn::GenericParam::Const(_) => {
+                return Err(syn::Error::new(
+                    item_struct.struct_token.span,
+                    "Unsupported generic parameters",
+                ))
+            }
+        }
+    }
+
+    let struct_name = item_struct.ident;
+    Ok(quote! {
+        impl<#(#generics),*> blade::ShaderData for #struct_name<#(#generics),*> {
+            fn layout() -> blade::ShaderDataLayout {
+                blade::ShaderDataLayout {
+                    bindings: vec![#(#bindings),*],
+                }
+            }
+            fn fill(&self, mut ctx: blade::PipelineContext) {
+                use blade::ShaderBindable as _;
+                #(#assignments)*
+            }
+        }
+    })
+}

--- a/blade-macros/tests/main.rs
+++ b/blade-macros/tests/main.rs
@@ -32,3 +32,27 @@ fn test_flat_struct() {
     let other = unsafe { Flat::read(vec.as_ptr()) };
     assert_eq!(data, other);
 }
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
+#[non_exhaustive]
+enum Foo {
+    #[allow(dead_code)]
+    A,
+    B,
+}
+
+#[derive(blade_macros::Flat, Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+struct FooWrap(Foo);
+
+#[test]
+fn test_flat_wrap() {
+    use blade_asset::Flat;
+
+    let foo = FooWrap(Foo::B);
+    let mut vec = vec![0u8; foo.size()];
+    unsafe { foo.write(vec.as_mut_ptr()) };
+    let other = unsafe { Flat::read(vec.as_ptr()) };
+    assert_eq!(foo, other);
+}

--- a/blade-macros/tests/main.rs
+++ b/blade-macros/tests/main.rs
@@ -1,0 +1,34 @@
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+struct Globals {
+    mvp_transform: [[f32; 4]; 4],
+}
+
+#[derive(blade_macros::ShaderData)]
+struct ShaderParams {
+    globals: Globals,
+    sprite_texture: blade::TextureView,
+    sprite_sampler: blade::Sampler,
+}
+
+#[derive(blade_macros::Flat, PartialEq, Debug)]
+struct FlatData<'a> {
+    array: [u32; 2],
+    single: f32,
+    slice: &'a [u16],
+}
+
+#[test]
+fn test_flat_struct() {
+    use blade_asset::Flat;
+
+    let data = FlatData {
+        array: [1, 2],
+        single: 3.0,
+        slice: &[4, 5, 6],
+    };
+    let mut vec = vec![0u8; data.size()];
+    unsafe { data.write(vec.as_mut_ptr()) };
+    let other = unsafe { Flat::read(vec.as_ptr()) };
+    assert_eq!(data, other);
+}

--- a/blade-render/Cargo.toml
+++ b/blade-render/Cargo.toml
@@ -9,11 +9,19 @@ repository = "https://github.com/kvark/blade"
 
 [lib]
 
+[features]
+default = ["asset"]
+asset = ["gltf" , "png", "texpresso"]
+
 [dependencies]
-blade = { package = "blade-graphics", version = "0.2", path = "../blade-graphics"}
-blade-macros = { version = "0.2", path = "../blade-macros"}
+blade = { package = "blade-graphics", version = "0.2", path = "../blade-graphics" }
+blade-asset = { version = "0.1", path = "../blade-asset" }
+blade-macros = { version = "0.2", path = "../blade-macros" }
 bytemuck = { workspace = true }
-gltf = { version = "1.1", features = ["names", "utils"] }
+choir = { workspace = true }
+gltf = { version = "1.1", features = ["names", "utils"], optional = true }
 glam = { workspace = true }
 log = { workspace = true }
 mint = { workspace = true }
+png = { version = "0.17", optional = true }
+texpresso = { version = "2.0", optional = true }

--- a/blade-render/src/asset_hub.rs
+++ b/blade-render/src/asset_hub.rs
@@ -1,0 +1,34 @@
+use blade_asset::AssetManager;
+use std::{path::Path, sync::Arc};
+
+pub struct AssetHub {
+    pub textures: AssetManager<crate::texture::Baker>,
+}
+
+impl AssetHub {
+    pub fn new(
+        root: &Path,
+        target: &Path,
+        choir: &Arc<choir::Choir>,
+        gpu_context: &Arc<blade::Context>,
+    ) -> Self {
+        let _ = std::fs::create_dir_all(target);
+        Self {
+            textures: AssetManager::new(
+                root,
+                target,
+                choir,
+                crate::texture::Baker::new(gpu_context),
+            ),
+        }
+    }
+
+    pub fn flush(
+        &self,
+        command_encoder: &mut blade::CommandEncoder,
+        temp_buffers: &mut Vec<blade::Buffer>,
+    ) {
+        let mut transfers = command_encoder.transfer();
+        self.textures.baker.flush(&mut transfers, temp_buffers);
+    }
+}

--- a/blade-render/src/lib.rs
+++ b/blade-render/src/lib.rs
@@ -1,13 +1,18 @@
 #![allow(irrefutable_let_patterns)]
 
 #[cfg(not(target_arch = "wasm32"))]
+mod asset_hub;
+#[cfg(not(target_arch = "wasm32"))]
 mod model;
 #[cfg(not(target_arch = "wasm32"))]
 mod renderer;
 #[cfg(not(target_arch = "wasm32"))]
 mod scene;
+#[cfg(not(target_arch = "wasm32"))]
 mod texture;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use asset_hub::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use renderer::*;
 

--- a/blade-render/src/lib.rs
+++ b/blade-render/src/lib.rs
@@ -1,11 +1,12 @@
 #![allow(irrefutable_let_patterns)]
 
 #[cfg(not(target_arch = "wasm32"))]
-mod gltf_loader;
+mod model;
 #[cfg(not(target_arch = "wasm32"))]
 mod renderer;
 #[cfg(not(target_arch = "wasm32"))]
 mod scene;
+mod texture;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use renderer::*;

--- a/blade-render/src/model/mod.rs
+++ b/blade-render/src/model/mod.rs
@@ -1,0 +1,21 @@
+mod gltf_loader;
+
+use std::path::Path;
+
+pub struct Baker;
+impl blade_asset::Baker for Baker {
+    type Meta = ();
+    type Output = usize;
+    fn cook(
+        &self,
+        _src_path: &Path,
+        _meta: (),
+        _dst_path: &Path,
+        _exe_context: choir::ExecutionContext,
+    ) {
+        unimplemented!()
+    }
+    fn serve(&self, _cooked: &[u8]) -> Self::Output {
+        unimplemented!()
+    }
+}

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -1,0 +1,114 @@
+use blade_asset::Flat as _;
+use std::{fs, io, path::Path};
+
+#[derive(blade_macros::Flat)]
+struct Image<'a> {
+    extent: [u32; 2],
+    data: &'a [u8],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Meta {
+    pub format: blade::TextureFormat,
+}
+
+#[cfg(feature = "asset")]
+struct RawImage {
+    width: usize,
+    height: usize,
+    data: Box<[u8]>,
+}
+
+#[cfg(feature = "asset")]
+impl RawImage {
+    fn from_png(input: impl io::Read) -> Self {
+        let mut decoder = png::Decoder::new(input);
+        decoder.set_transformations(png::Transformations::EXPAND);
+
+        let mut reader = decoder
+            .read_info()
+            .expect("Failed to read PNG header. Is this really a PNG file?");
+
+        // Preallocate the output buffer.
+        let mut buf = vec![0; reader.output_buffer_size()];
+
+        // Read the next frame. Currently this function should only called once.
+        reader.next_frame(&mut buf).unwrap();
+
+        let info = reader.info();
+        if info.bit_depth != png::BitDepth::Eight {
+            panic!("Only images with 8 bits per channel are supported");
+        }
+
+        // expand to rgba
+        buf = match info.color_type {
+            png::ColorType::Grayscale => buf[..]
+                .iter()
+                .flat_map(|&r| vec![r, r, r, 255])
+                .collect::<Vec<u8>>(),
+            png::ColorType::GrayscaleAlpha => buf[..]
+                .chunks(2)
+                .flat_map(|rg| vec![rg[0], rg[0], rg[0], rg[1]])
+                .collect::<Vec<u8>>(),
+            png::ColorType::Rgb => buf[..]
+                .chunks(3)
+                .flat_map(|rgb| vec![rgb[0], rgb[1], rgb[2], 255])
+                .collect::<Vec<u8>>(),
+            png::ColorType::Rgba => buf,
+            _ => unreachable!(),
+        };
+
+        Self {
+            width: info.width as usize,
+            height: info.height as usize,
+            data: buf.into_boxed_slice(),
+        }
+    }
+}
+
+pub struct Baker;
+impl blade_asset::Baker for Baker {
+    type Meta = Meta;
+    type Output = usize;
+    fn cook(
+        &self,
+        src_path: &Path,
+        meta: Meta,
+        dst_path: &Path,
+        _exe_context: choir::ExecutionContext,
+    ) {
+        use blade::TextureFormat as Tf;
+        let dst_format = match meta.format {
+            Tf::Bc1Unorm | Tf::Bc1UnormSrgb => texpresso::Format::Bc1,
+            Tf::Bc2Unorm | Tf::Bc2UnormSrgb => texpresso::Format::Bc2,
+            Tf::Bc3Unorm | Tf::Bc3UnormSrgb => texpresso::Format::Bc3,
+            Tf::Bc4Unorm | Tf::Bc4Snorm => texpresso::Format::Bc4,
+            Tf::Bc5Unorm | Tf::Bc5Snorm => texpresso::Format::Bc5,
+            other => panic!("Unsupported destination format {:?}", other),
+        };
+
+        let input = fs::File::open(src_path).unwrap();
+        match src_path.extension().unwrap().to_str().unwrap() {
+            #[cfg(feature = "asset")]
+            "png" => {
+                let src = RawImage::from_png(input);
+                let dst_size = dst_format.compressed_size(src.width, src.height);
+                let mut buf = vec![0u8; dst_size];
+                let params = texpresso::Params::default();
+                dst_format.compress(&src.data, src.width, src.height, params, &mut buf);
+
+                let image = Image {
+                    extent: [src.width as u32, src.height as u32],
+                    data: &buf,
+                };
+                let mut dst_raw = vec![0u8; image.size()];
+                unsafe { image.write(dst_raw.as_mut_ptr()) };
+                fs::write(dst_path, &dst_raw).unwrap();
+            }
+            other => panic!("Unknown texture extension: {}", other),
+        }
+    }
+    fn serve(&self, _cooked: &[u8]) -> Self::Output {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
The goal here is to create a mechanism by which:
  - the assets can be loaded in 2 steps: first cooked to an optimized format, and then served to the user
  - this cooking result can be cached automatically between runs to fasten the startup
  - all the processing can be done in parallel using Choir