### PR TITLE
Basic environment map support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ naga = { workspace = true }
 nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
 num_cpus = "1"
 profiling = { workspace = true }
+ron = "0.8"
+serde = { version = "1", features = ["serde_derive"] }
 winit = "0.27"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -457,6 +457,7 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
         Tf::Rgba8Snorm => (glow::RGBA8, glow::RGBA, glow::BYTE),
         Tf::Rgba16Float => (glow::RGBA16F, glow::RGBA, glow::FLOAT),
         Tf::R32Float => (glow::R32F, glow::RED, glow::FLOAT),
+        Tf::Rgba32Float => (glow::RGBA32F, glow::RGBA, glow::FLOAT),
         Tf::Depth32Float => (glow::DEPTH_COMPONENT32F, glow::DEPTH_COMPONENT, glow::FLOAT),
         Tf::Bc1Unorm => (glow::COMPRESSED_RGBA_S3TC_DXT1_EXT, glow::RGBA, 0),
         Tf::Bc1UnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT, glow::RGBA, 0),

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -199,6 +199,7 @@ pub enum TextureFormat {
     Rgba8Snorm,
     Rgba16Float,
     R32Float,
+    Rgba32Float,
     // depth and stencil
     Depth32Float,
     // S3TC block compression

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -284,6 +284,7 @@ fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {
         Tf::Rgba8Snorm => RGBA8Snorm,
         Tf::Rgba16Float => RGBA16Float,
         Tf::R32Float => R32Float,
+        Tf::Rgba32Float => RGBA32Float,
         Tf::Depth32Float => Depth32Float,
         Tf::Bc1Unorm => BC1_RGBA,
         Tf::Bc1UnormSrgb => BC1_RGBA_sRGB,

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -62,6 +62,7 @@ impl super::TextureFormat {
             Self::Rgba8Snorm => uncompressed(4),
             Self::Rgba16Float => uncompressed(8),
             Self::R32Float => uncompressed(4),
+            Self::Rgba32Float => uncompressed(32),
             Self::Depth32Float => uncompressed(4),
             Self::Bc1Unorm => cx_bc(8),
             Self::Bc1UnormSrgb => cx_bc(8),

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -435,6 +435,7 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::Rgba8Snorm => vk::Format::R8G8B8A8_SNORM,
         Tf::Rgba16Float => vk::Format::R16G16B16A16_SFLOAT,
         Tf::R32Float => vk::Format::R32_SFLOAT,
+        Tf::Rgba32Float => vk::Format::R32G32B32A32_SFLOAT,
         Tf::Depth32Float => vk::Format::D32_SFLOAT,
         Tf::Bc1Unorm => vk::Format::BC1_RGBA_SRGB_BLOCK,
         Tf::Bc1UnormSrgb => vk::Format::BC1_RGBA_UNORM_BLOCK,

--- a/blade-render/Cargo.toml
+++ b/blade-render/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/kvark/blade"
 
 [features]
 default = ["asset"]
-asset = ["gltf" , "base64", "texpresso", "zune-core", "zune-jpeg", "zune-png"]
+asset = ["gltf" , "base64", "exr", "texpresso", "zune-core", "zune-jpeg", "zune-png"]
 
 [dependencies]
 base64 = { workspace = true, optional = true }
@@ -20,6 +20,7 @@ blade-asset = { version = "0.1", path = "../blade-asset" }
 blade-macros = { version = "0.2", path = "../blade-macros" }
 bytemuck = { workspace = true }
 choir = { workspace = true }
+exr = { version = "1.6", optional = true }
 gltf = { version = "1.1", default-features = false, features = ["names", "utils"], optional = true }
 glam = { workspace = true }
 log = { workspace = true }

--- a/blade-render/src/lib.rs
+++ b/blade-render/src/lib.rs
@@ -42,8 +42,26 @@ pub struct Object {
     pub transform: blade_graphics::Transform,
 }
 
+#[derive(Clone, Debug)]
+pub struct PostProcessing {
+    //TODO: remove this, compute automatically
+    pub average_luminocity: f32,
+    pub exposure_key_value: f32,
+    pub white_level: f32,
+}
+impl Default for PostProcessing {
+    fn default() -> Self {
+        Self {
+            average_luminocity: 1.0,
+            exposure_key_value: 1.0,
+            white_level: 1.0,
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct Scene {
     pub objects: Vec<Object>,
     pub environment_map: Option<blade_asset::Handle<Texture>>,
+    pub post_processing: PostProcessing,
 }

--- a/blade-render/src/lib.rs
+++ b/blade-render/src/lib.rs
@@ -45,4 +45,5 @@ pub struct Object {
 #[derive(Default)]
 pub struct Scene {
     pub objects: Vec<Object>,
+    pub environment_map: Option<blade_asset::Handle<Texture>>,
 }

--- a/examples/scene/data/scene.ron
+++ b/examples/scene/data/scene.ron
@@ -1,0 +1,13 @@
+(
+    camera: (
+        position: (2.7, 1.6, 2.1),
+        orientation: (-0.04, 0.92, -0.05, -0.37),
+        fov_y: 0.8,
+        max_depth: 100.0,
+    ),
+    models: [
+        (
+            path: "monkey.gltf",
+        ),
+    ],
+)

--- a/examples/scene/data/scene.ron
+++ b/examples/scene/data/scene.ron
@@ -2,9 +2,10 @@
     camera: (
         position: (2.7, 1.6, 2.1),
         orientation: (-0.04, 0.92, -0.05, -0.37),
-        fov_y: 0.8,
+        fov_y: 1.0,
         max_depth: 100.0,
     ),
+    average_luminocity: 0.3,
     models: [
         (
             path: "monkey.gltf",


### PR DESCRIPTION
Adds EXR integration that processes envmaps into RGBA32F data. This format had to be added to blade-graphics.
Also makes the scene example work with RON files describing the model paths, the camera, and the envmap path.