### PR TITLE
API for destroying pipelines

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -109,8 +109,15 @@ pub struct GuiPainter {
 impl GuiPainter {
     /// Destroy the contents of the painter.
     pub fn destroy(&mut self, context: &blade_graphics::Context) {
+        context.destroy_render_pipeline(&mut self.pipeline);
         self.belt.destroy(context);
         for (_, gui_texture) in self.textures.drain() {
+            gui_texture.delete(context);
+        }
+        for gui_texture in self.textures_dropped.drain(..) {
+            gui_texture.delete(context);
+        }
+        for (gui_texture, _) in self.textures_to_delete.drain(..) {
             gui_texture.delete(context);
         }
         context.destroy_sampler(self.sampler);

--- a/blade-graphics/src/metal/pipeline.rs
+++ b/blade-graphics/src/metal/pipeline.rs
@@ -314,11 +314,14 @@ impl super::Context {
             wg_size,
         }
     }
+}
 
-    pub fn create_compute_pipeline(
-        &self,
-        desc: crate::ComputePipelineDesc,
-    ) -> super::ComputePipeline {
+#[hidden_trait::expose]
+impl crate::traits::ShaderDevice for super::Context {
+    type ComputePipeline = super::ComputePipeline;
+    type RenderPipeline = super::RenderPipeline;
+
+    fn create_compute_pipeline(&self, desc: crate::ComputePipelineDesc) -> super::ComputePipeline {
         let mut layout = make_pipeline_layout(desc.data_layouts, 0);
 
         objc::rc::autoreleasepool(|| {
@@ -354,7 +357,11 @@ impl super::Context {
         })
     }
 
-    pub fn create_render_pipeline(&self, desc: crate::RenderPipelineDesc) -> super::RenderPipeline {
+    fn destroy_compute_pipeline(&self, _pipeline: &mut super::ComputePipeline) {
+        //TODO: is there a way to release?
+    }
+
+    fn create_render_pipeline(&self, desc: crate::RenderPipelineDesc) -> super::RenderPipeline {
         let mut layout = make_pipeline_layout(desc.data_layouts, desc.vertex_fetches.len() as u32);
 
         let triangle_fill_mode = match desc.primitive.wireframe {
@@ -518,5 +525,9 @@ impl super::Context {
                 depth_stencil,
             }
         })
+    }
+
+    fn destroy_render_pipeline(&self, _pipeline: &mut super::RenderPipeline) {
+        //TODO: is there a way to release?
     }
 }

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -1,4 +1,5 @@
 use std::{fmt::Debug, hash::Hash};
+
 pub trait ResourceDevice {
     type Buffer: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
     type Texture: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
@@ -24,6 +25,16 @@ pub trait ResourceDevice {
         desc: super::AccelerationStructureDesc,
     ) -> Self::AccelerationStructure;
     fn destroy_acceleration_structure(&self, acceleration_structure: Self::AccelerationStructure);
+}
+
+pub trait ShaderDevice {
+    type ComputePipeline: Send + Sync;
+    type RenderPipeline: Send + Sync;
+
+    fn create_compute_pipeline(&self, desc: super::ComputePipelineDesc) -> Self::ComputePipeline;
+    fn destroy_compute_pipeline(&self, pipeline: &mut Self::ComputePipeline);
+    fn create_render_pipeline(&self, desc: super::RenderPipelineDesc) -> Self::RenderPipeline;
+    fn destroy_render_pipeline(&self, pipeline: &mut Self::RenderPipeline);
 }
 
 pub trait CommandDevice {

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -209,6 +209,8 @@ impl DebugRender {
         gpu.destroy_buffer(self.variance_buffer);
         gpu.destroy_buffer(self.entry_buffer);
         gpu.destroy_buffer(self.cpu_lines_buffer);
+        gpu.destroy_render_pipeline(&mut self.draw_pipeline);
+        gpu.destroy_render_pipeline(&mut self.blit_pipeline);
     }
 
     pub(super) fn recreate_draw_pipeline(

--- a/blade-render/src/render/env_map.rs
+++ b/blade-render/src/render/env_map.rs
@@ -80,6 +80,7 @@ impl EnvironmentMap {
         for view in self.weight_mips.drain(..) {
             gpu.destroy_texture_view(view);
         }
+        gpu.destroy_compute_pipeline(&mut self.prepare_pipeline);
     }
 
     pub fn assign(

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -741,6 +741,12 @@ impl Renderer {
         // samplers
         gpu.destroy_sampler(self.samplers.nearest);
         gpu.destroy_sampler(self.samplers.linear);
+        // pipelines
+        gpu.destroy_compute_pipeline(&mut self.blur.temporal_accum_pipeline);
+        gpu.destroy_compute_pipeline(&mut self.blur.atrous_pipeline);
+        gpu.destroy_compute_pipeline(&mut self.fill_pipeline);
+        gpu.destroy_compute_pipeline(&mut self.main_pipeline);
+        gpu.destroy_render_pipeline(&mut self.post_proc_pipeline);
     }
 
     #[profiling::function]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog for Blade
 
+## blade-graphics-0.6 (TBD)
+
+- graphics:
+  - API for destruction of pipelines
+
 ## blade-graphics-0.5, blade-macros-0.3, blade-egui-0.4, blade-util-0.1 (27 Aug 2024)
 
 - crate: `blade-util` for helper utilities

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -327,9 +327,12 @@ impl Example {
             self.context.wait_for(&sp, !0);
         }
         self.context.destroy_buffer(self.vertex_buf);
+        self.context.destroy_texture_view(self.view);
         self.context.destroy_texture(self.texture);
+        self.context.destroy_sampler(self.sampler);
         self.context
             .destroy_command_encoder(&mut self.command_encoder);
+        self.context.destroy_render_pipeline(&mut self.pipeline);
     }
 }
 

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -250,12 +250,15 @@ impl Example {
         if let Some(sp) = self.prev_sync_point {
             self.context.wait_for(&sp, !0);
         }
-        self.context
-            .destroy_command_encoder(&mut self.command_encoder);
         self.context.destroy_texture_view(self.target_view);
         self.context.destroy_texture(self.target);
         self.context.destroy_acceleration_structure(self.blas);
         self.context.destroy_acceleration_structure(self.tlas);
+        self.context
+            .destroy_command_encoder(&mut self.command_encoder);
+        self.context.destroy_compute_pipeline(&mut self.rt_pipeline);
+        self.context
+            .destroy_render_pipeline(&mut self.draw_pipeline);
     }
 
     fn render(&mut self) {


### PR DESCRIPTION
Now that we are properly destroying vkDevice, it's annoying to see all those validation errors about other objects not destroyed beforehand.