### PR TITLE
gles: implement blending and write masks

### DIFF
--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -810,6 +810,16 @@ impl EglContext {
             super::Capabilities::BUFFER_STORAGE,
             extensions.contains("GL_EXT_buffer_storage"),
         );
+        capabilities.set(
+            super::Capabilities::DRAW_BUFFERS_INDEXED,
+            if gl.version().is_embedded {
+                (gl.version().major, gl.version().minor) >= (3, 2)
+            } else {
+                (gl.version().major, gl.version().minor) >= (3, 0)
+            },
+            // glow uses unsuffixed functions like glEnablei instead of glEnableiEXT.
+            // Therefore, GL_EXT_draw_buffers_indexed is not sufficient.
+        );
 
         let limits = super::Limits {
             uniform_buffer_alignment: gl.get_parameter_i32(glow::UNIFORM_BUFFER_OFFSET_ALIGNMENT)

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -15,6 +15,7 @@ const DEBUG_ID: u32 = 0;
 bitflags::bitflags! {
     struct Capabilities: u32 {
         const BUFFER_STORAGE = 1 << 0;
+        const DRAW_BUFFERS_INDEXED = 1 << 1;
     }
 }
 
@@ -100,6 +101,7 @@ struct PipelineInner {
     program: glow::Program,
     group_mappings: Box<[ShaderDataMapping]>,
     vertex_attribute_infos: Box<[VertexAttributeInfo]>,
+    color_targets: Box<[(Option<crate::BlendState>, crate::ColorWrites)]>,
 }
 
 pub struct ComputePipeline {
@@ -253,6 +255,8 @@ enum Command {
     },
     InvalidateAttachment(u32),
     SetDrawColorBuffers(u8),
+    SetAllColorTargets(Option<crate::BlendState>, crate::ColorWrites),
+    SetSingleColorTarget(u32, Option<crate::BlendState>, crate::ColorWrites),
     ClearColor {
         draw_buffer: u32,
         color: crate::TextureColor,


### PR DESCRIPTION
Blending fixes the current mostly-transparent-window bug in zed-industries/zed#9581 (screenshot is attached there). Write masks weren't necessary, but easy to do.