### PR TITLE
GPU crash handler in Vulkan

### DIFF
--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -167,6 +167,7 @@ unsafe fn inspect_adapter(
         false
     } else {
         log::info!("Ray tracing is supported");
+        log::debug!("Ray tracing properties: {acceleration_structure_properties:#?}");
         true
     };
 
@@ -386,6 +387,18 @@ impl super::Context {
                         &device_core,
                     ),
                 })
+            } else {
+                None
+            },
+            buffer_marker: if capabilities.buffer_marker && desc.validation {
+                //TODO: https://github.com/ash-rs/ash/issues/768
+                Some(vk::AmdBufferMarkerFn::load(|name| unsafe {
+                    mem::transmute(
+                        instance
+                            .core
+                            .get_device_proc_addr(device_core.handle(), name.as_ptr()),
+                    )
+                }))
             } else {
                 None
             },

--- a/blade-render/src/model/mod.rs
+++ b/blade-render/src/model/mod.rs
@@ -254,12 +254,14 @@ impl fmt::Display for Meta {
     }
 }
 
+#[derive(Debug)]
 struct Transfer {
     stage: blade_graphics::Buffer,
     dst: blade_graphics::Buffer,
     size: u64,
 }
 
+#[derive(Debug)]
 struct BlasConstruct {
     meshes: Vec<blade_graphics::AccelerationStructureMesh>,
     scratch: blade_graphics::Buffer,


### PR DESCRIPTION
Example output:
```
[2023-07-09T07:19:57Z ERROR blade_graphics::hal] Last GPU executed marker is 'pass/acc-struct'
[2023-07-09T07:19:57Z INFO  blade_graphics::hal] Marker history: |start|pass/transfer|finish|start|pass/transfer|pass/transfer|pass/transfer|
thread 'main' panicked at 'GPU has crashed in main', blade-graphics\src\vulkan\mod.rs:446:21
```