### PR TITLE
Destroy queue before device

### DIFF
--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -1034,8 +1034,6 @@ impl Drop for super::Context {
                     surface_instance.destroy_surface(surface.raw, None);
                 }
             }
-            self.device.core.destroy_device(None);
-            self.instance.core.destroy_instance(None);
             if let Ok(queue) = self.queue.lock() {
                 self.device
                     .core
@@ -1044,6 +1042,8 @@ impl Drop for super::Context {
                     .core
                     .destroy_semaphore(queue.present_semaphore, None);
             }
+            self.device.core.destroy_device(None);
+            self.instance.core.destroy_instance(None);
         }
     }
 }


### PR DESCRIPTION
See: https://github.com/zed-industries/zed/issues/17005

Right now, the device is being destroyed before the queue. This causes crashes at least on Wayland (both in Zed and the examples in this repo).

There are still some Vulkan validation errors related to objects not being destroyed, but it's not crashing anymore at least 😅 