### PR TITLE
Vertex buffers support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "blade-graphics",
     "blade-macros",
     "blade-render",
+    "run-wasm",
 ]
 exclude = []
 
@@ -44,7 +45,6 @@ readme = "docs/README.md"
 blade-asset = { version = "0.2", path = "blade-asset" }
 blade-egui = { version = "0.3", path = "blade-egui" }
 blade-graphics = { version = "0.4", path = "blade-graphics" }
-blade-render = { version = "0.3", path = "blade-render" }
 base64 = { workspace = true }
 choir = { workspace = true }
 colorsys = "0.6"
@@ -61,6 +61,9 @@ slab = "0.4"
 strum = { workspace = true }
 winit = { version = "0.29", features = ["rwh_05"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+blade-render = { version = "0.3", path = "blade-render" }
+
 [dev-dependencies]
 blade-macros = { version = "0.2", path = "blade-macros" }
 bytemuck = { workspace = true }
@@ -68,7 +71,6 @@ choir = { workspace = true }
 egui = { workspace = true }
 egui-gizmo = "0.16"
 egui_plot = "0.26"
-egui-winit = "0.26"
 env_logger = "0.10"
 del-msh = "=0.1.25" # not following semver :(
 glam = { workspace = true }
@@ -81,10 +83,15 @@ ron = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 strum = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# see https://github.com/emilk/egui/issues/4270
+egui-winit = "0.26"
+
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = "1"
 web-sys = { workspace = true, features = ["Window"] }
+getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(any(target_os = "windows", target_os = "linux"))'.dev-dependencies]
 renderdoc = "0.11"

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -133,6 +133,7 @@ impl GuiPainter {
             name: "gui",
             data_layouts: &[&globals_layout, &locals_layout],
             vertex: shader.at("vs_main"),
+            vertex_fetches: &[],
             primitive: blade_graphics::PrimitiveState {
                 topology: blade_graphics::PrimitiveTopology::TriangleList,
                 ..Default::default()

--- a/blade-graphics/src/derive.rs
+++ b/blade-graphics/src/derive.rs
@@ -32,6 +32,7 @@ impl HasShaderBinding for super::AccelerationStructure {
 pub trait HasVertexAttribute {
     const FORMAT: VertexFormat;
 }
+
 impl HasVertexAttribute for f32 {
     const FORMAT: VertexFormat = VertexFormat::F32;
 }
@@ -55,4 +56,44 @@ impl HasVertexAttribute for [u32; 3] {
 }
 impl HasVertexAttribute for [u32; 4] {
     const FORMAT: VertexFormat = VertexFormat::U32Vec4;
+}
+impl HasVertexAttribute for i32 {
+    const FORMAT: VertexFormat = VertexFormat::I32;
+}
+impl HasVertexAttribute for [i32; 2] {
+    const FORMAT: VertexFormat = VertexFormat::I32Vec2;
+}
+impl HasVertexAttribute for [i32; 3] {
+    const FORMAT: VertexFormat = VertexFormat::I32Vec3;
+}
+impl HasVertexAttribute for [i32; 4] {
+    const FORMAT: VertexFormat = VertexFormat::I32Vec4;
+}
+
+impl HasVertexAttribute for mint::Vector2<f32> {
+    const FORMAT: VertexFormat = VertexFormat::F32Vec2;
+}
+impl HasVertexAttribute for mint::Vector3<f32> {
+    const FORMAT: VertexFormat = VertexFormat::F32Vec3;
+}
+impl HasVertexAttribute for mint::Vector4<f32> {
+    const FORMAT: VertexFormat = VertexFormat::F32Vec4;
+}
+impl HasVertexAttribute for mint::Vector2<u32> {
+    const FORMAT: VertexFormat = VertexFormat::U32Vec2;
+}
+impl HasVertexAttribute for mint::Vector3<u32> {
+    const FORMAT: VertexFormat = VertexFormat::U32Vec3;
+}
+impl HasVertexAttribute for mint::Vector4<u32> {
+    const FORMAT: VertexFormat = VertexFormat::U32Vec4;
+}
+impl HasVertexAttribute for mint::Vector2<i32> {
+    const FORMAT: VertexFormat = VertexFormat::I32Vec2;
+}
+impl HasVertexAttribute for mint::Vector3<i32> {
+    const FORMAT: VertexFormat = VertexFormat::I32Vec3;
+}
+impl HasVertexAttribute for mint::Vector4<i32> {
+    const FORMAT: VertexFormat = VertexFormat::I32Vec4;
 }

--- a/blade-graphics/src/derive.rs
+++ b/blade-graphics/src/derive.rs
@@ -1,0 +1,58 @@
+use std::mem;
+
+use super::{ResourceIndex, ShaderBinding, VertexFormat};
+
+pub trait HasShaderBinding: super::ShaderBindable {
+    const TYPE: ShaderBinding;
+}
+impl<T: bytemuck::Pod> HasShaderBinding for T {
+    const TYPE: ShaderBinding = ShaderBinding::Plain {
+        size: mem::size_of::<T>() as u32,
+    };
+}
+impl HasShaderBinding for super::TextureView {
+    const TYPE: ShaderBinding = ShaderBinding::Texture;
+}
+impl HasShaderBinding for super::Sampler {
+    const TYPE: ShaderBinding = ShaderBinding::Sampler;
+}
+impl HasShaderBinding for super::BufferPiece {
+    const TYPE: ShaderBinding = ShaderBinding::Buffer;
+}
+impl<'a, const N: ResourceIndex> HasShaderBinding for &'a super::BufferArray<N> {
+    const TYPE: ShaderBinding = ShaderBinding::BufferArray { count: N };
+}
+impl<'a, const N: ResourceIndex> HasShaderBinding for &'a super::TextureArray<N> {
+    const TYPE: ShaderBinding = ShaderBinding::TextureArray { count: N };
+}
+impl HasShaderBinding for super::AccelerationStructure {
+    const TYPE: ShaderBinding = ShaderBinding::AccelerationStructure;
+}
+
+pub trait HasVertexAttribute {
+    const FORMAT: VertexFormat;
+}
+impl HasVertexAttribute for f32 {
+    const FORMAT: VertexFormat = VertexFormat::F32;
+}
+impl HasVertexAttribute for [f32; 2] {
+    const FORMAT: VertexFormat = VertexFormat::F32Vec2;
+}
+impl HasVertexAttribute for [f32; 3] {
+    const FORMAT: VertexFormat = VertexFormat::F32Vec3;
+}
+impl HasVertexAttribute for [f32; 4] {
+    const FORMAT: VertexFormat = VertexFormat::F32Vec4;
+}
+impl HasVertexAttribute for u32 {
+    const FORMAT: VertexFormat = VertexFormat::U32;
+}
+impl HasVertexAttribute for [u32; 2] {
+    const FORMAT: VertexFormat = VertexFormat::U32Vec2;
+}
+impl HasVertexAttribute for [u32; 3] {
+    const FORMAT: VertexFormat = VertexFormat::U32Vec3;
+}
+impl HasVertexAttribute for [u32; 4] {
+    const FORMAT: VertexFormat = VertexFormat::U32Vec4;
+}

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -362,6 +362,15 @@ impl crate::traits::RenderPipelineEncoder for super::PipelineEncoder<'_> {
         self.commands.push(super::Command::SetScissor(rect.clone()));
     }
 
+    fn bind_vertex(&mut self, index: u32, vertex_buf: crate::BufferPiece) {
+        /*self.commands.push(super::Command::BindBuffer {
+            target: glow::SHADER_STORAGE_BUFFER,
+            slot,
+            buffer: vertex_buf.into(),
+        });*/
+        unimplemented!()
+    }
+
     fn draw(
         &mut self,
         start_vertex: u32,

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -442,6 +442,10 @@ impl crate::VertexFormat {
             Self::U32Vec2 => (2, glow::UNSIGNED_INT),
             Self::U32Vec3 => (3, glow::UNSIGNED_INT),
             Self::U32Vec4 => (4, glow::UNSIGNED_INT),
+            Self::I32 => (1, glow::INT),
+            Self::I32Vec2 => (2, glow::INT),
+            Self::I32Vec3 => (3, glow::INT),
+            Self::I32Vec4 => (4, glow::INT),
         }
     }
 }

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -44,10 +44,7 @@ impl crate::traits::ResourceDevice for super::Context {
         let usage = match desc.memory {
             crate::Memory::Device => glow::STATIC_DRAW,
             crate::Memory::Shared => {
-                map_flags = glow::MAP_READ_BIT
-                    | glow::MAP_WRITE_BIT
-                    | glow::MAP_PERSISTENT_BIT
-                    | glow::MAP_UNSYNCHRONIZED_BIT;
+                map_flags = glow::MAP_READ_BIT | glow::MAP_WRITE_BIT | glow::MAP_PERSISTENT_BIT;
                 storage_flags = glow::MAP_PERSISTENT_BIT
                     | glow::MAP_COHERENT_BIT
                     | glow::MAP_READ_BIT
@@ -72,6 +69,7 @@ impl crate::traits::ResourceDevice for super::Context {
                 gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
                 if map_flags != 0 {
                     data = gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
+                    assert!(!data.is_null());
                 }
             } else {
                 gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -559,9 +559,14 @@ pub struct VertexAttribute {
     pub format: VertexFormat,
 }
 
+struct VertexAttributeMapping {
+    buffer_index: usize,
+    attribute_index: usize,
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct VertexLayout {
-    pub attributes: Vec<VertexAttribute>,
+    pub attributes: Vec<(&'static str, VertexAttribute)>,
     pub stride: u32,
 }
 

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -469,6 +469,10 @@ pub enum VertexFormat {
     U32Vec2,
     U32Vec3,
     U32Vec4,
+    I32,
+    I32Vec2,
+    I32Vec3,
+    I32Vec4,
 }
 
 #[derive(Clone, Debug)]

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -526,9 +526,8 @@ impl crate::traits::RenderPipelineEncoder for super::RenderPipelineContext<'_> {
     }
 
     fn bind_vertex(&mut self, index: u32, vertex_buf: crate::BufferPiece) {
-        //TODO: figure out the binding slot
         self.encoder.set_vertex_buffer(
-            index as u64 + 9999,
+            index as u64,
             Some(vertex_buf.buffer.as_ref()),
             vertex_buf.offset,
         );

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -525,6 +525,15 @@ impl crate::traits::RenderPipelineEncoder for super::RenderPipelineContext<'_> {
         self.encoder.set_scissor_rect(scissor);
     }
 
+    fn bind_vertex(&mut self, index: u32, vertex_buf: crate::BufferPiece) {
+        //TODO: figure out the binding slot
+        self.encoder.set_vertex_buffer(
+            index as u64 + 9999,
+            Some(vertex_buf.buffer.as_ref()),
+            vertex_buf.offset,
+        );
+    }
+
     fn draw(
         &mut self,
         first_vertex: u32,

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -337,7 +337,14 @@ fn map_index_type(ty: crate::IndexType) -> metal::MTLIndexType {
 
 fn map_attribute_format(format: crate::VertexFormat) -> metal::MTLAttributeFormat {
     match format {
+        crate::VertexFormat::F32 => metal::MTLAttributeFormat::Float,
+        crate::VertexFormat::F32Vec2 => metal::MTLAttributeFormat::Float2,
         crate::VertexFormat::F32Vec3 => metal::MTLAttributeFormat::Float3,
+        crate::VertexFormat::F32Vec4 => metal::MTLAttributeFormat::Float4,
+        crate::VertexFormat::U32 => metal::MTLAttributeFormat::UInt,
+        crate::VertexFormat::U32Vec2 => metal::MTLAttributeFormat::UInt2,
+        crate::VertexFormat::U32Vec3 => metal::MTLAttributeFormat::UInt3,
+        crate::VertexFormat::U32Vec4 => metal::MTLAttributeFormat::UInt4,
     }
 }
 

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -335,20 +335,55 @@ fn map_index_type(ty: crate::IndexType) -> metal::MTLIndexType {
     }
 }
 
-fn map_attribute_format(format: crate::VertexFormat) -> metal::MTLAttributeFormat {
+fn map_vertex_format(
+    format: crate::VertexFormat,
+) -> (metal::MTLVertexFormat, metal::MTLAttributeFormat) {
     match format {
-        crate::VertexFormat::F32 => metal::MTLAttributeFormat::Float,
-        crate::VertexFormat::F32Vec2 => metal::MTLAttributeFormat::Float2,
-        crate::VertexFormat::F32Vec3 => metal::MTLAttributeFormat::Float3,
-        crate::VertexFormat::F32Vec4 => metal::MTLAttributeFormat::Float4,
-        crate::VertexFormat::U32 => metal::MTLAttributeFormat::UInt,
-        crate::VertexFormat::U32Vec2 => metal::MTLAttributeFormat::UInt2,
-        crate::VertexFormat::U32Vec3 => metal::MTLAttributeFormat::UInt3,
-        crate::VertexFormat::U32Vec4 => metal::MTLAttributeFormat::UInt4,
-        crate::VertexFormat::I32 => metal::MTLAttributeFormat::Int,
-        crate::VertexFormat::I32Vec2 => metal::MTLAttributeFormat::Int2,
-        crate::VertexFormat::I32Vec3 => metal::MTLAttributeFormat::Int3,
-        crate::VertexFormat::I32Vec4 => metal::MTLAttributeFormat::Int4,
+        crate::VertexFormat::F32 => (
+            metal::MTLVertexFormat::Float,
+            metal::MTLAttributeFormat::Float,
+        ),
+        crate::VertexFormat::F32Vec2 => (
+            metal::MTLVertexFormat::Float2,
+            metal::MTLAttributeFormat::Float2,
+        ),
+        crate::VertexFormat::F32Vec3 => (
+            metal::MTLVertexFormat::Float3,
+            metal::MTLAttributeFormat::Float3,
+        ),
+        crate::VertexFormat::F32Vec4 => (
+            metal::MTLVertexFormat::Float4,
+            metal::MTLAttributeFormat::Float4,
+        ),
+        crate::VertexFormat::U32 => (
+            metal::MTLVertexFormat::UInt,
+            metal::MTLAttributeFormat::UInt,
+        ),
+        crate::VertexFormat::U32Vec2 => (
+            metal::MTLVertexFormat::UInt2,
+            metal::MTLAttributeFormat::UInt2,
+        ),
+        crate::VertexFormat::U32Vec3 => (
+            metal::MTLVertexFormat::UInt3,
+            metal::MTLAttributeFormat::UInt3,
+        ),
+        crate::VertexFormat::U32Vec4 => (
+            metal::MTLVertexFormat::UInt4,
+            metal::MTLAttributeFormat::UInt4,
+        ),
+        crate::VertexFormat::I32 => (metal::MTLVertexFormat::Int, metal::MTLAttributeFormat::Int),
+        crate::VertexFormat::I32Vec2 => (
+            metal::MTLVertexFormat::Int2,
+            metal::MTLAttributeFormat::Int2,
+        ),
+        crate::VertexFormat::I32Vec3 => (
+            metal::MTLVertexFormat::Int3,
+            metal::MTLAttributeFormat::Int3,
+        ),
+        crate::VertexFormat::I32Vec4 => (
+            metal::MTLVertexFormat::Int4,
+            metal::MTLAttributeFormat::Int4,
+        ),
     }
 }
 
@@ -507,7 +542,8 @@ fn make_bottom_level_acceleration_structure_desc(
         }
         //TODO: requires macOS-13 ?
         if false {
-            descriptor.set_vertex_format(map_attribute_format(mesh.vertex_format));
+            let (_, attribute_format) = map_vertex_format(mesh.vertex_format);
+            descriptor.set_vertex_format(attribute_format);
             if !mesh.transform_data.buffer.raw.is_null() {
                 descriptor
                     .set_transformation_matrix_buffer(Some(mesh.transform_data.buffer.as_ref()));

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -345,6 +345,10 @@ fn map_attribute_format(format: crate::VertexFormat) -> metal::MTLAttributeForma
         crate::VertexFormat::U32Vec2 => metal::MTLAttributeFormat::UInt2,
         crate::VertexFormat::U32Vec3 => metal::MTLAttributeFormat::UInt3,
         crate::VertexFormat::U32Vec4 => metal::MTLAttributeFormat::UInt4,
+        crate::VertexFormat::I32 => metal::MTLAttributeFormat::Int,
+        crate::VertexFormat::I32Vec2 => metal::MTLAttributeFormat::Int2,
+        crate::VertexFormat::I32Vec3 => metal::MTLAttributeFormat::Int3,
+        crate::VertexFormat::I32Vec4 => metal::MTLAttributeFormat::Int4,
     }
 }
 

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -93,6 +93,7 @@ pub trait ComputePipelineEncoder: PipelineEncoder {
 pub trait RenderPipelineEncoder: PipelineEncoder {
     //TODO: reconsider exposing this here
     fn set_scissor_rect(&mut self, rect: &super::ScissorRect);
+    fn bind_vertex(&mut self, index: u32, vertex_buf: super::BufferPiece);
     fn draw(
         &mut self,
         first_vertex: u32,

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -756,6 +756,17 @@ impl crate::traits::RenderPipelineEncoder for super::PipelineEncoder<'_, '_> {
         };
     }
 
+    fn bind_vertex(&mut self, index: u32, vertex_buf: crate::BufferPiece) {
+        unsafe {
+            self.device.core.cmd_bind_vertex_buffers(
+                self.cmd_buf.raw,
+                index,
+                &[vertex_buf.buffer.raw],
+                &[vertex_buf.offset],
+            );
+        }
+    }
+
     fn draw(
         &mut self,
         start_vertex: u32,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -561,7 +561,14 @@ fn map_index_type(index_type: crate::IndexType) -> vk::IndexType {
 fn map_vertex_format(vertex_format: crate::VertexFormat) -> vk::Format {
     use crate::VertexFormat as Vf;
     match vertex_format {
+        Vf::F32 => vk::Format::R32_SFLOAT,
+        Vf::F32Vec2 => vk::Format::R32G32_SFLOAT,
         Vf::F32Vec3 => vk::Format::R32G32B32_SFLOAT,
+        Vf::F32Vec4 => vk::Format::R32G32B32A32_SFLOAT,
+        Vf::U32 => vk::Format::R32_UINT,
+        Vf::U32Vec2 => vk::Format::R32G32_UINT,
+        Vf::U32Vec3 => vk::Format::R32G32B32_UINT,
+        Vf::U32Vec4 => vk::Format::R32G32B32A32_UINT,
     }
 }
 

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -569,6 +569,10 @@ fn map_vertex_format(vertex_format: crate::VertexFormat) -> vk::Format {
         Vf::U32Vec2 => vk::Format::R32G32_UINT,
         Vf::U32Vec3 => vk::Format::R32G32B32_UINT,
         Vf::U32Vec4 => vk::Format::R32G32B32A32_UINT,
+        Vf::I32 => vk::Format::R32_SINT,
+        Vf::I32Vec2 => vk::Format::R32G32_SINT,
+        Vf::I32Vec3 => vk::Format::R32G32B32_SINT,
+        Vf::I32Vec4 => vk::Format::R32G32B32A32_SINT,
     }
 }
 

--- a/blade-graphics/src/vulkan/pipeline.rs
+++ b/blade-graphics/src/vulkan/pipeline.rs
@@ -75,12 +75,12 @@ impl super::Context {
         vertex_fetch_states: &[crate::VertexFetchState],
     ) -> CompiledShader {
         let ep_index = sf.entry_point_index();
-        let ep_info = sf.shader.info.get_entry_point(ep_index);
-        let ep = &sf.shader.module.entry_points[ep_index];
         let mut module = sf.shader.module.clone();
         let attribute_mappings =
-            crate::Shader::fill_vertex_locations(&mut module, ep, vertex_fetch_states);
+            crate::Shader::fill_vertex_locations(&mut module, ep_index, vertex_fetch_states);
 
+        let ep_info = sf.shader.info.get_entry_point(ep_index);
+        let ep = &sf.shader.module.entry_points[ep_index];
         let mut layouter = naga::proc::Layouter::default();
         layouter.update(module.to_ctx()).unwrap();
 

--- a/blade-macros/Cargo.toml
+++ b/blade-macros/Cargo.toml
@@ -19,3 +19,4 @@ quote = "1.0"
 blade-graphics = { version = "0.4", path = "../blade-graphics" }
 blade-asset = { version = "0.2", path = "../blade-asset" }
 bytemuck = { workspace = true }
+mint = { workspace = true }

--- a/blade-macros/src/lib.rs
+++ b/blade-macros/src/lib.rs
@@ -1,6 +1,7 @@
 mod as_primitive;
 mod flat;
 mod shader_data;
+mod vertex;
 
 use proc_macro::TokenStream;
 
@@ -17,6 +18,26 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(ShaderData)]
 pub fn shader_data_derive(input: TokenStream) -> TokenStream {
     let stream = match shader_data::generate(input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.into_compile_error(),
+    };
+    stream.into()
+}
+
+/// Derive the `Vertex` trait for a struct.
+///
+/// ## Example
+///
+/// ```rust
+/// #[derive(blade_macros::Vertex)]
+/// struct Test {
+///   pos: [f32; 3],
+///   tc: mint::Vector2<f32>,
+/// }
+/// ```
+#[proc_macro_derive(Vertex)]
+pub fn vertex_derive(input: TokenStream) -> TokenStream {
+    let stream = match vertex::generate(input) {
         Ok(tokens) => tokens,
         Err(err) => err.into_compile_error(),
     };

--- a/blade-macros/src/shader_data.rs
+++ b/blade-macros/src/shader_data.rs
@@ -20,7 +20,7 @@ pub fn generate(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStre
         let name = field.ident.as_ref().unwrap();
         let ty = &field.ty;
         bindings.push(quote! {
-            (stringify!(#name), <#ty as blade_graphics::HasShaderBinding>::TYPE)
+            (stringify!(#name), <#ty as blade_graphics::derive::HasShaderBinding>::TYPE)
         });
         assignments.push(quote! {
             self.#name.bind_to(&mut ctx, #index);

--- a/blade-macros/src/vertex.rs
+++ b/blade-macros/src/vertex.rs
@@ -37,12 +37,12 @@ pub fn generate(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStre
         //TODO: use this when MSRV gets to 1.77
         // `std::mem::offset_of!(#full_struct_name, #name)
         attributes.push(quote! {
-            blade_graphics::VertexAttribute {
+            (stringify!(#name), blade_graphics::VertexAttribute {
                 offset: unsafe {
                     (&(*base_ptr).#name as *const _ as *const u8).offset_from(base_ptr as *const u8) as u32
                 },
                 format: <#ty as blade_graphics::derive::HasVertexAttribute>::FORMAT,
-            }
+            })
         });
     }
 

--- a/blade-macros/src/vertex.rs
+++ b/blade-macros/src/vertex.rs
@@ -1,0 +1,61 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+pub fn generate(input_stream: TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let item_struct = syn::parse::<syn::ItemStruct>(input_stream)?;
+    let fields = match item_struct.fields {
+        syn::Fields::Named(ref fields) => fields,
+        _ => {
+            return Err(syn::Error::new(
+                item_struct.struct_token.span,
+                "Structure fields must be named",
+            ))
+        }
+    };
+
+    let struct_name = item_struct.ident;
+    let mut generics = Vec::new();
+    for param in item_struct.generics.params {
+        match param {
+            syn::GenericParam::Lifetime(lt) => {
+                generics.push(lt.lifetime);
+            }
+            syn::GenericParam::Type(_) | syn::GenericParam::Const(_) => {
+                return Err(syn::Error::new(
+                    item_struct.struct_token.span,
+                    "Unsupported generic parameters",
+                ))
+            }
+        }
+    }
+    let full_struct_name = quote!(#struct_name<#(#generics),*>);
+
+    let mut attributes = Vec::new();
+    for field in fields.named.iter() {
+        let name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        //TODO: use this when MSRV gets to 1.77
+        // `std::mem::offset_of!(#full_struct_name, #name)
+        attributes.push(quote! {
+            blade_graphics::VertexAttribute {
+                offset: unsafe {
+                    (&(*base_ptr).#name as *const _ as *const u8).offset_from(base_ptr as *const u8) as u32
+                },
+                format: <#ty as blade_graphics::derive::HasVertexAttribute>::FORMAT,
+            }
+        });
+    }
+
+    Ok(quote! {
+        impl<#(#generics),*> blade_graphics::Vertex for #full_struct_name {
+            fn layout() -> blade_graphics::VertexLayout {
+                let uninit = <core::mem::MaybeUninit<Self>>::uninit();
+                let base_ptr = uninit.as_ptr();
+                blade_graphics::VertexLayout {
+                    attributes: vec![#(#attributes),*],
+                    stride: core::mem::size_of::<Self>() as u32,
+                }
+            }
+        }
+    })
+}

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -83,6 +83,7 @@ fn create_draw_pipeline(
         name: "debug-draw",
         data_layouts: &[&layout],
         vertex: shader.at("debug_vs"),
+        vertex_fetches: &[],
         primitive: blade_graphics::PrimitiveState {
             topology: blade_graphics::PrimitiveTopology::LineList,
             ..Default::default()
@@ -108,6 +109,7 @@ fn create_blit_pipeline(
         name: "debug-blit",
         data_layouts: &[&layout],
         vertex: shader.at("blit_vs"),
+        vertex_fetches: &[],
         primitive: blade_graphics::PrimitiveState {
             topology: blade_graphics::PrimitiveTopology::TriangleStrip,
             ..Default::default()

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -582,6 +582,7 @@ impl ShaderPipelines {
                 ..Default::default()
             },
             vertex: shader.at("blit_vs"),
+            vertex_fetches: &[],
             fragment: shader.at("blit_fs"),
             color_targets: &[format.into()],
             depth_stencil: None,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog for Blade
 
+## blade-graphics-0.5, blade-macros-0.3 (TBD)
+
+- vertex buffers support
+- configuration for disabling exclusive fullscreen
+
 ## blade-graphics-0.4, blade-render-0.3, blade-0.2 (22 Mar 2024)
+
 - crate: `blade` for high-level engine
   - built-in physics via Rapier3D
 - examples: "vehicle"
@@ -16,6 +22,7 @@ Changelog for Blade
   - overlay support
 
 ## blade-graphics-0.3, blade-render-0.2 (17 Nov 2023)
+
 - tangent space generation
 - spatio-temporal resampling
 - SVGF de-noising
@@ -29,15 +36,17 @@ Changelog for Blade
   - using egui-gizmo for manipulation
 
 ## blade-graphics-0.2, blade-render-0.1 (31 May 2023)
+
 - ray tracing support
 - examples: "ray-query", "scene"
 - crate: `blade-egui` for egui integration
 - crate: `blade-asset` for asset pipeline
 - crate: `blade-render` for ray-traced renderer
   - load models: `gltf`
-	- load textures: `png`, `jpg`
+  - load textures: `png`, `jpg`
 
 ## blade-graphics-0.1 (25 Jan 2023)
+
 - backends: Vulkan, Metal, OpenGL ES + WebGL2
 - examples: "mini", "bunnymark", "particle"
 - crate: `blade-graphics` for GPU abstracting GPU operations

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 
 ![](logo.png)
 
-Blade is an innovative rendering solution for Rust. It starts with a lean [low-level GPU abstraction](https://youtu.be/63dnzjw4azI?t=623) focused at ergonomics and fun. It then grows into a high-level rendering library that utilizes hardware ray-tracing. Finally, a [task-parallel asset pipeline](https://youtu.be/1DiA3OYqvqU) together with [egui](https://www.egui.rs/) support turn it into a minimal rendering engine.
+Blade is an innovative rendering solution for Rust. It starts with a lean [low-level GPU abstraction](https://youtu.be/63dnzjw4azI?t=623) focused at ergonomics and fun. It then grows into a high-level rendering library that utilizes hardware ray-tracing. It's accompanied by a [task-parallel asset pipeline](https://youtu.be/1DiA3OYqvqU) together with [egui](https://www.egui.rs/) support, turning into a minimal rendering engine. Finally, the top-level Blade engine combines all of this with Rapier3D-based physics and hides them behind a concise API.
 
 ![architecture](https://raw.githubusercontent.com/kvark/blade/main/docs/architecture2.png)
 
@@ -23,6 +23,7 @@ Blade is an innovative rendering solution for Rust. It starts with a lean [low-l
 ## Instructions
 
 Just the usual :crab: workflow. E.g. to run the bunny-mark benchmark run:
+
 ```bash
 cargo run --release --example bunnymark
 ```

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -303,6 +303,7 @@ impl Example {
 
             for sprite in self.bunnies.iter() {
                 rc.bind(1, &sprite.data);
+                rc.bind_vertex(0, sprite.vertex_buf);
                 rc.draw(0, 4, 0, 1);
             }
         }

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -66,7 +66,7 @@ impl Example {
             gpu::Context::init_windowed(
                 window,
                 gpu::ContextDesc {
-                    validation: false,
+                    validation: cfg!(debug_assertions),
                     capture: false,
                     overlay: true,
                 },
@@ -176,6 +176,7 @@ impl Example {
                 vertex_data.len(),
             );
         }
+        context.sync_buffer(vertex_buf);
 
         let mut bunnies = Vec::new();
         bunnies.push(Sprite {
@@ -302,6 +303,9 @@ impl Example {
             );
 
             for sprite in self.bunnies.iter() {
+                //Note: technically, we could get away with either of those bindings
+                // but not them together. However, the purpose of this test is to
+                // mimic a real world draw call, not a super optimized ideal.
                 rc.bind(1, &sprite.data);
                 rc.bind_vertex(0, sprite.vertex_buf);
                 rc.draw(0, 4, 0, 1);
@@ -343,13 +347,11 @@ fn main() {
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
         console_log::init().expect("could not initialize logger");
         // On wasm, append the canvas to the document body
+        let canvas = window.canvas().unwrap();
         web_sys::window()
             .and_then(|win| win.document())
             .and_then(|doc| doc.body())
-            .and_then(|body| {
-                body.append_child(&web_sys::Element::from(window.canvas()))
-                    .ok()
-            })
+            .and_then(|body| body.append_child(&web_sys::Element::from(canvas)).ok())
             .expect("couldn't append canvas to document body");
     }
 

--- a/examples/bunnymark/shader.wgsl
+++ b/examples/bunnymark/shader.wgsl
@@ -14,7 +14,6 @@ var<uniform> locals: Locals;
 struct Vertex {
     pos: vec2<f32>,
 };
-var<storage, read> vertices: array<Vertex>;
 
 var sprite_texture: texture_2d<f32>;
 var sprite_sampler: sampler;
@@ -32,9 +31,8 @@ fn unpack_color(raw: u32) -> vec4<f32> {
 }
 
 @vertex
-fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
-    //let tc = vec2<f32>(f32(vi & 1u), 0.5 * f32(vi & 2u));
-    let tc = vertices[vi].pos;
+fn vs_main(vertex: Vertex) -> VertexOutput {
+    let tc = vertex.pos;
     let offset = tc * globals.sprite_size;
     let pos = globals.mvp_transform * vec4<f32>(locals.position + offset, 0.0, 1.0);
     let color = unpack_color(locals.color);

--- a/examples/bunnymark/shader.wgsl
+++ b/examples/bunnymark/shader.wgsl
@@ -11,6 +11,11 @@ struct Locals {
 };
 var<uniform> locals: Locals;
 
+struct Vertex {
+    pos: vec2<f32>,
+};
+var<storage, read> vertices: array<Vertex>;
+
 var sprite_texture: texture_2d<f32>;
 var sprite_sampler: sampler;
 
@@ -28,7 +33,8 @@ fn unpack_color(raw: u32) -> vec4<f32> {
 
 @vertex
 fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
-    let tc = vec2<f32>(f32(vi & 1u), 0.5 * f32(vi & 2u));
+    //let tc = vec2<f32>(f32(vi & 1u), 0.5 * f32(vi & 2u));
+    let tc = vertices[vi].pos;
     let offset = tc * globals.sprite_size;
     let pos = globals.mvp_transform * vec4<f32>(locals.position + offset, 0.0, 1.0);
     let color = unpack_color(locals.color);

--- a/examples/init/main.rs
+++ b/examples/init/main.rs
@@ -43,6 +43,7 @@ impl EnvMapSampler {
             name: "env-init",
             data_layouts: &[&layout],
             vertex: shader.at("vs_init"),
+            vertex_fetches: &[],
             fragment: shader.at("fs_init"),
             primitive: gpu::PrimitiveState {
                 topology: gpu::PrimitiveTopology::TriangleStrip,
@@ -59,6 +60,7 @@ impl EnvMapSampler {
             name: "env-accum",
             data_layouts: &[&layout],
             vertex: shader.at("vs_accum"),
+            vertex_fetches: &[],
             fragment: shader.at("fs_accum"),
             primitive: gpu::PrimitiveState {
                 topology: gpu::PrimitiveTopology::PointList,

--- a/examples/particle/particle.rs
+++ b/examples/particle/particle.rs
@@ -98,6 +98,7 @@ impl System {
                 ..Default::default()
             },
             vertex: shader.at("draw_vs"),
+            vertex_fetches: &[],
             fragment: shader.at("draw_fs"),
             color_targets: &[gpu::ColorTargetState {
                 format: desc.draw_format,

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -109,6 +109,7 @@ impl Example {
                 ..Default::default()
             },
             vertex: shader.at("draw_vs"),
+            vertex_fetches: &[],
             fragment: shader.at("draw_fs"),
             color_targets: &[surface_format.into()],
             depth_stencil: None,


### PR DESCRIPTION
Closes #101
Example bits from the updated _bunnymark_:
```rust
#[derive(blade_macros::Vertex)]
struct SpriteVertex {
    pos: [f32; 2],
}

            vertex_fetches: &[gpu::VertexFetchState {
                layout: &<SpriteVertex as gpu::Vertex>::layout(),
                instanced: false,
            }],

rc.bind_vertex(0, sprite.vertex_buf);
```

TODO:
- [x] API update
  - [x] more vertex formats
- [x] derive macro
- [x] _bunnymark_ example update
- [x] Implementation
  - [x] Vulkan
  - [x] Metal
  - [x] GLES
  - [ ] WebGL
- [ ] prototype in Zed

This is pretty much done, and it opens the doors properly to use GLES backend with real geometry. However, I realized that porting Zed to vertex buffers isn't going to be as straightforward as I thought. Both Rust and WGSL side structures are deeply nested in it, and that's not expected by either Naga or Blade today. We may need to have additional changes here once we confirm with Zed.