### PR TITLE
Draw debug lines from CPU

### DIFF
--- a/blade-render/code/debug-draw.wgsl
+++ b/blade-render/code/debug-draw.wgsl
@@ -3,6 +3,7 @@
 #include "camera.inc.wgsl"
 
 var<uniform> camera: CameraParams;
+var<storage> debug_lines: array<DebugLine>;
 
 struct DebugVarying {
     @builtin(position) pos: vec4<f32>,
@@ -12,7 +13,7 @@ struct DebugVarying {
 
 @vertex
 fn debug_vs(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> DebugVarying {
-    let line = debug_buf.lines[instance_id];
+    let line = debug_lines[instance_id];
     var point = line.a;
     if (vertex_id != 0u) {
         point = line.b;

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -492,8 +492,13 @@ impl Example {
                     }
                     None => &[],
                 };
-                self.renderer
-                    .post_proc(&mut pass, self.debug, self.post_proc_config, debug_blits);
+                self.renderer.post_proc(
+                    &mut pass,
+                    self.debug,
+                    self.post_proc_config,
+                    &[],
+                    debug_blits,
+                );
             }
             self.gui_painter
                 .paint(&mut pass, gui_primitives, &screen_desc, &self.context);


### PR DESCRIPTION
Debug collider bounding box visualization:
![cpu-debug-lines](https://github.com/kvark/blade/assets/107301/e559de17-aa53-4bef-8ea6-dc1321cb4a62)
