### PR TITLE
[vk] Shader debug info

### DIFF
--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -556,6 +556,7 @@ pub struct AccelerationStructureSizes {
 pub struct Shader {
     module: naga::Module,
     info: naga::valid::ModuleInfo,
+    source: String,
 }
 
 #[derive(Clone, Copy)]

--- a/blade-graphics/src/shader.rs
+++ b/blade-graphics/src/shader.rs
@@ -35,7 +35,11 @@ impl super::Context {
                 "validation failed"
             })?;
 
-        Ok(super::Shader { module, info })
+        Ok(super::Shader {
+            module,
+            info,
+            source: desc.source.to_owned(),
+        })
     }
 
     pub fn create_shader(&self, desc: super::ShaderDesc) -> super::Shader {

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -695,7 +695,7 @@ impl super::Context {
         });
 
         let mut naga_flags = spv::WriterFlags::FORCE_POINT_SIZE;
-        if desc.validation {
+        if desc.validation || desc.capture {
             naga_flags |= spv::WriterFlags::DEBUG;
         }
 

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -695,9 +695,15 @@ impl super::Context {
         });
 
         let mut naga_flags = spv::WriterFlags::FORCE_POINT_SIZE;
-        if desc.validation || desc.capture {
+        let shader_debug_path = if desc.validation || desc.capture {
+            use std::{env, fs};
             naga_flags |= spv::WriterFlags::DEBUG;
-        }
+            let dir = env::temp_dir().join("blade");
+            let _ = fs::create_dir(&dir);
+            Some(dir)
+        } else {
+            None
+        };
 
         Ok(super::Context {
             memory: Mutex::new(memory_manager),
@@ -712,6 +718,7 @@ impl super::Context {
             surface,
             physical_device,
             naga_flags,
+            shader_debug_path,
             instance,
             _entry: entry,
         })

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -1,5 +1,5 @@
 use ash::{khr, vk};
-use std::{num::NonZeroU32, ptr, sync::Mutex};
+use std::{num::NonZeroU32, path::PathBuf, ptr, sync::Mutex};
 
 mod command;
 mod descriptor;
@@ -107,6 +107,7 @@ pub struct Context {
     surface: Option<Mutex<Surface>>,
     physical_device: vk::PhysicalDevice,
     naga_flags: naga::back::spv::WriterFlags,
+    shader_debug_path: Option<PathBuf>,
     instance: Instance,
     _entry: ash::Entry,
 }


### PR DESCRIPTION
Including debug info is a quality-of-life improvement during development.
Storing the preprocessed WGSL is a bonus, allows to associate the errors easier.