### PR TITLE
Support transparency and forbidden full screen

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -120,10 +120,7 @@ impl GuiPainter {
     /// It supports renderpasses with only a color attachment,
     /// and this attachment format must be The `output_format`.
     #[profiling::function]
-    pub fn new(
-        output_format: blade_graphics::TextureFormat,
-        context: &blade_graphics::Context,
-    ) -> Self {
+    pub fn new(info: blade_graphics::SurfaceInfo, context: &blade_graphics::Context) -> Self {
         let shader = context.create_shader(blade_graphics::ShaderDesc {
             source: SHADER_SOURCE,
         });
@@ -141,7 +138,7 @@ impl GuiPainter {
             depth_stencil: None, //TODO?
             fragment: shader.at("fs_main"),
             color_targets: &[blade_graphics::ColorTargetState {
-                format: output_format,
+                format: info.format,
                 blend: Some(blade_graphics::BlendState::ALPHA_BLENDING),
                 write_mask: blade_graphics::ColorWrites::all(),
             }],

--- a/blade-graphics/src/gles/web.rs
+++ b/blade-graphics/src/gles/web.rs
@@ -48,6 +48,7 @@ impl Context {
                     &wasm_bindgen::JsValue::FALSE,
                 )
                 .expect("Cannot create context options");
+                //Note: could also set: "alpha", "premultipliedAlpha"
 
                 canvas
                     .get_context_with_context_options("webgl2", &context_options)
@@ -81,7 +82,8 @@ impl Context {
         })
     }
 
-    pub fn resize(&self, config: crate::SurfaceConfig) -> crate::TextureFormat {
+    pub fn resize(&self, config: crate::SurfaceConfig) -> crate::SurfaceInfo {
+        //TODO: create WebGL context here
         let sc = &self.swapchain;
         let format_desc = super::describe_texture_format(sc.format);
         let gl = &self.glow;
@@ -104,7 +106,11 @@ impl Context {
             gl.bind_renderbuffer(glow::RENDERBUFFER, None);
         }
         sc.extent.set(config.size);
-        sc.format
+
+        crate::SurfaceInfo {
+            format: sc.format,
+            alpha: crate::AlphaMode::PreMultiplied,
+        }
     }
 
     pub fn acquire_frame(&self) -> super::Frame {

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -1009,7 +1009,7 @@ pub enum ColorSpace {
     Srgb,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SurfaceConfig {
     pub size: Extent,
     pub usage: TextureUsage,
@@ -1021,6 +1021,22 @@ pub struct SurfaceConfig {
     /// For example, if the display expects sRGB space and we render
     /// in `ColorSpace::Linear` space, the returned format will be sRGB.
     pub color_space: ColorSpace,
+    pub transparent: bool,
+    pub allow_exclusive_full_screen: bool,
+}
+
+#[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
+pub enum AlphaMode {
+    #[default]
+    Ignored,
+    PreMultiplied,
+    PostMultiplied,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SurfaceInfo {
+    pub format: TextureFormat,
+    pub alpha: AlphaMode,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/blade-graphics/src/metal/surface.rs
+++ b/blade-graphics/src/metal/surface.rs
@@ -70,7 +70,7 @@ impl super::Surface {
         &mut self,
         device: &metal::DeviceRef,
         config: crate::SurfaceConfig,
-    ) -> crate::TextureFormat {
+    ) -> crate::SurfaceInfo {
         let format = match config.color_space {
             crate::ColorSpace::Linear => crate::TextureFormat::Bgra8UnormSrgb,
             crate::ColorSpace::Srgb => crate::TextureFormat::Bgra8Unorm,
@@ -80,7 +80,7 @@ impl super::Surface {
             crate::DisplaySync::Recent | crate::DisplaySync::Tear => false,
         };
 
-        self.render_layer.set_opaque(true);
+        self.render_layer.set_opaque(!config.transparent);
         self.render_layer.set_device(device);
         self.render_layer
             .set_pixel_format(super::map_texture_format(format));
@@ -95,12 +95,15 @@ impl super::Surface {
             let () = msg_send![self.render_layer, setDisplaySyncEnabled: vsync];
         }
 
-        format
+        crate::SurfaceInfo {
+            format,
+            alpha: crate::AlphaMode::PostMultiplied,
+        }
     }
 }
 
 impl super::Context {
-    pub fn resize(&self, config: crate::SurfaceConfig) -> crate::TextureFormat {
+    pub fn resize(&self, config: crate::SurfaceConfig) -> crate::SurfaceInfo {
         let mut surface = self.surface.as_ref().unwrap().lock().unwrap();
         surface.reconfigure(&*self.device.lock().unwrap(), config)
     }

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -33,6 +33,7 @@ struct Device {
     ray_tracing: Option<RayTracingDevice>,
     buffer_marker: Option<ash::amd::buffer_marker::Device>,
     shader_info: Option<ash::amd::shader_info::Device>,
+    full_screen_exclusive: Option<ash::ext::full_screen_exclusive::Device>,
     workarounds: Workarounds,
 }
 

--- a/blade-render/code/blur.wgsl
+++ b/blade-render/code/blur.wgsl
@@ -104,7 +104,7 @@ fn temporal_accum(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let cur_luminocity = dot(cur_illumination, LUMA);
     var mixed_ilm = vec4<f32>(cur_illumination, cur_luminocity * cur_luminocity);
     if (sum_weight > MIN_WEIGHT) {
-        let prev_ilm = sum_ilm / w4(sum_weight);
+        let prev_ilm = sum_ilm / vec4(vec3<f32>(sum_weight), max(0.001, sum_weight*sum_weight));
         mixed_ilm = mix(mixed_ilm, prev_ilm, sum_weight * (1.0 - params.temporal_weight));
     }
     textureStore(output, global_id.xy, mixed_ilm);

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -142,13 +142,13 @@ impl DebugRender {
         shader_draw: &blade_graphics::Shader,
         shader_blit: &blade_graphics::Shader,
         capacity: u32,
-        surface_format: blade_graphics::TextureFormat,
+        surface_info: blade_graphics::SurfaceInfo,
     ) -> Self {
         let line_size = shader_draw.get_struct_size("DebugLine");
         let buffer_size = shader_draw.get_struct_size("DebugBuffer");
         let this = Self {
             capacity,
-            surface_format,
+            surface_format: surface_info.format,
             buffer: gpu.create_buffer(blade_graphics::BufferDesc {
                 name: "debug",
                 size: (buffer_size + capacity.saturating_sub(1) * line_size) as u64,
@@ -170,8 +170,8 @@ impl DebugRender {
                 memory: blade_graphics::Memory::Shared,
             }),
             cpu_lines_offset: Cell::new(0),
-            draw_pipeline: create_draw_pipeline(shader_draw, surface_format, gpu),
-            blit_pipeline: create_blit_pipeline(shader_blit, surface_format, gpu),
+            draw_pipeline: create_draw_pipeline(shader_draw, surface_info.format, gpu),
+            blit_pipeline: create_blit_pipeline(shader_blit, surface_info.format, gpu),
             line_size,
             buffer_size,
         };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,10 @@ Changelog for Blade
 ## blade-graphics-0.5, blade-macros-0.3, blade-egui-0.4 (TBD)
 
 - vertex buffers support
-- configuration for disabling exclusive fullscreen
+- surface configuration:
+  - transparency support
+  - option to disable exclusive fullscreen
+  - VK: using linear sRGB color space if available
 - window API switched to raw-window-handle-0.6
 - GLES: support for storage buffer and compute
 - GLES: scissor rects, able to run "particle" example

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -74,7 +74,7 @@ impl Example {
             .unwrap()
         };
 
-        let surface_format = context.resize(gpu::SurfaceConfig {
+        let surface_info = context.resize(gpu::SurfaceConfig {
             size: gpu::Extent {
                 width: window_size.width,
                 height: window_size.height,
@@ -82,7 +82,7 @@ impl Example {
             },
             usage: gpu::TextureUsage::TARGET,
             display_sync: gpu::DisplaySync::Recent,
-            color_space: gpu::ColorSpace::Linear,
+            ..Default::default()
         });
 
         let global_layout = <Params as gpu::ShaderData>::layout();
@@ -110,7 +110,7 @@ impl Example {
             depth_stencil: None,
             fragment: shader.at("fs_main"),
             color_targets: &[gpu::ColorTargetState {
-                format: surface_format,
+                format: surface_info.format,
                 blend: Some(gpu::BlendState::ALPHA_BLENDING),
                 write_mask: gpu::ColorWrites::default(),
             }],

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -27,7 +27,7 @@ impl Example {
             .unwrap()
         };
 
-        let surface_format = context.resize(gpu::SurfaceConfig {
+        let surface_info = context.resize(gpu::SurfaceConfig {
             size: gpu::Extent {
                 width: window_size.width,
                 height: window_size.height,
@@ -35,15 +35,15 @@ impl Example {
             },
             usage: gpu::TextureUsage::TARGET,
             display_sync: gpu::DisplaySync::Block,
-            color_space: gpu::ColorSpace::Linear,
+            ..Default::default()
         });
-        let gui_painter = blade_egui::GuiPainter::new(surface_format, &context);
+        let gui_painter = blade_egui::GuiPainter::new(surface_info, &context);
         let particle_system = particle::System::new(
             &context,
             particle::SystemDesc {
                 name: "particle system",
                 capacity: 100_000,
-                draw_format: surface_format,
+                draw_format: surface_info.format,
             },
         );
 

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -85,11 +85,11 @@ impl Example {
             subresources: &gpu::TextureSubresources::default(),
         });
 
-        let surface_format = context.resize(gpu::SurfaceConfig {
+        let surface_info = context.resize(gpu::SurfaceConfig {
             size: screen_size,
             usage: gpu::TextureUsage::TARGET,
-            display_sync: gpu::DisplaySync::Block,
-            color_space: gpu::ColorSpace::Linear,
+            transparent: true,
+            ..Default::default()
         });
 
         let source = std::fs::read_to_string("examples/ray-query/shader.wgsl").unwrap();
@@ -111,7 +111,7 @@ impl Example {
             vertex: shader.at("draw_vs"),
             vertex_fetches: &[],
             fragment: shader.at("draw_fs"),
-            color_targets: &[surface_format.into()],
+            color_targets: &[surface_info.format.into()],
             depth_stencil: None,
         });
 
@@ -327,6 +327,7 @@ fn main() {
     let event_loop = winit::event_loop::EventLoop::new().unwrap();
     let window = winit::window::WindowBuilder::new()
         .with_title("blade-ray-query")
+        .with_transparent(true)
         .build(&event_loop)
         .unwrap();
 


### PR DESCRIPTION
Extends `SurfaceConfig` with a few extra fields, adds Default derive, and switches the `resize()` result type to the new `SurfaceInfo` struct.

Closes #112 
Closes #103

![transparency](https://github.com/kvark/blade/assets/107301/54793bbb-1d6c-4239-a25f-ffb6c5d0be44)
