### PR TITLE
Remove unwraps from init()

### DIFF
--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -316,7 +316,7 @@ impl Context {
             }
             other => {
                 log::error!("Unsupported RDH {:?}", other);
-                return Err(crate::NotSupportedError::NoSupportedPlatformFound);
+                return Err(crate::NotSupportedError::PlatformNotSupported);
             }
         };
 

--- a/blade-graphics/src/gles/web.rs
+++ b/blade-graphics/src/gles/web.rs
@@ -21,7 +21,7 @@ pub struct Context {
 
 impl Context {
     pub unsafe fn init(_desc: crate::ContextDesc) -> Result<Self, crate::NotSupportedError> {
-        Err(crate::NotSupportedError)
+        Err(crate::NotSupportedError::PlatformNotSupported)
     }
 
     pub unsafe fn init_windowed<
@@ -56,7 +56,7 @@ impl Context {
                     .and_then(|context| context.dyn_into::<web_sys::WebGl2RenderingContext>().ok())
                     .expect("Cannot convert into WebGL2 context")
             }
-            _ => return Err(crate::NotSupportedError),
+            _ => return Err(crate::NotSupportedError::PlatformNotSupported),
         };
 
         let glow = glow::Context::from_webgl2_context(webgl2.clone());

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -99,13 +99,13 @@ pub enum NotSupportedError {
     ))]
     VulkanError(ash::vk::Result),
 
-    #[cfg(any(gles, target_arch = "wasm32"))]
+    #[cfg(gles)]
     GLESLoadingError(egl::LoadError<libloading::Error>),
-    #[cfg(any(gles, target_arch = "wasm32"))]
+    #[cfg(gles)]
     GLESError(egl::Error),
 
     NoSupportedDeviceFound,
-    NoSupportedPlatformFound,
+    PlatformNotSupported,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -23,6 +23,7 @@
     clippy::pattern_type_mismatch,
 )]
 
+use ash::vk;
 pub use naga::{StorageAccess, VectorSize};
 pub type Transform = mint::RowMatrix3x4<f32>;
 
@@ -87,7 +88,26 @@ pub struct ContextDesc {
 }
 
 #[derive(Debug)]
-pub struct NotSupportedError;
+pub enum NotSupportedError {
+    VulkanLoadingError(ash::LoadingError),
+    VulkanError(vk::Result),
+    /// Vulkan API below 1.1
+    ApiMismatch,
+    NoSupportedDeviceFound,
+    ExtensionNotSupported,
+}
+
+impl From<vk::Result> for NotSupportedError {
+    fn from(result: vk::Result) -> Self {
+        Self::VulkanError(result)
+    }
+}
+
+impl From<ash::LoadingError> for NotSupportedError {
+    fn from(result: ash::LoadingError) -> Self {
+        Self::VulkanLoadingError(result)
+    }
+}
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Capabilities {

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -23,7 +23,6 @@
     clippy::pattern_type_mismatch,
 )]
 
-use ash::vk;
 pub use naga::{StorageAccess, VectorSize};
 pub type Transform = mint::RowMatrix3x4<f32>;
 
@@ -89,24 +88,24 @@ pub struct ContextDesc {
 
 #[derive(Debug)]
 pub enum NotSupportedError {
+    #[cfg(all(
+        not(gles),
+        any(vulkan, windows, target_os = "linux", target_os = "android")
+    ))]
     VulkanLoadingError(ash::LoadingError),
-    VulkanError(vk::Result),
-    /// Vulkan API below 1.1
-    ApiMismatch,
+    #[cfg(all(
+        not(gles),
+        any(vulkan, windows, target_os = "linux", target_os = "android")
+    ))]
+    VulkanError(ash::vk::Result),
+
+    #[cfg(any(gles, target_arch = "wasm32"))]
+    GLESLoadingError(egl::LoadError<libloading::Error>),
+    #[cfg(any(gles, target_arch = "wasm32"))]
+    GLESError(egl::Error),
+
     NoSupportedDeviceFound,
-    ExtensionNotSupported,
-}
-
-impl From<vk::Result> for NotSupportedError {
-    fn from(result: vk::Result) -> Self {
-        Self::VulkanError(result)
-    }
-}
-
-impl From<ash::LoadingError> for NotSupportedError {
-    fn from(result: ash::LoadingError) -> Self {
-        Self::VulkanLoadingError(result)
-    }
+    NoSupportedPlatformFound,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -443,7 +443,7 @@ impl Context {
             raw_window_handle::RawWindowHandle::AppKit(handle) => {
                 Surface::from_view(handle.ns_view.as_ptr() as *mut _)
             }
-            _ => return Err(crate::NotSupportedError::NoSupportedPlatformFound),
+            _ => return Err(crate::NotSupportedError::PlatformNotSupported),
         };
 
         context.surface = Some(Mutex::new(surface));

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -397,7 +397,8 @@ impl Context {
             std::env::set_var("MTL_HUD_ENABLED", "1");
         }
 
-        let device = metal::Device::system_default().ok_or(super::NotSupportedError)?;
+        let device = metal::Device::system_default()
+            .ok_or(super::NotSupportedError::NoSupportedDeviceFound)?;
         let queue = device.new_command_queue();
 
         let capture = if desc.capture {
@@ -442,7 +443,7 @@ impl Context {
             raw_window_handle::RawWindowHandle::AppKit(handle) => {
                 Surface::from_view(handle.ns_view.as_ptr() as *mut _)
             }
-            _ => return Err(crate::NotSupportedError),
+            _ => return Err(crate::NotSupportedError::NoSupportedPlatformFound),
         };
 
         context.surface = Some(Mutex::new(surface));


### PR DESCRIPTION
This will allow us to present a sensible error message to users when we cannot
open a window.

Co-Authored-By: Mikayla <mikayla@zed.dev>
