### PR TITLE
Update khronos-egl to 6.0

### DIFF
--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -39,7 +39,7 @@ glow = "0.13"
 naga = { workspace = true, features = ["glsl-out"] }
 
 [target.'cfg(all(gles, not(target_arch = "wasm32")))'.dependencies]
-egl = { package = "khronos-egl", version = "5.0", features = ["dynamic"] }
+egl = { package = "khronos-egl", version = "6.0", features = ["dynamic"] }
 libloading = { version = "0.8" }
 
 [target.'cfg(all(target_arch = "wasm32"))'.dependencies]

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -440,13 +440,15 @@ impl Context {
                     .into_iter()
                     .map(|v| v as usize)
                     .collect::<Vec<_>>();
-                egl.create_platform_window_surface(
-                    inner.egl.display,
-                    inner.egl.config,
-                    native_window_ptr,
-                    &attributes_usize,
-                )
-                .unwrap()
+                unsafe {
+                    egl.create_platform_window_surface(
+                        inner.egl.display,
+                        inner.egl.config,
+                        native_window_ptr,
+                        &attributes_usize,
+                    )
+                    .unwrap()
+                }
             }
             _ => unsafe {
                 inner


### PR DESCRIPTION
This fixes a compilation error when trying to build Zed on Windows with the GLES backend
![image](https://github.com/user-attachments/assets/afc01ff9-c36c-4c6f-a594-9f3068048a12)
_(screenshot from the Zed Discord)_ 