### PR TITLE
Correctly drop Vulkan objects

### DIFF
--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -1015,3 +1015,17 @@ impl super::Context {
         }
     }
 }
+
+impl Drop for super::Context {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(surface) = &self.surface {
+                if let Some(surface_instance) = &self.instance.surface {
+                    surface_instance.destroy_surface(surface.lock().unwrap().raw, None);
+                }
+            }
+            self.device.core.destroy_device(None);
+            self.instance.core.destroy_instance(None);
+        }
+    }
+}


### PR DESCRIPTION
There are some Vulkan objects that are created when creating the context that do not implement drop semantics and require them to be explicitly destroyed. This PR correctly destroys these objects.

This should fix/help this issue observed in Zed https://github.com/zed-industries/zed/issues/13346, where memory leaks due to creating and destroying the context's by creating and destroying windows in Zed.

This needed explicit object destruction is documented here [create_instance](https://docs.rs/ash/latest/ash/struct.Entry.html#method.create_instance), [create_device](https://docs.rs/ash/latest/ash/struct.Instance.html#method.create_device), and [create_surface](https://docs.rs/ash-window/latest/ash_window/fn.create_surface.html).