### PR TITLE
vk: ignore non-coherent host-visible memory types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,11 @@ Changelog for Blade
     - option to disable exclusive fullscreen
     - VK: using linear sRGB color space if available
   - exposed initialization errors
+  - exposed device information
   - Vk:
     - fixed initial RAM consumption
     - worked around Intel descriptor memory allocation bug
+    - fixed coherent memory requirements
   - GLES:
     - support for storage buffer and compute
     - scissor rects, able to run "particle" example


### PR DESCRIPTION
Relevant to https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30499
Since Blade doesn't expose API to do explicit memory flush/invalidation, let's ignore the affected memory types.