### PR TITLE
Add support for FreeBSD

### DIFF
--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -26,7 +26,7 @@ metal = "0.29"
 objc = "0.2.5"
 naga = { workspace = true, features = ["msl-out"] }
 
-[target.'cfg(any(vulkan, windows, target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(any(vulkan, windows, target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
 ash = "0.38"
 ash-window = "0.13"
 gpu-alloc = "0.6"

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -55,7 +55,13 @@ pub mod derive;
 #[cfg_attr(
     all(
         not(gles),
-        any(vulkan, windows, target_os = "linux", target_os = "android")
+        any(
+            vulkan,
+            windows,
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        )
     ),
     path = "vulkan/mod.rs"
 )]
@@ -90,12 +96,24 @@ pub struct ContextDesc {
 pub enum NotSupportedError {
     #[cfg(all(
         not(gles),
-        any(vulkan, windows, target_os = "linux", target_os = "android")
+        any(
+            vulkan,
+            windows,
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        )
     ))]
     VulkanLoadingError(ash::LoadingError),
     #[cfg(all(
         not(gles),
-        any(vulkan, windows, target_os = "linux", target_os = "android")
+        any(
+            vulkan,
+            windows,
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        )
     ))]
     VulkanError(ash::vk::Result),
 


### PR DESCRIPTION
Just a few cfg changes to allow Vulkan rendering on FreeBSD. Tested both GLES and Vulkan to be working on FreeBSD-current with drm-5.15.