### PR TITLE
Return errors more often

### DIFF
--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -427,7 +427,7 @@ impl crate::traits::CommandDevice for Context {
 
     fn destroy_command_encoder(&self, _command_encoder: &mut CommandEncoder) {}
 
-    fn submit(&self, encoder: &mut CommandEncoder) -> SyncPoint {
+    fn submit(&self, encoder: &mut CommandEncoder) -> Result<SyncPoint, crate::GpuError> {
         use glow::HasContext as _;
 
         let fence = {
@@ -464,13 +464,13 @@ impl crate::traits::CommandDevice for Context {
                 if push_group {
                     gl.pop_debug_group();
                 }
-                gl.fence_sync(glow::SYNC_GPU_COMMANDS_COMPLETE, 0).unwrap()
+                gl.fence_sync(glow::SYNC_GPU_COMMANDS_COMPLETE, 0)?
             }
         };
         if encoder.has_present {
             self.present();
         }
-        SyncPoint { fence }
+        Ok(SyncPoint { fence })
     }
 
     fn wait_for(&self, sp: &SyncPoint, timeout_ms: u32) -> bool {

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -127,6 +127,11 @@ pub enum NotSupportedError {
     PlatformNotSupported,
 }
 
+#[derive(Debug)]
+pub enum GpuError {
+    VulkanError(ash::vk::Result),
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Capabilities {
     /// Which shader stages support ray queries

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -507,10 +507,10 @@ impl crate::traits::CommandDevice for Context {
 
     fn destroy_command_encoder(&self, _command_encoder: &mut CommandEncoder) {}
 
-    fn submit(&self, encoder: &mut CommandEncoder) -> SyncPoint {
+    fn submit(&self, encoder: &mut CommandEncoder) -> Result<SyncPoint, crate::GpuError> {
         let cmd_buf = encoder.raw.take().unwrap();
         cmd_buf.commit();
-        SyncPoint { cmd_buf }
+        Ok(SyncPoint { cmd_buf })
     }
 
     fn wait_for(&self, sp: &SyncPoint, timeout_ms: u32) -> bool {

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -32,7 +32,10 @@ pub trait CommandDevice {
 
     fn create_command_encoder(&self, desc: super::CommandEncoderDesc) -> Self::CommandEncoder;
     fn destroy_command_encoder(&self, encoder: &mut Self::CommandEncoder);
-    fn submit(&self, encoder: &mut Self::CommandEncoder) -> Self::SyncPoint;
+    fn submit(
+        &self,
+        encoder: &mut Self::CommandEncoder,
+    ) -> Result<Self::SyncPoint, crate::GpuError>;
     fn wait_for(&self, sp: &Self::SyncPoint, timeout_ms: u32) -> bool;
 }
 

--- a/blade-render/src/util/frame_pacer.rs
+++ b/blade-render/src/util/frame_pacer.rs
@@ -55,7 +55,7 @@ impl FramePacer {
     }
 
     pub fn end_frame(&mut self, context: &blade_graphics::Context) -> &blade_graphics::SyncPoint {
-        let sync_point = context.submit(&mut self.command_encoder);
+        let sync_point = context.submit(&mut self.command_encoder).unwrap();
         self.frame_index += 1;
         // Wait for the previous frame immediately - this ensures that we are
         // only processing one frame at a time, and yet not stalling.

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -203,7 +203,7 @@ impl Example {
         if let mut transfer = command_encoder.transfer() {
             transfer.copy_buffer_to_texture(upload_buffer.into(), 4, texture.into(), extent);
         }
-        let sync_point = context.submit(&mut command_encoder);
+        let sync_point = context.submit(&mut command_encoder).unwrap();
         context.wait_for(&sync_point, !0);
 
         context.destroy_buffer(upload_buffer);
@@ -273,7 +273,7 @@ impl Example {
     }
 
     fn render(&mut self) {
-        let frame = self.context.acquire_frame();
+        let frame = self.context.acquire_frame().unwrap();
 
         self.command_encoder.start();
         self.command_encoder.init_texture(frame.texture());
@@ -315,7 +315,7 @@ impl Example {
             }
         }
         self.command_encoder.present(frame);
-        let sync_point = self.context.submit(&mut self.command_encoder);
+        let sync_point = self.context.submit(&mut self.command_encoder).unwrap();
         if let Some(sp) = self.prev_sync_point.take() {
             self.context.wait_for(&sp, !0);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,7 +683,7 @@ impl Engine {
             }
         }
 
-        let frame = self.gpu_context.acquire_frame();
+        let frame = self.gpu_context.acquire_frame().unwrap();
         command_encoder.init_texture(frame.texture());
 
         if let mut pass = command_encoder.render(gpu::RenderTargetSet {


### PR DESCRIPTION
At Zed, by far the most common panics we experience across the userbase
are from Linux users who crash during a `draw` call in the Blade
renderer.

We'd like to be able to detect that something has gone wrong and show a
notification via dbus to help people understand the problem and debug.

This PR is a work in progress, as before I completely change the API I wanted
to check that this is the right direction.

Even with these changes I'd stil like to try and reduce the frequency that
users see these problems, but I'm not sure how to do that.
