### PR TITLE
Vulkan: Delete smaller descriptor pools.

### DIFF
--- a/blade-graphics/src/vulkan/descriptor.rs
+++ b/blade-graphics/src/vulkan/descriptor.rs
@@ -7,6 +7,7 @@ const COUNT_BASE: u32 = 16;
 #[derive(Debug)]
 pub struct DescriptorPool {
     sub_pools: Vec<vk::DescriptorPool>,
+    current_pool: usize,
 }
 
 impl super::Device {
@@ -60,6 +61,7 @@ impl super::Device {
         let vk_pool = self.create_descriptor_sub_pool(COUNT_BASE);
         DescriptorPool {
             sub_pools: vec![vk_pool],
+            current_pool: 0,
         }
     }
 
@@ -75,22 +77,31 @@ impl super::Device {
         layout: &super::DescriptorSetLayout,
     ) -> vk::DescriptorSet {
         let descriptor_set_layouts = [layout.raw];
-        let mut descriptor_set_info = vk::DescriptorSetAllocateInfo::default()
-            .descriptor_pool(pool.sub_pools[0])
-            .set_layouts(&descriptor_set_layouts);
-        let result = unsafe { self.core.allocate_descriptor_sets(&descriptor_set_info) };
-        match result {
-            Ok(vk_sets) => return vk_sets[0],
-            Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY) | Err(vk::Result::ERROR_FRAGMENTED_POOL) => {}
-            Err(other) => panic!("Unexpected descriptor allocation error: {:?}", other),
-        };
+
+        while pool.current_pool < pool.sub_pools.len() {
+            let descriptor_set_info = vk::DescriptorSetAllocateInfo::default()
+                .descriptor_pool(pool.sub_pools[pool.current_pool])
+                .set_layouts(&descriptor_set_layouts);
+            let result = unsafe { self.core.allocate_descriptor_sets(&descriptor_set_info) };
+            match result {
+                Ok(vk_sets) => return vk_sets[0],
+                Err(vk::Result::ERROR_OUT_OF_POOL_MEMORY)
+                | Err(vk::Result::ERROR_FRAGMENTED_POOL) => {
+                    pool.current_pool += 1;
+                }
+                Err(other) => panic!("Unexpected descriptor allocation error: {:?}", other),
+            };
+        }
 
         let next_max_sets = COUNT_BASE.pow(pool.sub_pools.len() as u32 + 1);
         let vk_pool = self.create_descriptor_sub_pool(next_max_sets);
-        // Always insert in front to avoid expecting any overflows down the road
-        pool.sub_pools.insert(0, vk_pool);
+        pool.sub_pools.push(vk_pool);
+        pool.current_pool = pool.sub_pools.len() - 1;
 
-        descriptor_set_info.descriptor_pool = vk_pool;
+        let descriptor_set_info = vk::DescriptorSetAllocateInfo::default()
+            .descriptor_pool(pool.sub_pools[pool.current_pool])
+            .set_layouts(&descriptor_set_layouts);
+
         let vk_sets = unsafe {
             self.core
                 .allocate_descriptor_sets(&descriptor_set_info)
@@ -107,5 +118,6 @@ impl super::Device {
                     .unwrap();
             }
         }
+        pool.current_pool = 0
     }
 }


### PR DESCRIPTION
This fixes a bug where the smaller descriptor sub pools are left unused.