### PR TITLE
Experiment/restir pass loop

### DIFF
--- a/blade-render/code/debug-param.inc.wgsl
+++ b/blade-render/code/debug-param.inc.wgsl
@@ -4,8 +4,8 @@
 
 struct DebugParams {
     view_mode: u32,
+    pass_index: u32,
     draw_flags: u32,
     texture_flags: u32,
-    pad: u32,
     mouse_pos: vec2<u32>,
 };

--- a/blade-render/code/env-importance.inc.wgsl
+++ b/blade-render/code/env-importance.inc.wgsl
@@ -11,7 +11,7 @@ fn compute_texel_solid_angle(itc: vec2<i32>, dim: vec2<u32>) -> f32 {
     return meridian_solid_angle * meridian_part;
 }
 
-fn generate_environment_sample(rng: ptr<function, RandomState>, dim: vec2<u32>) -> EnvImportantSample {
+fn generate_environment_sample(rng: ptr<private, RandomState>, dim: vec2<u32>) -> EnvImportantSample {
     var es = EnvImportantSample();
     es.pdf = 1.0;
     var mip = i32(textureNumLevels(env_weights));

--- a/blade-render/code/random.inc.wgsl
+++ b/blade-render/code/random.inc.wgsl
@@ -28,7 +28,7 @@ fn rot32(x: u32, bits: u32) -> u32 {
 }
 
 // https://en.wikipedia.org/wiki/MurmurHash
-fn murmur3(rng: ptr<function, RandomState>) -> u32 {
+fn murmur3(rng: ptr<private, RandomState>) -> u32 {
     let c1 = 0xcc9e2d51u;
     let c2 = 0x1b873593u;
     let r1 = 15u;
@@ -56,11 +56,11 @@ fn murmur3(rng: ptr<function, RandomState>) -> u32 {
     return hash;
 }
 
-fn random_u32(rng: ptr<function, RandomState>) -> u32 {
+fn random_u32(rng: ptr<private, RandomState>) -> u32 {
     return murmur3(rng);
 }
 
-fn random_gen(rng: ptr<function, RandomState>) -> f32 {
+fn random_gen(rng: ptr<private, RandomState>) -> f32 {
     let v = murmur3(rng);
     let one = bitcast<u32>(1.0);
     let mask = (1u << 23u) - 1u;

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -53,10 +53,8 @@ pub enum DebugMode {
     HitConsistency = 4,
     Grouping = 5,
     Reprojection = 6,
-    TemporalMatch = 10,
-    TemporalMisCanonical = 11,
-    SpatialMatch = 12,
-    SpatialMisCanonical = 13,
+    PassMatch = 10,
+    PassMisCanonical = 11,
     Variance = 100,
 }
 
@@ -86,6 +84,7 @@ bitflags::bitflags! {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DebugConfig {
     pub view_mode: DebugMode,
+    pub pass_index: u32,
     pub draw_flags: DebugDrawFlags,
     pub texture_flags: DebugTextureFlags,
     pub mouse_pos: Option<[i32; 2]>,
@@ -355,9 +354,9 @@ struct CameraParams {
 #[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 struct DebugParams {
     view_mode: u32,
+    pass_index: u32,
     draw_flags: u32,
     texture_flags: u32,
-    unused: u32,
     mouse_pos: [i32; 2],
 }
 
@@ -972,9 +971,9 @@ impl Renderer {
     fn make_debug_params(&self, config: &DebugConfig) -> DebugParams {
         DebugParams {
             view_mode: config.view_mode as u32,
+            pass_index: config.pass_index,
             draw_flags: config.draw_flags.bits(),
             texture_flags: config.texture_flags.bits(),
-            unused: 0,
             mouse_pos: match config.mouse_pos {
                 Some(p) => [p[0], self.surface_size.height as i32 - p[1]],
                 None => [-1; 2],


### PR DESCRIPTION
Experiment branched off  #161
The idea is to re-organize main ReSTIR routing so that the shared code is actually re-used, instead of relying on the functions to be re-used properly.
Interestingly, it doesn't work at all on NVidia:
![Local3-passes](https://github.com/user-attachments/assets/0a9f021c-1bd6-4dcb-b1b7-972eb96fdc77)
