### PR TITLE
vk: add workaround for Intel HD/UHD memory leak (#117)

### DIFF
--- a/blade-graphics/src/vulkan/descriptor.rs
+++ b/blade-graphics/src/vulkan/descriptor.rs
@@ -45,18 +45,12 @@ impl super::Device {
             max_inline_uniform_block_bindings: max_sets,
             ..Default::default()
         };
-        let descriptor_pool_info = if self.workarounds.intel_fix_descriptor_pool_leak {
-            vk::DescriptorPoolCreateInfo::default()
-                .max_sets(max_sets)
-                .flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET)
-                .pool_sizes(&descriptor_sizes)
-                .push_next(&mut inline_uniform_block_info)
-        } else {
-            vk::DescriptorPoolCreateInfo::default()
-                .max_sets(max_sets)
-                .pool_sizes(&descriptor_sizes)
-                .push_next(&mut inline_uniform_block_info)
-        };
+
+        let descriptor_pool_info = vk::DescriptorPoolCreateInfo::default()
+            .max_sets(max_sets)
+            .flags(self.workarounds.extra_descriptor_pool_create_flags)
+            .pool_sizes(&descriptor_sizes)
+            .push_next(&mut inline_uniform_block_info);
 
         unsafe {
             self.core

--- a/blade-graphics/src/vulkan/descriptor.rs
+++ b/blade-graphics/src/vulkan/descriptor.rs
@@ -45,10 +45,19 @@ impl super::Device {
             max_inline_uniform_block_bindings: max_sets,
             ..Default::default()
         };
-        let descriptor_pool_info = vk::DescriptorPoolCreateInfo::default()
-            .max_sets(max_sets)
-            .pool_sizes(&descriptor_sizes)
-            .push_next(&mut inline_uniform_block_info);
+        let descriptor_pool_info = if self.workarounds.intel_fix_descriptor_pool_leak {
+            vk::DescriptorPoolCreateInfo::default()
+                .max_sets(max_sets)
+                .flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET)
+                .pool_sizes(&descriptor_sizes)
+                .push_next(&mut inline_uniform_block_info)
+        } else {
+            vk::DescriptorPoolCreateInfo::default()
+                .max_sets(max_sets)
+                .pool_sizes(&descriptor_sizes)
+                .push_next(&mut inline_uniform_block_info)
+        };
+
         unsafe {
             self.core
                 .create_descriptor_pool(&descriptor_pool_info, None)

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -108,7 +108,7 @@ unsafe fn inspect_adapter(
     //Note: this is somewhat broad across X11/Wayland and different drivers.
     // It could be narrower, but at the end of the day if the user forced Prime
     // for GLX it should be safe to assume they want it for Vulkan as well.
-    let intel_unable_to_present = is_nvidia_prime_forced();
+    let intel_unable_to_present = is_nvidia_prime_forced() && properties2_khr.properties.vendor_id == db::intel::VENDOR;
 
     let queue_family_index = 0; //TODO
     if let Some(surface) = surface {
@@ -117,7 +117,7 @@ unsafe fn inspect_adapter(
             log::warn!("Rejected for not presenting to the window surface");
             return None;
         }
-        if intel_unable_to_present && properties2_khr.properties.vendor_id == db::intel::VENDOR {
+        if intel_unable_to_present {
             log::warn!("Rejecting Intel for not presenting when Nvidia is present (on Linux)");
             return None;
         }

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -23,6 +23,7 @@ struct RayTracingDevice {
 struct Workarounds {
     extra_sync_src_access: vk::AccessFlags,
     extra_sync_dst_access: vk::AccessFlags,
+    intel_fix_descriptor_pool_leak: bool,
 }
 
 #[derive(Clone)]

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -23,7 +23,7 @@ struct RayTracingDevice {
 struct Workarounds {
     extra_sync_src_access: vk::AccessFlags,
     extra_sync_dst_access: vk::AccessFlags,
-    intel_fix_descriptor_pool_leak: bool,
+    extra_descriptor_pool_create_flags: vk::DescriptorPoolCreateFlags,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This will detect an Intel graphics card and apply the fix for leaky descriptor pools.
