### PR TITLE
Improve the debug selection logic.

### DIFF
--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -149,7 +149,7 @@ impl<B: Baker> Cooker<B> {
     }
 
     /// Put the data into it.
-    pub fn finish<'a>(&self, value: B::Data<'a>) {
+    pub fn finish(&self, value: B::Data<'_>) {
         let mut inner = self.inner.lock().unwrap();
         inner.result = vec![0u8; value.size()];
         unsafe { value.write(inner.result.as_mut_ptr()) };


### PR DESCRIPTION
It was not good that the selected position remained even with camera movement. Instead, it's now reset. At the same time, it's possible to look at a frame worth of restrir debug lines, while zooming around it freely.