### PR TITLE
Optimize ray-tracing a bit

### DIFF
--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -33,6 +33,7 @@ struct Device {
     dynamic_rendering: khr::DynamicRendering,
     ray_tracing: Option<RayTracingDevice>,
     buffer_marker: Option<vk::AmdBufferMarkerFn>,
+    shader_info: Option<vk::AmdShaderInfoFn>,
     workarounds: Workarounds,
 }
 

--- a/blade-render/code/fill-gbuf.wgsl
+++ b/blade-render/code/fill-gbuf.wgsl
@@ -54,7 +54,7 @@ fn debug_raw_normal(pos: vec3<f32>, normal_raw: u32, rotation: vec4<f32>, debug_
     debug_line(pos, pos + debug_len * nw, color);
 }
 
-@compute @workgroup_size(8, 8)
+@compute @workgroup_size(8, 4)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (any(global_id.xy >= camera.target_size)) {
         return;

--- a/blade-render/code/ray-trace.wgsl
+++ b/blade-render/code/ray-trace.wgsl
@@ -32,9 +32,11 @@ var<uniform> parameters: MainParams;
 var acc_struct: acceleration_structure;
 var env_map: texture_2d<f32>;
 var sampler_linear: sampler;
+var sampler_nearest: sampler;
 
 struct StoredReservoir {
-    light_dir: vec3<f32>,
+    light_uv: vec2<f32>,
+    light_index: u32,
     target_score: f32,
     contribution_weight: f32,
     confidence: f32,
@@ -43,13 +45,14 @@ var<storage, read_write> reservoirs: array<StoredReservoir>;
 var<storage, read> prev_reservoirs: array<StoredReservoir>;
 
 struct LightSample {
-    dir: vec3<f32>,
     radiance: vec3<f32>,
     pdf: f32,
+    uv: vec2<f32>,
 }
 
 struct LiveReservoir {
-    selected_dir: vec3<f32>,
+    selected_uv: vec2<f32>,
+    selected_light_index: u32,
     selected_target_score: f32,
     weight_sum: f32,
     history: f32,
@@ -76,10 +79,11 @@ fn get_pixel_from_reservoir_index(index: i32, camera: CameraParams) -> vec2<i32>
 fn bump_reservoir(r: ptr<function, LiveReservoir>, history: f32) {
     (*r).history += history;
 }
-fn make_reservoir(ls: LightSample, color: vec3<f32>) -> LiveReservoir {
+fn make_reservoir(ls: LightSample, light_index: u32, brdf: vec3<f32>) -> LiveReservoir {
     var r: LiveReservoir;
-    r.selected_dir = ls.dir;
-    r.selected_target_score = compute_target_score(color);
+    r.selected_uv = ls.uv;
+    r.selected_light_index = light_index;
+    r.selected_target_score = compute_target_score(ls.radiance * brdf);
     r.weight_sum = r.selected_target_score / ls.pdf;
     r.history = 1.0;
     return r;
@@ -88,7 +92,8 @@ fn merge_reservoir(r: ptr<function, LiveReservoir>, other: LiveReservoir, random
     (*r).weight_sum += other.weight_sum;
     (*r).history += other.history;
     if ((*r).weight_sum * random < other.weight_sum) {
-        (*r).selected_dir = other.selected_dir;
+        (*r).selected_light_index = other.selected_light_index;
+        (*r).selected_uv = other.selected_uv;
         (*r).selected_target_score = other.selected_target_score;
         return true;
     } else {
@@ -97,7 +102,8 @@ fn merge_reservoir(r: ptr<function, LiveReservoir>, other: LiveReservoir, random
 }
 fn unpack_reservoir(f: StoredReservoir, max_history: u32) -> LiveReservoir {
     var r: LiveReservoir;
-    r.selected_dir = f.light_dir;
+    r.selected_light_index = f.light_index;
+    r.selected_uv = f.light_uv;
     r.selected_target_score = f.target_score;
     let history = min(f.confidence, f32(max_history));
     r.weight_sum = f.contribution_weight * f.target_score * history;
@@ -106,7 +112,8 @@ fn unpack_reservoir(f: StoredReservoir, max_history: u32) -> LiveReservoir {
 }
 fn pack_reservoir_detail(r: LiveReservoir, denom_factor: f32) -> StoredReservoir {
     var f: StoredReservoir;
-    f.light_dir = r.selected_dir;
+    f.light_index = r.selected_light_index;
+    f.light_uv = r.selected_uv;
     f.target_score = r.selected_target_score;
     f.confidence = r.history;
     let denom = f.target_score * denom_factor;
@@ -152,13 +159,14 @@ fn evaluate_environment(dir: vec3<f32>) -> vec3<f32> {
 }
 
 fn sample_light_from_sphere(rng: ptr<function, RandomState>) -> LightSample {
-    var ls = LightSample();
-    ls.pdf = 1.0 / (4.0 * PI);
     let a = random_gen(rng);
     let h = 1.0 - 2.0 * random_gen(rng); // make sure to allow h==1
     let tangential = sqrt(1.0 - square(h)) * sample_circle(a);
-    ls.dir = vec3<f32>(tangential.x, h, tangential.y);
-    ls.radiance = evaluate_environment(ls.dir);
+    let dir = vec3<f32>(tangential.x, h, tangential.y);
+    var ls = LightSample();
+    ls.uv = map_equirect_dir_to_uv(dir);
+    ls.pdf = 1.0 / (4.0 * PI);
+    ls.radiance = textureSampleLevel(env_map, sampler_linear, ls.uv, 0.0).xyz;
     return ls;
 }
 
@@ -171,8 +179,7 @@ fn sample_light_from_environment(rng: ptr<function, RandomState>) -> LightSample
     ls.radiance = textureLoad(env_map, es.pixel, 0).xyz;
     // for determining direction - offset randomly within the texel
     // Note: this only works if the texels are sufficiently small
-    let uv = (vec2<f32>(es.pixel) + vec2<f32>(random_gen(rng), random_gen(rng))) / vec2<f32>(dim);
-    ls.dir = map_equirect_uv_to_dir(uv);
+    ls.uv = (vec2<f32>(es.pixel) + vec2<f32>(random_gen(rng), random_gen(rng))) / vec2<f32>(dim);
     return ls;
 }
 
@@ -216,10 +223,17 @@ fn check_ray_occluded(position: vec3<f32>, direction: vec3<f32>, debug_len: f32)
     return occluded;
 }
 
-fn evaluate_reflected_light(surface: Surface, direction: vec3<f32>) -> vec3<f32> {
-    let radiance = evaluate_environment(direction);
+fn evaluate_reflected_light(surface: Surface, light_index: u32, light_uv: vec2<f32>) -> vec3<f32> {
+    if (light_index != 0u) {
+        return vec3<f32>(0.0);
+    }
+    let direction = map_equirect_uv_to_dir(light_uv);
     let brdf = evaluate_brdf(surface, direction);
+    if (brdf <= 0.0) {
+        return vec3<f32>(0.0);
+    }
     // Note: returns radiance not modulated by albedo
+    let radiance = textureSampleLevel(env_map, sampler_nearest, light_uv, 0.0).xyz;
     return radiance * brdf;
 }
 
@@ -232,9 +246,16 @@ fn make_target_pdf(color: vec3<f32>) -> TargetPdf {
     return TargetPdf(color, compute_target_score(color));
 }
 
-fn estimate_target_pdf_with_occlusion(surface: Surface, position: vec3<f32>, direction: vec3<f32>, debug_len: f32) -> TargetPdf {
+fn estimate_target_pdf_with_occlusion(surface: Surface, position: vec3<f32>, light_index: u32, light_uv: vec2<f32>, debug_len: f32) -> TargetPdf {
+    if (light_index != 0u) {
+        return TargetPdf();
+    }
+    let direction = map_equirect_uv_to_dir(light_uv);
+    if (dot(direction, surface.flat_normal) <= 0.0) {
+        return TargetPdf();
+    }
     let brdf = evaluate_brdf(surface, direction);
-    if (dot(direction, surface.flat_normal) <= 0.0 || brdf == 0.0) {
+    if (brdf <= 0.0) {
         return TargetPdf();
     }
 
@@ -242,39 +263,34 @@ fn estimate_target_pdf_with_occlusion(surface: Surface, position: vec3<f32>, dir
         return TargetPdf();
     } else {
         //Note: same as `evaluate_reflected_light`
-        let radiance = evaluate_environment(direction);
+        let radiance = textureSampleLevel(env_map, sampler_nearest, light_uv, 0.0).xyz;
         return make_target_pdf(brdf * radiance);
     }
 }
 
-const REJECT_NO = 0u;
-const REJECT_BACKFACING = 1u;
-const REJECT_UNCORRELATED = 2u;
-const REJECT_ZERO_TARGET_SCORE = 3u;
-const REJECT_OCCLUDED = 4u;
-
-fn evaluate_sample(ls: LightSample, surface: Surface, start_pos: vec3<f32>, debug_len: f32) -> u32 {
-    if (dot(ls.dir, surface.flat_normal) <= 0.0)
+fn evaluate_sample(ls: LightSample, surface: Surface, start_pos: vec3<f32>, debug_len: f32) -> f32 {
+    let dir = map_equirect_uv_to_dir(ls.uv);
+    if (dot(dir, surface.flat_normal) <= 0.0)
     {
-        return REJECT_BACKFACING;
+        return 0.0;
     }
 
-    let up = qrot(surface.basis, vec3<f32>(0.0, 0.0, 1.0));
-    if (dot(ls.dir, up) <= 0.0)
+    let brdf = evaluate_brdf(surface, dir);
+    if (brdf <= 0.0)
     {
-        return REJECT_UNCORRELATED;
+        return 0.0;
     }
 
     let target_score = compute_target_score(ls.radiance);
     if (target_score < 0.01 * ls.pdf) {
-        return REJECT_ZERO_TARGET_SCORE;
+        return 0.0;
     }
 
-    if (check_ray_occluded(start_pos, ls.dir, debug_len)) {
-        return REJECT_OCCLUDED;
+    if (check_ray_occluded(start_pos, dir, debug_len)) {
+        return 0.0;
     }
 
-    return REJECT_NO;
+    return brdf;
 }
 
 struct HeuristicFactors {
@@ -324,12 +340,11 @@ fn compute_restir(surface: Surface, pixel: vec2<i32>, rng: ptr<function, RandomS
             ls = sample_light_from_sphere(rng);
         }
 
-        let reject = evaluate_sample(ls, surface, position, debug_len);
-        if (reject == 0u) {
-            let radiance = ls.radiance * evaluate_brdf(surface, ls.dir);
-            let other = make_reservoir(ls, radiance);
+        let brdf = evaluate_sample(ls, surface, position, debug_len);
+        if (brdf > 0.0) {
+            let other = make_reservoir(ls, 0u, vec3<f32>(brdf));
             if (merge_reservoir(&canonical, other, random_gen(rng))) {
-                canonical_radiance = radiance;
+                canonical_radiance = ls.radiance * brdf;
             }
         } else {
             bump_reservoir(&canonical, 1.0);
@@ -396,7 +411,8 @@ fn compute_restir(surface: Surface, pixel: vec2<i32>, rng: ptr<function, RandomS
                 let neighbor_dir = get_ray_direction(prev_camera, neighbor_pixel);
                 let neighbor_position = prev_camera.position + neighbor_surface.depth * neighbor_dir;
 
-                let t_canonical_at_neighbor = estimate_target_pdf_with_occlusion(neighbor_surface, neighbor_position, canonical.selected_dir, debug_len);
+                let t_canonical_at_neighbor = estimate_target_pdf_with_occlusion(
+                    neighbor_surface, neighbor_position, canonical.selected_light_index, canonical.selected_uv, debug_len);
                 let mis_sub_canonical = balance_heuristic(
                     t_canonical_at_neighbor.score, canonical.selected_target_score,
                     neighbor_history * f32(accepted_count), canonical.history);
@@ -408,13 +424,15 @@ fn compute_restir(surface: Surface, pixel: vec2<i32>, rng: ptr<function, RandomS
             //   target light has moved, and re-evaluate the occlusion.
             // 2. we can use the cached target score, and there is no use of the target color
             //let t_neighbor_at_neighbor = estimate_target_pdf(neighbor_surface, neighbor_position, neighbor.selected_dir);
-            let t_neighbor_at_canonical = estimate_target_pdf_with_occlusion(surface, position, neighbor.light_dir, debug_len);
+            let t_neighbor_at_canonical = estimate_target_pdf_with_occlusion(
+                surface, position, neighbor.light_index, neighbor.light_uv, debug_len);
             let mis_neighbor = balance_heuristic(
                 neighbor.target_score, t_neighbor_at_canonical.score,
                 neighbor_history * f32(accepted_count), canonical.history);
 
             other.history = neighbor_history;
-            other.selected_dir = neighbor.light_dir;
+            other.selected_light_index = neighbor.light_index;
+            other.selected_uv = neighbor.light_uv;
             other.selected_target_score = t_neighbor_at_canonical.score;
             other.weight_sum = t_neighbor_at_canonical.score * neighbor.contribution_weight * mis_neighbor.weight;
             //Note: should be needed according to the paper
@@ -422,7 +440,7 @@ fn compute_restir(surface: Surface, pixel: vec2<i32>, rng: ptr<function, RandomS
             other_color = t_neighbor_at_canonical.color;
         } else {
             other = unpack_reservoir(neighbor, max_history);
-            other_color = evaluate_reflected_light(surface, other.selected_dir);
+            other_color = evaluate_reflected_light(surface, other.selected_light_index, other.selected_uv);
         }
 
         if (other.weight_sum <= 0.0) {

--- a/blade-render/code/ray-trace.wgsl
+++ b/blade-render/code/ray-trace.wgsl
@@ -440,7 +440,7 @@ fn compute_restir(surface: Surface, pixel: vec2<i32>, rng: ptr<function, RandomS
     return ro;
 }
 
-@compute @workgroup_size(8, 8)
+@compute @workgroup_size(8, 4)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (any(global_id.xy >= camera.target_size)) {
         return;


### PR DESCRIPTION
Starting state:
>[2023-07-18T07:02:04Z INFO  blade_graphics::hal::pipeline] Compute pipeline 'fill-gbuf' uses: 64 VGPRs, 40 SGPRs
[2023-07-18T07:02:04Z INFO  blade_graphics::hal::pipeline] Compute pipeline 'ray-trace' uses: 128 VGPRs, 76 SGPRs
[2023-07-18T07:02:04Z INFO  blade_graphics::hal::pipeline] Compute pipeline 'atrous' uses: 23 VGPRs, 33 SGPRs

Finish state:
>[2023-07-19T06:56:24Z INFO  blade_graphics::hal::pipeline] Compute pipeline 'ray-trace' uses: 96 VGPRs, 89 SGPRs
