### PR TITLE
Refactor device init, work around Rust-1.80 warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ blade-macros = { version = "0.2", path = "blade-macros" }
 bytemuck = { workspace = true }
 choir = { workspace = true }
 egui = { workspace = true }
-transform-gizmo-egui = { git = "https://github.com/urholaukkarinen/transform-gizmo", rev = "5be085444468ff7059abcd4e4872ab4510f65a06"}
+transform-gizmo-egui = { git = "https://github.com/urholaukkarinen/transform-gizmo", rev = "5be085444468ff7059abcd4e4872ab4510f65a06" }
 egui_plot = "0.28"
 env_logger = "0.11"
 glam = { workspace = true }
@@ -107,4 +107,14 @@ opt-level = 3
 
 [package.metadata.cargo_check_external_types]
 #TODO: reconsider `egui`/`epaint` and `winit` here
-allowed_external_types = ["egui::*", "epaint::*", "mint::*", "profiling::*", "serde::*", "winit::*"]
+allowed_external_types = [
+    "egui::*",
+    "epaint::*",
+    "mint::*",
+    "profiling::*",
+    "serde::*",
+    "winit::*",
+]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(gles)'] }

--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -3,7 +3,8 @@
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
-    unused_qualifications,
+    //TODO: re-enable. Currently doesn't like "mem::size_of" on newer Rust
+    //unused_qualifications,
     // We don't match on a reference, unless required.
     clippy::pattern_type_mismatch,
 )]

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -18,7 +18,8 @@ const SHADER_SOURCE: &'static str = include_str!("../shader.wgsl");
 use blade_util::{BufferBelt, BufferBeltDescriptor};
 use std::{
     collections::hash_map::{Entry, HashMap},
-    mem, ptr,
+    mem::size_of,
+    ptr,
 };
 
 #[repr(C)]
@@ -202,7 +203,7 @@ impl GuiPainter {
                 egui::ImageData::Font(ref a) => {
                     let color_iter = a.srgba_pixels(None);
                     let stage = self.belt.alloc(
-                        (color_iter.len() * mem::size_of::<egui::Color32>()) as u64,
+                        (color_iter.len() * size_of::<egui::Color32>()) as u64,
                         context,
                     );
                     let mut ptr = stage.data() as *mut egui::Color32;

--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -44,8 +44,19 @@ libloading = { version = "0.8" }
 
 [target.'cfg(all(target_arch = "wasm32"))'.dependencies]
 wasm-bindgen = "0.2.83"
-web-sys = { workspace = true, features = ["HtmlCanvasElement", "WebGl2RenderingContext"] }
+web-sys = { workspace = true, features = [
+    "HtmlCanvasElement",
+    "WebGl2RenderingContext",
+] }
 js-sys = "0.3.60"
 
 [package.metadata.cargo_check_external_types]
-allowed_external_types = ["bitflags::*", "mint::*", "naga::*", "raw_window_handle::*"]
+allowed_external_types = [
+    "bitflags::*",
+    "mint::*",
+    "naga::*",
+    "raw_window_handle::*",
+]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(gles)'] }

--- a/blade-graphics/README.md
+++ b/blade-graphics/README.md
@@ -22,6 +22,22 @@ The backend is selected automatically based on the host platform:
 | compute | :white_check_mark: | :white_check_mark: | |
 | ray tracing | :white_check_mark: | | |
 
+### Vulkan
+
+Required instance extensions:
+- VK_EXT_debug_utils
+- VK_KHR_get_physical_device_properties2
+- VK_KHR_get_surface_capabilities2
+
+Required device extensions:
+- VK_EXT_inline_uniform_block
+- VK_KHR_descriptor_update_template
+- VK_KHR_timeline_semaphore
+- VK_KHR_dynamic_rendering
+
+Conceptually, Blade requires the baseline Vulkan hardware with a relatively fresh driver.
+All of these required extensions are supported in software by the driver on any underlying architecture.
+
 ### OpenGL ES
 
 GLES is also supported at a basic level. It's enabled for `wasm32-unknown-unknown` target, and can also be force-enabled on native:

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -18,7 +18,8 @@
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
-    unused_qualifications,
+    //TODO: re-enable. Currently doesn't like "mem::size_of" on newer Rust
+    //unused_qualifications,
     // We don't match on a reference, unless required.
     clippy::pattern_type_mismatch,
 )]

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -11,6 +11,7 @@ struct Instance {
     core: ash::Instance,
     _debug_utils: ash::ext::debug_utils::Instance,
     get_physical_device_properties2: khr::get_physical_device_properties2::Instance,
+    get_surface_capabilities2: khr::get_surface_capabilities2::Instance,
     surface: Option<khr::surface::Instance>,
 }
 

--- a/blade-helpers/Cargo.toml
+++ b/blade-helpers/Cargo.toml
@@ -22,3 +22,6 @@ winit = { workspace = true }
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["blade_render::*", "epaint::*", "mint::*", "winit::*"]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(gles)'] }

--- a/blade-render/Cargo.toml
+++ b/blade-render/Cargo.toml
@@ -11,7 +11,19 @@ repository = "https://github.com/kvark/blade"
 
 [features]
 default = ["asset"]
-asset = ["gltf" , "base64", "exr", "mikktspace", "slab", "texpresso", "zune-core", "zune-jpeg", "zune-png", "zune-hdr", "zune-imageprocs"]
+asset = [
+    "gltf",
+    "base64",
+    "exr",
+    "mikktspace",
+    "slab",
+    "texpresso",
+    "zune-core",
+    "zune-jpeg",
+    "zune-png",
+    "zune-hdr",
+    "zune-imageprocs",
+]
 
 [dependencies]
 base64 = { workspace = true, optional = true }
@@ -38,4 +50,16 @@ zune-hdr = { version = "0.4", optional = true }
 zune-imageprocs = { version = "0.4", optional = true }
 
 [package.metadata.cargo_check_external_types]
-allowed_external_types = ["bitflags::*", "blade_asset::*", "blade_graphics::*", "bytemuck::*", "choir::*", "epaint::*", "mint::*", "strum::*"]
+allowed_external_types = [
+    "bitflags::*",
+    "blade_asset::*",
+    "blade_graphics::*",
+    "bytemuck::*",
+    "choir::*",
+    "epaint::*",
+    "mint::*",
+    "strum::*",
+]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(gles)'] }

--- a/blade-render/src/lib.rs
+++ b/blade-render/src/lib.rs
@@ -4,7 +4,8 @@
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
-    unused_qualifications,
+    //TODO: re-enable. Currently doesn't like "mem::size_of" on newer Rust
+    //unused_qualifications,
     // We don't match on a reference, unless required.
     clippy::pattern_type_mismatch,
 )]


### PR DESCRIPTION
Addresses the validation error, also slightly faster since we aren't getting properties twice.
![init-error](https://github.com/user-attachments/assets/c26a84af-273d-46ad-82ac-55b86d142cb3)
