### PR TITLE
vk: work around acquire() on out of date swapchain

### DIFF
--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -297,6 +297,10 @@ impl super::CommandEncoder {
     }
 
     pub fn present(&mut self, frame: super::Frame) {
+        if frame.acquire_semaphore == vk::Semaphore::null() {
+            return;
+        }
+
         assert_eq!(self.present, None);
         let wa = &self.device.workarounds;
         self.present = Some(super::Presentation {


### PR DESCRIPTION
Closes #104
This isn't a proper fix but rather a minimal workaround.

Given that this isn't reproducible on Blade examples (see https://github.com/kvark/blade/issues/104#issuecomment-2028560416), there is possible a better solution on the user side. However, it would be good for Blade to at least not panic in this case, and that's what the PR does.