### PR TITLE
Make ResourceDevice actually generic over the backend

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -71,13 +71,15 @@ impl GuiTexture {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
         });
-        let view = context.create_texture_view(blade_graphics::TextureViewDesc {
-            name,
-            texture: allocation,
-            format,
-            dimension: blade_graphics::ViewDimension::D2,
-            subresources: &blade_graphics::TextureSubresources::default(),
-        });
+        let view = context.create_texture_view(
+            allocation,
+            blade_graphics::TextureViewDesc {
+                name,
+                format,
+                dimension: blade_graphics::ViewDimension::D2,
+                subresources: &blade_graphics::TextureSubresources::default(),
+            },
+        );
         Self { allocation, view }
     }
 

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -231,7 +231,10 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn create_texture_view(&self, desc: crate::TextureViewDesc) -> super::TextureView {
+    fn create_texture_view(
+        &self,
+        desc: crate::TextureViewDesc<super::Texture>,
+    ) -> super::TextureView {
         //TODO: actual reinterpretation
         super::TextureView {
             inner: desc.texture.inner,

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -233,12 +233,13 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn create_texture_view(
         &self,
-        desc: crate::TextureViewDesc<super::Texture>,
+        texture: super::Texture,
+        desc: crate::TextureViewDesc,
     ) -> super::TextureView {
         //TODO: actual reinterpretation
         super::TextureView {
-            inner: desc.texture.inner,
-            target_size: desc.texture.target_size,
+            inner: texture.inner,
+            target_size: texture.target_size,
             aspects: desc.format.aspects(),
         }
     }

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -388,9 +388,9 @@ pub struct TextureSubresources {
 }
 
 #[derive(Debug)]
-pub struct TextureViewDesc<'a> {
+pub struct TextureViewDesc<'a, T> {
     pub name: &'a str,
-    pub texture: Texture,
+    pub texture: T,
     pub format: TextureFormat,
     pub dimension: ViewDimension,
     pub subresources: &'a TextureSubresources,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -388,9 +388,8 @@ pub struct TextureSubresources {
 }
 
 #[derive(Debug)]
-pub struct TextureViewDesc<'a, T> {
+pub struct TextureViewDesc<'a> {
     pub name: &'a str,
-    pub texture: T,
     pub format: TextureFormat,
     pub dimension: ViewDimension,
     pub subresources: &'a TextureSubresources,

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -218,7 +218,10 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn create_texture_view(&self, desc: crate::TextureViewDesc) -> super::TextureView {
+    fn create_texture_view(
+        &self,
+        desc: crate::TextureViewDesc<super::Texture>,
+    ) -> super::TextureView {
         let texture = desc.texture.as_ref();
         let mtl_format = super::map_texture_format(desc.format);
         let mtl_type = map_view_dimension(desc.dimension);

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -220,9 +220,10 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn create_texture_view(
         &self,
-        desc: crate::TextureViewDesc<super::Texture>,
+        texture: super::Texture,
+        desc: crate::TextureViewDesc,
     ) -> super::TextureView {
-        let texture = desc.texture.as_ref();
+        let texture = texture.as_ref();
         let mtl_format = super::map_texture_format(desc.format);
         let mtl_type = map_view_dimension(desc.dimension);
         let mip_level_count = match desc.subresources.mip_level_count {

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -11,8 +11,11 @@ pub trait ResourceDevice {
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);
-    fn create_texture_view(&self, desc: super::TextureViewDesc<Self::Texture>)
-        -> Self::TextureView;
+    fn create_texture_view(
+        &self,
+        texture: Self::Texture,
+        desc: super::TextureViewDesc,
+    ) -> Self::TextureView;
     fn destroy_texture_view(&self, view: Self::TextureView);
     fn create_sampler(&self, desc: super::SamplerDesc) -> Self::Sampler;
     fn destroy_sampler(&self, sampler: Self::Sampler);

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -11,7 +11,8 @@ pub trait ResourceDevice {
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);
-    fn create_texture_view(&self, desc: super::TextureViewDesc) -> Self::TextureView;
+    fn create_texture_view(&self, desc: super::TextureViewDesc<Self::Texture>)
+        -> Self::TextureView;
     fn destroy_texture_view(&self, view: Self::TextureView);
     fn create_sampler(&self, desc: super::SamplerDesc) -> Self::Sampler;
     fn destroy_sampler(&self, sampler: Self::Sampler);

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -314,12 +314,13 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn create_texture_view(
         &self,
-        desc: crate::TextureViewDesc<super::Texture>,
+        texture: super::Texture,
+        desc: crate::TextureViewDesc,
     ) -> super::TextureView {
         let aspects = desc.format.aspects();
         let subresource_range = super::map_subresource_range(desc.subresources, aspects);
         let vk_info = vk::ImageViewCreateInfo {
-            image: desc.texture.raw,
+            image: texture.raw,
             view_type: map_view_dimension(desc.dimension),
             format: super::map_texture_format(desc.format),
             subresource_range: subresource_range,
@@ -334,8 +335,8 @@ impl crate::traits::ResourceDevice for super::Context {
         super::TextureView {
             raw,
             target_size: [
-                (desc.texture.target_size[0] >> desc.subresources.base_mip_level).max(1),
-                (desc.texture.target_size[1] >> desc.subresources.base_mip_level).max(1),
+                (texture.target_size[0] >> desc.subresources.base_mip_level).max(1),
+                (texture.target_size[1] >> desc.subresources.base_mip_level).max(1),
             ],
             aspects,
         }

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -312,7 +312,10 @@ impl crate::traits::ResourceDevice for super::Context {
         self.free_memory(texture.memory_handle);
     }
 
-    fn create_texture_view(&self, desc: crate::TextureViewDesc) -> super::TextureView {
+    fn create_texture_view(
+        &self,
+        desc: crate::TextureViewDesc<super::Texture>,
+    ) -> super::TextureView {
         let aspects = desc.format.aspects();
         let subresource_range = super::map_subresource_range(desc.subresources, aspects);
         let vk_info = vk::ImageViewCreateInfo {

--- a/blade-render/src/render/dummy.rs
+++ b/blade-render/src/render/dummy.rs
@@ -30,13 +30,15 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
         });
-        let white_view = gpu.create_texture_view(blade_graphics::TextureViewDesc {
-            name: "dummy/white",
-            texture: white_texture,
-            format: blade_graphics::TextureFormat::Rgba8Unorm,
-            dimension: blade_graphics::ViewDimension::D2,
-            subresources: &blade_graphics::TextureSubresources::default(),
-        });
+        let white_view = gpu.create_texture_view(
+            white_texture,
+            blade_graphics::TextureViewDesc {
+                name: "dummy/white",
+                format: blade_graphics::TextureFormat::Rgba8Unorm,
+                dimension: blade_graphics::ViewDimension::D2,
+                subresources: &blade_graphics::TextureSubresources::default(),
+            },
+        );
         let black_texture = gpu.create_texture(blade_graphics::TextureDesc {
             name: "dummy/black",
             format: blade_graphics::TextureFormat::Rgba8Unorm,
@@ -46,13 +48,15 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
         });
-        let black_view = gpu.create_texture_view(blade_graphics::TextureViewDesc {
-            name: "dummy/black",
-            texture: black_texture,
-            format: blade_graphics::TextureFormat::Rgba8Unorm,
-            dimension: blade_graphics::ViewDimension::D2,
-            subresources: &blade_graphics::TextureSubresources::default(),
-        });
+        let black_view = gpu.create_texture_view(
+            black_texture,
+            blade_graphics::TextureViewDesc {
+                name: "dummy/black",
+                format: blade_graphics::TextureFormat::Rgba8Unorm,
+                dimension: blade_graphics::ViewDimension::D2,
+                subresources: &blade_graphics::TextureSubresources::default(),
+            },
+        );
         let red_texture = gpu.create_texture(blade_graphics::TextureDesc {
             name: "dummy/red",
             format: blade_graphics::TextureFormat::Rgba8Unorm,
@@ -62,13 +66,15 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
         });
-        let red_view = gpu.create_texture_view(blade_graphics::TextureViewDesc {
-            name: "dummy/red",
-            texture: red_texture,
-            format: blade_graphics::TextureFormat::Rgba8Unorm,
-            dimension: blade_graphics::ViewDimension::D2,
-            subresources: &blade_graphics::TextureSubresources::default(),
-        });
+        let red_view = gpu.create_texture_view(
+            red_texture,
+            blade_graphics::TextureViewDesc {
+                name: "dummy/red",
+                format: blade_graphics::TextureFormat::Rgba8Unorm,
+                dimension: blade_graphics::ViewDimension::D2,
+                subresources: &blade_graphics::TextureSubresources::default(),
+            },
+        );
 
         command_encoder.init_texture(white_texture);
         command_encoder.init_texture(black_texture);

--- a/blade-render/src/render/env_map.rs
+++ b/blade-render/src/render/env_map.rs
@@ -112,25 +112,29 @@ impl EnvironmentMap {
             mip_level_count,
             usage: blade_graphics::TextureUsage::RESOURCE | blade_graphics::TextureUsage::STORAGE,
         });
-        self.weight_view = gpu.create_texture_view(blade_graphics::TextureViewDesc {
-            name: "env-weight",
-            texture: self.weight_texture,
-            format,
-            dimension: blade_graphics::ViewDimension::D2,
-            subresources: &Default::default(),
-        });
-        for base_mip_level in 0..mip_level_count {
-            let view = gpu.create_texture_view(blade_graphics::TextureViewDesc {
-                name: &format!("env-weight-mip{}", base_mip_level),
-                texture: self.weight_texture,
+        self.weight_view = gpu.create_texture_view(
+            self.weight_texture,
+            blade_graphics::TextureViewDesc {
+                name: "env-weight",
                 format,
                 dimension: blade_graphics::ViewDimension::D2,
-                subresources: &blade_graphics::TextureSubresources {
-                    base_mip_level,
-                    mip_level_count: NonZeroU32::new(1),
-                    ..Default::default()
+                subresources: &Default::default(),
+            },
+        );
+        for base_mip_level in 0..mip_level_count {
+            let view = gpu.create_texture_view(
+                self.weight_texture,
+                blade_graphics::TextureViewDesc {
+                    name: &format!("env-weight-mip{}", base_mip_level),
+                    format,
+                    dimension: blade_graphics::ViewDimension::D2,
+                    subresources: &blade_graphics::TextureSubresources {
+                        base_mip_level,
+                        mip_level_count: NonZeroU32::new(1),
+                        ..Default::default()
+                    },
                 },
-            });
+            );
             self.weight_mips.push(view);
         }
 

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -172,17 +172,19 @@ impl<const N: usize> RenderTarget<N> {
 
         let mut views = [blade_graphics::TextureView::default(); N];
         for (i, view) in views.iter_mut().enumerate() {
-            *view = gpu.create_texture_view(blade_graphics::TextureViewDesc {
-                name: &format!("{name}{i}"),
+            *view = gpu.create_texture_view(
                 texture,
-                format,
-                dimension: blade_graphics::ViewDimension::D2,
-                subresources: &blade_graphics::TextureSubresources {
-                    base_array_layer: i as u32,
-                    array_layer_count: NonZeroU32::new(1),
-                    ..Default::default()
+                blade_graphics::TextureViewDesc {
+                    name: &format!("{name}{i}"),
+                    format,
+                    dimension: blade_graphics::ViewDimension::D2,
+                    subresources: &blade_graphics::TextureSubresources {
+                        base_array_layer: i as u32,
+                        array_layer_count: NonZeroU32::new(1),
+                        ..Default::default()
+                    },
                 },
-            });
+            );
         }
 
         Self { texture, views }

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -397,15 +397,15 @@ impl blade_asset::Baker for Baker {
                 dimension: blade_graphics::TextureDimension::D2,
                 usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             });
-        let view = self
-            .gpu_context
-            .create_texture_view(blade_graphics::TextureViewDesc {
+        let view = self.gpu_context.create_texture_view(
+            texture,
+            blade_graphics::TextureViewDesc {
                 name,
-                texture,
                 format: image.format.0,
                 dimension: blade_graphics::ViewDimension::D2,
                 subresources: &Default::default(),
-            });
+            },
+        );
         self.pending_operations
             .lock()
             .unwrap()

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -131,13 +131,15 @@ impl Example {
             mip_level_count: 1,
             usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::COPY,
         });
-        let view = context.create_texture_view(gpu::TextureViewDesc {
-            name: "view",
+        let view = context.create_texture_view(
             texture,
-            format: gpu::TextureFormat::Rgba8Unorm,
-            dimension: gpu::ViewDimension::D2,
-            subresources: &Default::default(),
-        });
+            gpu::TextureViewDesc {
+                name: "view",
+                format: gpu::TextureFormat::Rgba8Unorm,
+                dimension: gpu::ViewDimension::D2,
+                subresources: &Default::default(),
+            },
+        );
 
         let upload_buffer = context.create_buffer(gpu::BufferDesc {
             name: "staging",

--- a/examples/init/main.rs
+++ b/examples/init/main.rs
@@ -30,13 +30,15 @@ impl EnvMapSampler {
             dimension: gpu::TextureDimension::D2,
             usage: gpu::TextureUsage::TARGET,
         });
-        let accum_view = context.create_texture_view(gpu::TextureViewDesc {
-            texture: accum_texture,
-            name: "env-test",
-            format,
-            dimension: gpu::ViewDimension::D2,
-            subresources: &gpu::TextureSubresources::default(),
-        });
+        let accum_view = context.create_texture_view(
+            accum_texture,
+            gpu::TextureViewDesc {
+                name: "env-test",
+                format,
+                dimension: gpu::ViewDimension::D2,
+                subresources: &gpu::TextureSubresources::default(),
+            },
+        );
 
         let layout = <EnvSampleData as gpu::ShaderData>::layout();
         let init_pipeline = context.create_render_pipeline(gpu::RenderPipelineDesc {

--- a/examples/mini/main.rs
+++ b/examples/mini/main.rs
@@ -62,18 +62,20 @@ fn main() {
     });
     let views = (0..mip_level_count)
         .map(|i| {
-            context.create_texture_view(gpu::TextureViewDesc {
-                name: &format!("mip-{}", i),
+            context.create_texture_view(
                 texture,
-                format: gpu::TextureFormat::Rgba8Unorm,
-                dimension: gpu::ViewDimension::D2,
-                subresources: &gpu::TextureSubresources {
-                    base_mip_level: i,
-                    mip_level_count: NonZeroU32::new(1),
-                    base_array_layer: 0,
-                    array_layer_count: None,
+                gpu::TextureViewDesc {
+                    name: &format!("mip-{}", i),
+                    format: gpu::TextureFormat::Rgba8Unorm,
+                    dimension: gpu::ViewDimension::D2,
+                    subresources: &gpu::TextureSubresources {
+                        base_mip_level: i,
+                        mip_level_count: NonZeroU32::new(1),
+                        base_array_layer: 0,
+                        array_layer_count: None,
+                    },
                 },
-            })
+            )
         })
         .collect::<Vec<_>>();
 

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -77,13 +77,15 @@ impl Example {
             mip_level_count: 1,
             usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::STORAGE,
         });
-        let target_view = context.create_texture_view(gpu::TextureViewDesc {
-            name: "main",
-            texture: target,
-            format: TARGET_FORMAT,
-            dimension: gpu::ViewDimension::D2,
-            subresources: &gpu::TextureSubresources::default(),
-        });
+        let target_view = context.create_texture_view(
+            target,
+            gpu::TextureViewDesc {
+                name: "main",
+                format: TARGET_FORMAT,
+                dimension: gpu::ViewDimension::D2,
+                subresources: &gpu::TextureSubresources::default(),
+            },
+        );
 
         let surface_info = context.resize(gpu::SurfaceConfig {
             size: screen_size,


### PR DESCRIPTION
The ResourceDevice trait is intended not to depend on the specific backend. This is shown by the type parameters that are used in the function signatures (such as `Self::Texture`) instead of `super::Texture`. However, `super::TextureViewDesc` contains `super::Texture`, so the trait indirectly depends on the concrete `super::Texture`, but not on all the other type parameters. Therefore, this seems like an oversight.

To fix this inconsistency, this PR makes `crate::TextureViewDesc` generic over the contained Texture, so the trait can use this struct with the correct `Self::Texture` type parameter. Advantage of this solution is that users don't need to change the code if they just pass the TextureViewDesc to `create_texture_view`, even if there were different implementations of `ResourceDevice`. Alternative solution would be to exclude the actual `Texture` from `TextureViewDesc` and just specify it as first parameter in `create_texture_view`. Another solution would be to add a `Self::TextureViewDesc` type parameter to `ResourceDevice`, but then, it would be difficult for users to create the `TextureViewDesc` in a generic way.

I would be happy if this inconsistency is fixed with any solution (the mentioned ones or another).