### PR TITLE
vk: grow descriptor pools progressively instead of pre-allocating

### DIFF
--- a/blade-graphics/src/vulkan/descriptor.rs
+++ b/blade-graphics/src/vulkan/descriptor.rs
@@ -1,0 +1,111 @@
+use ash::vk;
+
+//TODO: replace by an abstraction in `gpu-descriptor`
+// https://github.com/zakarumych/gpu-descriptor/issues/42
+const COUNT_BASE: u32 = 16;
+
+#[derive(Debug)]
+pub struct DescriptorPool {
+    sub_pools: Vec<vk::DescriptorPool>,
+}
+
+impl super::Device {
+    fn create_descriptor_sub_pool(&self, max_sets: u32) -> vk::DescriptorPool {
+        log::info!("Creating a descriptor pool for at most {} sets", max_sets);
+        let mut descriptor_sizes = vec![
+            vk::DescriptorPoolSize {
+                ty: vk::DescriptorType::INLINE_UNIFORM_BLOCK_EXT,
+                descriptor_count: max_sets * crate::limits::PLAIN_DATA_SIZE,
+            },
+            vk::DescriptorPoolSize {
+                ty: vk::DescriptorType::STORAGE_BUFFER,
+                descriptor_count: max_sets,
+            },
+            vk::DescriptorPoolSize {
+                ty: vk::DescriptorType::SAMPLED_IMAGE,
+                descriptor_count: 2 * max_sets,
+            },
+            vk::DescriptorPoolSize {
+                ty: vk::DescriptorType::SAMPLER,
+                descriptor_count: max_sets,
+            },
+            vk::DescriptorPoolSize {
+                ty: vk::DescriptorType::STORAGE_IMAGE,
+                descriptor_count: max_sets,
+            },
+        ];
+        if self.ray_tracing.is_some() {
+            descriptor_sizes.push(vk::DescriptorPoolSize {
+                ty: vk::DescriptorType::ACCELERATION_STRUCTURE_KHR,
+                descriptor_count: max_sets,
+            });
+        }
+
+        let mut inline_uniform_block_info = vk::DescriptorPoolInlineUniformBlockCreateInfoEXT {
+            max_inline_uniform_block_bindings: max_sets,
+            ..Default::default()
+        };
+        let descriptor_pool_info = vk::DescriptorPoolCreateInfo::default()
+            .max_sets(max_sets)
+            .pool_sizes(&descriptor_sizes)
+            .push_next(&mut inline_uniform_block_info);
+        unsafe {
+            self.core
+                .create_descriptor_pool(&descriptor_pool_info, None)
+                .unwrap()
+        }
+    }
+
+    pub(super) fn create_descriptor_pool(&self) -> DescriptorPool {
+        let vk_pool = self.create_descriptor_sub_pool(COUNT_BASE);
+        DescriptorPool {
+            sub_pools: vec![vk_pool],
+        }
+    }
+
+    pub(super) fn destroy_descriptor_pool(&self, pool: &mut DescriptorPool) {
+        for sub_pool in pool.sub_pools.drain(..) {
+            unsafe { self.core.destroy_descriptor_pool(sub_pool, None) };
+        }
+    }
+
+    pub(super) fn allocate_descriptor_set(
+        &self,
+        pool: &mut DescriptorPool,
+        layout: &super::DescriptorSetLayout,
+    ) -> vk::DescriptorSet {
+        let descriptor_set_layouts = [layout.raw];
+        let mut descriptor_set_info = vk::DescriptorSetAllocateInfo::default()
+            .descriptor_pool(pool.sub_pools[0])
+            .set_layouts(&descriptor_set_layouts);
+        let result = unsafe { self.core.allocate_descriptor_sets(&descriptor_set_info) };
+        match result {
+            Ok(vk_sets) => return vk_sets[0],
+            Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY) => {}
+            Err(other) => panic!("Unexpected descriptor allocation error: {:?}", other),
+        };
+
+        let next_max_sets = COUNT_BASE.pow(pool.sub_pools.len() as u32 + 1);
+        let vk_pool = self.create_descriptor_sub_pool(next_max_sets);
+        // Always insert in front to avoid expecting any overflows down the road
+        pool.sub_pools.insert(0, vk_pool);
+
+        descriptor_set_info.descriptor_pool = vk_pool;
+        let vk_sets = unsafe {
+            self.core
+                .allocate_descriptor_sets(&descriptor_set_info)
+                .unwrap()
+        };
+        vk_sets[0]
+    }
+
+    pub(super) fn reset_descriptor_pool(&self, pool: &mut DescriptorPool) {
+        for &vk_pool in pool.sub_pools.iter() {
+            unsafe {
+                self.core
+                    .reset_descriptor_pool(vk_pool, vk::DescriptorPoolResetFlags::empty())
+                    .unwrap();
+            }
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Blade
 - window API switched to raw-window-handle-0.6
 - GLES: support for storage buffer and compute
 - GLES: scissor rects, able to run "particle" example
+- fixed initial RAM consumption
 
 ## blade-graphics-0.4, blade-render-0.3, blade-0.2 (22 Mar 2024)
 


### PR DESCRIPTION
Related to https://github.com/zakarumych/gpu-descriptor/issues/42
Practically fixes https://github.com/zed-industries/zed/issues/10351