### PR TITLE
GLES explicit bindings

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -302,16 +302,16 @@ impl GuiPainter {
             // Make sure clip rect can fit within an `u32`.
             let clip_min_x = (sd.scale_factor * clip_rect.min.x)
                 .clamp(0.0, sd.physical_size.0 as f32)
-                .trunc() as u32;
+                .trunc() as i32;
             let clip_min_y = (sd.scale_factor * clip_rect.min.y)
                 .clamp(0.0, sd.physical_size.1 as f32)
-                .trunc() as u32;
+                .trunc() as i32;
             let clip_max_x = (sd.scale_factor * clip_rect.max.x)
                 .clamp(0.0, sd.physical_size.0 as f32)
-                .ceil() as u32;
+                .ceil() as i32;
             let clip_max_y = (sd.scale_factor * clip_rect.max.y)
                 .clamp(0.0, sd.physical_size.1 as f32)
-                .ceil() as u32;
+                .ceil() as i32;
 
             if clip_max_x <= clip_min_x || clip_max_y == clip_min_y {
                 continue;
@@ -320,8 +320,8 @@ impl GuiPainter {
             pc.set_scissor_rect(&blade_graphics::ScissorRect {
                 x: clip_min_x,
                 y: clip_min_y,
-                w: clip_max_x - clip_min_x,
-                h: clip_max_y - clip_min_y,
+                w: (clip_max_x - clip_min_x) as u32,
+                h: (clip_max_y - clip_min_y) as u32,
             });
 
             if let egui::epaint::Primitive::Mesh(ref mesh) = clipped_prim.primitive {

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -204,7 +204,7 @@ impl super::PassEncoder<'_, super::ComputePipeline> {
         super::PipelineEncoder {
             commands: self.commands,
             plain_data: self.plain_data,
-            bind_group_infos: &pipeline.inner.bind_group_infos,
+            group_mappings: &pipeline.inner.group_mappings,
             topology: 0,
             limits: self.limits,
             vertex_attributes: &[],
@@ -222,7 +222,7 @@ impl super::PassEncoder<'_, super::RenderPipeline> {
         super::PipelineEncoder {
             commands: self.commands,
             plain_data: self.plain_data,
-            bind_group_infos: &pipeline.inner.bind_group_infos,
+            group_mappings: &pipeline.inner.group_mappings,
             topology: map_primitive_topology(pipeline.topology),
             limits: self.limits,
             vertex_attributes: &pipeline.inner.vertex_attribute_infos,
@@ -345,7 +345,7 @@ impl crate::traits::PipelineEncoder for super::PipelineEncoder<'_> {
         data.fill(super::PipelineContext {
             commands: self.commands,
             plain_data: self.plain_data,
-            targets: &self.bind_group_infos[group as usize].targets,
+            targets: &self.group_mappings[group as usize].targets,
             limits: self.limits,
         });
     }

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -302,6 +302,7 @@ enum Command {
         target: BindTarget,
         slot: u32,
         buffer: BufferPart,
+        size: u32,
     },
     SetVertexAttribute {
         index: u32,

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -85,7 +85,7 @@ pub struct AccelerationStructure {}
 
 type SlotList = Vec<u32>;
 
-struct BindGroupInfo {
+struct ShaderDataMapping {
     targets: Box<[SlotList]>,
 }
 
@@ -98,7 +98,7 @@ struct VertexAttributeInfo {
 
 struct PipelineInner {
     program: glow::Program,
-    bind_group_infos: Box<[BindGroupInfo]>,
+    group_mappings: Box<[ShaderDataMapping]>,
     vertex_attribute_infos: Box<[VertexAttributeInfo]>,
 }
 
@@ -359,7 +359,7 @@ pub type RenderCommandEncoder<'a> = PassEncoder<'a, RenderPipeline>;
 pub struct PipelineEncoder<'a> {
     commands: &'a mut Vec<Command>,
     plain_data: &'a mut Vec<u8>,
-    bind_group_infos: &'a [BindGroupInfo],
+    group_mappings: &'a [ShaderDataMapping],
     topology: u32,
     limits: &'a Limits,
     vertex_attributes: &'a [VertexAttributeInfo],

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -8,23 +8,86 @@ impl super::Context {
         group_layouts: &[&crate::ShaderDataLayout],
         vertex_fetch_states: &[crate::VertexFetchState],
         name: &str,
+        extra_flags: glsl::WriterFlags,
     ) -> super::PipelineInner {
         let gl = self.lock();
-        let use_explicit_bindings = false; //TODO
+        let force_explicit_bindings = self
+            .capabilities
+            .contains(super::Capabilities::BUFFER_STORAGE);
+        let mut naga_options = glsl::Options {
+            version: glsl::Version::Embedded {
+                version: if force_explicit_bindings { 320 } else { 300 },
+                is_webgl: cfg!(target_arch = "wasm32"),
+            },
+            writer_flags: extra_flags | glsl::WriterFlags::ADJUST_COORDINATE_SPACE,
+            binding_map: Default::default(),
+            zero_initialize_workgroup_memory: false,
+        };
+
+        let mut group_mappings = group_layouts
+            .iter()
+            .map(|layout| super::ShaderDataMapping {
+                targets: vec![Vec::new(); layout.bindings.len()].into_boxed_slice(),
+            })
+            .collect::<Box<[_]>>();
+        if force_explicit_bindings {
+            let mut num_textures = 0u32;
+            let mut num_samplers = 0u32;
+            let mut num_buffers = 0u32;
+            for (group_index, (data_mapping, &layout)) in group_mappings
+                .iter_mut()
+                .zip(group_layouts.iter())
+                .enumerate()
+            {
+                for (binding_index, (slot_list, &(_, ref binding))) in data_mapping
+                    .targets
+                    .iter_mut()
+                    .zip(layout.bindings.iter())
+                    .enumerate()
+                {
+                    let target = match *binding {
+                        crate::ShaderBinding::Texture => {
+                            num_textures += 1;
+                            num_textures - 1
+                        }
+                        crate::ShaderBinding::Sampler => {
+                            num_samplers += 1;
+                            num_samplers - 1
+                        }
+                        crate::ShaderBinding::Buffer => {
+                            num_buffers += 1;
+                            num_buffers - 1
+                        }
+                        crate::ShaderBinding::TextureArray { .. }
+                        | crate::ShaderBinding::BufferArray { .. }
+                        | crate::ShaderBinding::AccelerationStructure => unimplemented!(),
+                        crate::ShaderBinding::Plain { .. } => {
+                            num_buffers += 1;
+                            num_buffers - 1
+                        }
+                    };
+
+                    let rb = naga::ResourceBinding {
+                        group: group_index as u32,
+                        binding: binding_index as u32,
+                    };
+                    naga_options.binding_map.insert(rb, target as u8);
+                    slot_list.push(target);
+                }
+            }
+            log::info!(
+                "Detected {} textures, {} samples, and {} buffers",
+                num_textures,
+                num_samplers,
+                num_buffers
+            );
+        }
 
         let program = gl.create_program().unwrap();
         #[cfg(not(target_arch = "wasm32"))]
         if !name.is_empty() && gl.supports_debug() {
             gl.object_label(glow::PROGRAM, std::mem::transmute(program), Some(name));
         }
-
-        let naga_options = glsl::Options {
-            version: glsl::Version::Embedded {
-                version: if use_explicit_bindings { 320 } else { 300 },
-                is_webgl: cfg!(target_arch = "wasm32"),
-            },
-            ..Default::default()
-        };
 
         let mut baked_shaders = Vec::with_capacity(shaders.len());
         let mut group_infos = group_layouts
@@ -38,7 +101,7 @@ impl super::Context {
             let ep = &sf.shader.module.entry_points[ep_index];
 
             let mut module = sf.shader.module.clone();
-            if use_explicit_bindings {
+            if force_explicit_bindings {
                 let ep_info = sf.shader.info.get_entry_point(ep_index);
                 crate::Shader::fill_resource_bindings(
                     &mut module,
@@ -111,101 +174,101 @@ impl super::Context {
         assert!(linked_ok, "Link: {}", msg);
         gl.use_program(Some(program));
 
-        let mut group_mappings = group_layouts
-            .iter()
-            .map(|layout| super::ShaderDataMapping {
-                targets: vec![Vec::new(); layout.bindings.len()].into_boxed_slice(),
-            })
-            .collect::<Box<[_]>>();
-
-        let force_uniform_block_assignment = true;
-        let mut variables_to_bind = Vec::new();
-        for (sf, &(shader, ref reflection)) in shaders.iter().zip(baked_shaders.iter()) {
-            for (glsl_name, mapping) in reflection.texture_mapping.iter() {
-                variables_to_bind.push((glsl_name, mapping.texture));
-                if let Some(handle) = mapping.sampler {
+        if !force_explicit_bindings {
+            let force_uniform_block_assignment = true;
+            let mut variables_to_bind = Vec::new();
+            for (sf, &(_, ref reflection)) in shaders.iter().zip(baked_shaders.iter()) {
+                for (glsl_name, mapping) in reflection.texture_mapping.iter() {
+                    variables_to_bind.push((glsl_name, mapping.texture));
+                    if let Some(handle) = mapping.sampler {
+                        variables_to_bind.push((glsl_name, handle));
+                    }
+                }
+                for (&handle, glsl_name) in reflection.uniforms.iter() {
                     variables_to_bind.push((glsl_name, handle));
                 }
-            }
-            for (&handle, glsl_name) in reflection.uniforms.iter() {
-                variables_to_bind.push((glsl_name, handle));
-            }
 
-            for (glsl_name, var_handle) in variables_to_bind.drain(..) {
-                let var = &sf.shader.module.global_variables[var_handle];
-                let var_name = var.name.as_ref().unwrap().as_str();
-                let (group_index, binding_index) = group_layouts
-                    .iter()
-                    .enumerate()
-                    .find_map(|(group_index, layout)| {
-                        layout
-                            .bindings
-                            .iter()
-                            .position(|&(name, _)| name == var_name)
-                            .map(|binding_index| (group_index, binding_index))
-                    })
-                    .unwrap_or_else(|| {
-                        panic!("Shader variable {} is not found in the bindings", var_name)
-                    });
+                for (glsl_name, var_handle) in variables_to_bind.drain(..) {
+                    let var = &sf.shader.module.global_variables[var_handle];
+                    let var_name = var.name.as_ref().unwrap().as_str();
+                    let (group_index, binding_index) = group_layouts
+                        .iter()
+                        .enumerate()
+                        .find_map(|(group_index, layout)| {
+                            layout
+                                .bindings
+                                .iter()
+                                .position(|&(name, _)| name == var_name)
+                                .map(|binding_index| (group_index, binding_index))
+                        })
+                        .unwrap_or_else(|| {
+                            panic!("Shader variable {} is not found in the bindings", var_name)
+                        });
 
-                let targets = &mut group_mappings[group_index].targets[binding_index];
-                match group_layouts[group_index].bindings[binding_index].1 {
-                    crate::ShaderBinding::Texture | crate::ShaderBinding::Sampler => {
-                        if let Some(ref location) = gl.get_uniform_location(program, glsl_name) {
-                            let mut slots = [0i32];
-                            gl.get_uniform_i32(program, location, &mut slots);
-                            targets.push(slots[0] as u32);
+                    let targets = &mut group_mappings[group_index].targets[binding_index];
+                    match group_layouts[group_index].bindings[binding_index].1 {
+                        crate::ShaderBinding::Texture | crate::ShaderBinding::Sampler => {
+                            if let Some(ref location) = gl.get_uniform_location(program, glsl_name)
+                            {
+                                let mut slots = [0i32];
+                                gl.get_uniform_i32(program, location, &mut slots);
+                                targets.push(slots[0] as u32);
+                            }
                         }
-                    }
-                    crate::ShaderBinding::Buffer => {
-                        if let Some(index) = gl.get_shader_storage_block_index(program, glsl_name) {
-                            let params = gl.get_program_resource_i32(
-                                program,
-                                glow::SHADER_STORAGE_BLOCK,
-                                index,
-                                &[glow::BUFFER_BINDING],
-                            );
-                            targets.push(params[0] as u32);
+                        crate::ShaderBinding::Buffer => {
+                            if let Some(index) =
+                                gl.get_shader_storage_block_index(program, glsl_name)
+                            {
+                                let params = gl.get_program_resource_i32(
+                                    program,
+                                    glow::SHADER_STORAGE_BLOCK,
+                                    index,
+                                    &[glow::BUFFER_BINDING],
+                                );
+                                targets.push(params[0] as u32);
+                            }
                         }
-                    }
-                    crate::ShaderBinding::TextureArray { .. }
-                    | crate::ShaderBinding::BufferArray { .. }
-                    | crate::ShaderBinding::AccelerationStructure => {
-                        unimplemented!()
-                    }
-                    crate::ShaderBinding::Plain { size } => {
-                        if let Some(index) = gl.get_uniform_block_index(program, glsl_name) {
-                            let expected_size = gl.get_active_uniform_block_parameter_i32(
-                                program,
-                                index,
-                                glow::UNIFORM_BLOCK_DATA_SIZE,
-                            ) as u32;
-                            let rounded_up_size = super::round_up_uniform_size(size);
-                            assert!(
-                                expected_size <= rounded_up_size,
-                                "Shader expects block[{}] size {}, but data has size of {} (rounded up to {})",
-                                index,
-                                expected_size,
-                                size,
-                                rounded_up_size,
-                            );
-                            let slot = if force_uniform_block_assignment {
-                                gl.uniform_block_binding(program, index, index);
-                                index
-                            } else {
-                                gl.get_active_uniform_block_parameter_i32(
+                        crate::ShaderBinding::TextureArray { .. }
+                        | crate::ShaderBinding::BufferArray { .. }
+                        | crate::ShaderBinding::AccelerationStructure => {
+                            unimplemented!()
+                        }
+                        crate::ShaderBinding::Plain { size } => {
+                            if let Some(index) = gl.get_uniform_block_index(program, glsl_name) {
+                                let expected_size = gl.get_active_uniform_block_parameter_i32(
                                     program,
                                     index,
-                                    glow::UNIFORM_BLOCK_BINDING,
-                                ) as u32
-                            };
-                            targets.push(slot);
+                                    glow::UNIFORM_BLOCK_DATA_SIZE,
+                                ) as u32;
+                                let rounded_up_size = super::round_up_uniform_size(size);
+                                assert!(
+                                    expected_size <= rounded_up_size,
+                                    "Shader expects block[{}] size {}, but data has size of {} (rounded up to {})",
+                                    index,
+                                    expected_size,
+                                    size,
+                                    rounded_up_size,
+                                );
+                                let slot = if force_uniform_block_assignment {
+                                    gl.uniform_block_binding(program, index, index);
+                                    index
+                                } else {
+                                    gl.get_active_uniform_block_parameter_i32(
+                                        program,
+                                        index,
+                                        glow::UNIFORM_BLOCK_BINDING,
+                                    ) as u32
+                                };
+                                targets.push(slot);
+                            }
                         }
                     }
                 }
             }
 
-            gl.delete_shader(shader);
+            for (shader, _) in baked_shaders {
+                gl.delete_shader(shader);
+            }
         }
         gl.use_program(None);
 
@@ -222,18 +285,31 @@ impl super::Context {
     ) -> super::ComputePipeline {
         let wg_size = desc.compute.shader.module.entry_points[desc.compute.entry_point_index()]
             .workgroup_size;
-        let inner =
-            unsafe { self.create_pipeline(&[desc.compute], desc.data_layouts, &[], desc.name) };
+        let inner = unsafe {
+            self.create_pipeline(
+                &[desc.compute],
+                desc.data_layouts,
+                &[],
+                desc.name,
+                glsl::WriterFlags::empty(),
+            )
+        };
         super::ComputePipeline { inner, wg_size }
     }
 
     pub fn create_render_pipeline(&self, desc: crate::RenderPipelineDesc) -> super::RenderPipeline {
+        let extra_flags = if desc.primitive.topology == crate::PrimitiveTopology::PointList {
+            glsl::WriterFlags::FORCE_POINT_SIZE
+        } else {
+            glsl::WriterFlags::empty()
+        };
         let inner = unsafe {
             self.create_pipeline(
                 &[desc.vertex, desc.fragment],
                 desc.data_layouts,
                 desc.vertex_fetches,
                 desc.name,
+                extra_flags,
             )
         };
         super::RenderPipeline {

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -541,15 +541,26 @@ pub trait ShaderBindable: Clone + Copy {
     fn bind_to(&self, context: &mut PipelineContext, index: u32);
 }
 
+struct ShaderDataInfo {
+    visibility: ShaderVisibility,
+    binding_access: Box<[StorageAccess]>,
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ShaderDataLayout {
     pub bindings: Vec<(&'static str, ShaderBinding)>,
 }
-
 impl ShaderDataLayout {
     pub const EMPTY: &'static Self = &Self {
         bindings: Vec::new(),
     };
+
+    fn to_info(&self) -> ShaderDataInfo {
+        ShaderDataInfo {
+            visibility: ShaderVisibility::empty(),
+            binding_access: vec![StorageAccess::empty(); self.bindings.len()].into_boxed_slice(),
+        }
+    }
 }
 
 pub trait ShaderData {

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -541,6 +541,7 @@ pub trait ShaderBindable: Clone + Copy {
     fn bind_to(&self, context: &mut PipelineContext, index: u32);
 }
 
+#[derive(Debug)]
 struct ShaderDataInfo {
     visibility: ShaderVisibility,
     binding_access: Box<[StorageAccess]>,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -1031,8 +1031,8 @@ pub enum IndexType {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ScissorRect {
-    pub x: u32,
-    pub y: u32,
+    pub x: i32,
+    pub y: i32,
     pub w: u32,
     pub h: u32,
 }

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -387,8 +387,8 @@ impl super::ComputeCommandEncoder<'_> {
 
         super::ComputePipelineContext {
             encoder: &mut self.raw,
-            bind_groups: &pipeline.layout.bind_groups,
             wg_size: pipeline.wg_size,
+            group_mappings: &pipeline.layout.group_mappings,
         }
     }
 }
@@ -444,7 +444,7 @@ impl super::RenderCommandEncoder<'_> {
         super::RenderPipelineContext {
             encoder: &mut self.raw,
             primitive_type: pipeline.primitive_type,
-            bind_groups: &pipeline.layout.bind_groups,
+            group_mappings: &pipeline.layout.group_mappings,
         }
     }
 }
@@ -458,7 +458,7 @@ impl Drop for super::RenderCommandEncoder<'_> {
 #[hidden_trait::expose]
 impl crate::traits::PipelineEncoder for super::ComputePipelineContext<'_> {
     fn bind<D: crate::ShaderData>(&mut self, group: u32, data: &D) {
-        let info = &self.bind_groups[group as usize];
+        let info = &self.group_mappings[group as usize];
 
         data.fill(super::PipelineContext {
             cs_encoder: if info.visibility.contains(crate::ShaderVisibility::COMPUTE) {
@@ -494,7 +494,7 @@ impl Drop for super::ComputePipelineContext<'_> {
 #[hidden_trait::expose]
 impl crate::traits::PipelineEncoder for super::RenderPipelineContext<'_> {
     fn bind<D: crate::ShaderData>(&mut self, group: u32, data: &D) {
-        let info = &self.bind_groups[group as usize];
+        let info = &self.group_mappings[group as usize];
 
         data.fill(super::PipelineContext {
             cs_encoder: None,

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -185,14 +185,15 @@ pub struct CommandEncoder {
 }
 
 #[derive(Debug)]
-struct BindGroupInfo {
+struct ShaderDataMapping {
     visibility: crate::ShaderVisibility,
     targets: Box<[u32]>,
 }
 
 #[derive(Debug)]
 struct PipelineLayout {
-    bind_groups: Box<[BindGroupInfo]>,
+    group_mappings: Box<[ShaderDataMapping]>,
+    group_infos: Box<[crate::ShaderDataInfo]>,
     sizes_buffer_slot: Option<u32>,
 }
 
@@ -269,14 +270,14 @@ pub struct PipelineContext<'a> {
 pub struct ComputePipelineContext<'a> {
     encoder: &'a mut metal::ComputeCommandEncoder,
     wg_size: metal::MTLSize,
-    bind_groups: &'a [BindGroupInfo],
+    group_mappings: &'a [ShaderDataMapping],
 }
 
 #[derive(Debug)]
 pub struct RenderPipelineContext<'a> {
     encoder: &'a mut metal::RenderCommandEncoder,
     primitive_type: metal::MTLPrimitiveType,
-    bind_groups: &'a [BindGroupInfo],
+    group_mappings: &'a [ShaderDataMapping],
 }
 
 fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -636,8 +636,8 @@ impl<'a> super::RenderCommandEncoder<'a> {
     pub fn set_scissor_rect(&mut self, rect: &crate::ScissorRect) {
         let vk_scissor = vk::Rect2D {
             offset: vk::Offset2D {
-                x: rect.x as i32,
-                y: rect.y as i32,
+                x: rect.x,
+                y: rect.y,
             },
             extent: vk::Extent2D {
                 width: rect.w,
@@ -741,8 +741,8 @@ impl crate::traits::RenderPipelineEncoder for super::PipelineEncoder<'_, '_> {
     fn set_scissor_rect(&mut self, rect: &crate::ScissorRect) {
         let vk_scissor = vk::Rect2D {
             offset: vk::Offset2D {
-                x: rect.x as i32,
-                y: rect.y as i32,
+                x: rect.x,
+                y: rect.y,
             },
             extent: vk::Extent2D {
                 width: rect.w,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog for Blade
 
 - vertex buffers support
 - configuration for disabling exclusive fullscreen
+- GLES: support for storage buffer and compute
+- GLES: scissor rects, able to run "particle" example
 
 ## blade-graphics-0.4, blade-render-0.3, blade-0.2 (22 Mar 2024)
 


### PR DESCRIPTION
Every backend has specifics on how the bindings are treated. But all of them eventually need to ensure the `naga::Module` bindings are filled up, and this process is backend-independent. Now it's done in a separate function.
With all the improvements to GLES, it's now able to run the "particle" example on desktop:
```bash
RUSTFLAGS="--cfg gles" CARGO_TARGET_DIR=./target-gl cargo run --example particle
```
![particles-gles](https://github.com/kvark/blade/assets/107301/07c01f28-736f-4f8e-a718-1bace0244073)

TODO: check how it works with Zed