### PR TITLE
Pass names, scopes, and timings

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -265,7 +265,7 @@ impl GuiPainter {
             copies.push((src, dst, extent));
         }
 
-        if let mut transfer = command_encoder.transfer() {
+        if let mut transfer = command_encoder.transfer("update egui textures") {
             for (src, dst, extent) in copies {
                 transfer.copy_buffer_to_texture(src, 4 * extent.width, dst, extent);
             }

--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -23,7 +23,10 @@ raw-window-handle = "0.6"
 block = "0.1"
 core-graphics-types = "0.1"
 #TODO: switch to crates once https://github.com/gfx-rs/metal-rs/pull/335 is published
-metal = { git = "https://github.com/gfx-rs/metal-rs", rev = "9bbe74b1d3706e46ddf41bc8aad58ee74b0bf844" }
+#TODO: switch to upstream once these are merged:
+# - https://github.com/gfx-rs/metal-rs/pull/336
+# - https://github.com/gfx-rs/metal-rs/pull/337
+metal = { git = "https://github.com/kvark/metal-rs", branch = "blade" }
 objc = "0.2.5"
 naga = { workspace = true, features = ["msl-out"] }
 

--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -22,7 +22,8 @@ raw-window-handle = "0.6"
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 block = "0.1"
 core-graphics-types = "0.1"
-metal = "0.29"
+#TODO: switch to crates once https://github.com/gfx-rs/metal-rs/pull/335 is published
+metal = { git = "https://github.com/gfx-rs/metal-rs", rev = "9bbe74b1d3706e46ddf41bc8aad58ee74b0bf844" }
 objc = "0.2.5"
 naga = { workspace = true, features = ["msl-out"] }
 

--- a/blade-graphics/README.md
+++ b/blade-graphics/README.md
@@ -42,7 +42,7 @@ All of these required extensions are supported in software by the driver on any 
 
 GLES is also supported at a basic level. It's enabled for `wasm32-unknown-unknown` target, and can also be force-enabled on native:
 ```bash
-RUSTFLAGS="--cfg gles" CARGO_TARGET_DIR=./target-gl cargo test
+RUSTFLAGS="--cfg gles" CARGO_TARGET_DIR=./target-gl cargo run --example bunnymark
 ```
 
 This path can be activated on all platforms via Angle library.

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 const COLOR_ATTACHMENTS: &[u32] = &[
     glow::COLOR_ATTACHMENT0,
     glow::COLOR_ATTACHMENT1,
@@ -200,6 +202,10 @@ impl super::CommandEncoder {
             pipeline: Default::default(),
             limits: &self.limits,
         }
+    }
+
+    pub fn timings(&self) -> &[(String, Duration)] {
+        &[]
     }
 }
 

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -91,7 +91,7 @@ impl super::CommandEncoder {
         self.has_present = true;
     }
 
-    pub fn transfer(&mut self) -> super::PassEncoder<()> {
+    pub fn transfer(&mut self, _label: &str) -> super::PassEncoder<()> {
         super::PassEncoder {
             commands: &mut self.commands,
             plain_data: &mut self.plain_data,
@@ -102,11 +102,11 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn acceleration_structure(&mut self) -> super::PassEncoder<()> {
+    pub fn acceleration_structure(&mut self, _label: &str) -> super::PassEncoder<()> {
         unimplemented!()
     }
 
-    pub fn compute(&mut self) -> super::PassEncoder<super::ComputePipeline> {
+    pub fn compute(&mut self, _label: &str) -> super::PassEncoder<super::ComputePipeline> {
         super::PassEncoder {
             commands: &mut self.commands,
             plain_data: &mut self.plain_data,
@@ -119,6 +119,7 @@ impl super::CommandEncoder {
 
     pub fn render(
         &mut self,
+        _label: &str,
         targets: crate::RenderTargetSet,
     ) -> super::PassEncoder<super::RenderPipeline> {
         let mut target_size = [0u16; 2];

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -826,6 +826,11 @@ impl EglContext {
         );
 
         let toggles = super::Toggles {
+            scoping: desc.capture
+                && (gl.supports_debug() || {
+                    log::warn!("Scoping is not supported");
+                    false
+                }),
             timing: desc.timing
                 && (extensions.contains("GL_EXT_disjoint_timer_query") || {
                     log::warn!("Timing is not supported");

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -775,18 +775,22 @@ impl EglContext {
                 .get_proc_address(name)
                 .map_or(ptr::null(), |p| p as *const _)
         });
-        if desc.validation && gl.supports_debug() {
-            log::info!("Enabling GLES debug output");
-            gl.enable(glow::DEBUG_OUTPUT);
-            gl.debug_message_callback(gl_debug_message_callback);
-            for &(level, severity) in LOG_LEVEL_SEVERITY.iter() {
-                gl.debug_message_control(
-                    glow::DONT_CARE,
-                    glow::DONT_CARE,
-                    severity,
-                    &[],
-                    level <= log::max_level(),
-                );
+        if desc.validation {
+            if gl.supports_debug() {
+                log::info!("Enabling GLES debug output");
+                gl.enable(glow::DEBUG_OUTPUT);
+                gl.debug_message_callback(gl_debug_message_callback);
+                for &(level, severity) in LOG_LEVEL_SEVERITY.iter() {
+                    gl.debug_message_control(
+                        glow::DONT_CARE,
+                        glow::DONT_CARE,
+                        severity,
+                        &[],
+                        level <= log::max_level(),
+                    );
+                }
+            } else {
+                log::warn!("Can't enable validation");
             }
         }
 

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -72,9 +72,15 @@ mod shader;
 mod traits;
 pub mod util;
 pub mod limits {
+    /// Max number of passes inside a command encoder.
+    pub const PASS_COUNT: usize = 100;
+    /// Max plain data size for a pipeline.
     pub const PLAIN_DATA_SIZE: u32 = 256;
+    /// Max number of resources in a bind group.
     pub const RESOURCES_IN_GROUP: u32 = 8;
+    /// Min storage buffer alignment.
     pub const STORAGE_BUFFER_ALIGNMENT: u64 = 256;
+    /// Min acceleration structure scratch buffer alignment.
     pub const ACCELERATION_STRUCTURE_SCRATCH_ALIGNMENT: u64 = 256;
 }
 
@@ -87,6 +93,8 @@ pub struct ContextDesc {
     /// Enable validation of the GAPI, shaders,
     /// and insert crash markers into command buffers.
     pub validation: bool,
+    /// Enable GPU timing of all passes.
+    pub timing: bool,
     /// Enable capture support with GAPI tools.
     pub capture: bool,
     /// Enable GAPI overlay.

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -141,6 +141,9 @@ impl super::CommandEncoder {
     pub fn compute(&mut self, _label: &str) -> super::ComputeCommandEncoder {
         let raw = objc::rc::autoreleasepool(|| {
             let descriptor = metal::ComputePassDescriptor::new();
+            if self.private_info.supports_dispatch_type {
+                descriptor.set_dispatch_type(metal::MTLDispatchType::Concurrent);
+            }
             self.raw
                 .as_mut()
                 .unwrap()

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -106,12 +106,13 @@ impl super::CommandEncoder {
         self.raw.as_mut().unwrap().present_drawable(&frame.drawable);
     }
 
-    pub fn transfer(&mut self) -> super::TransferCommandEncoder {
+    pub fn transfer(&mut self, _label: &str) -> super::TransferCommandEncoder {
         let raw = objc::rc::autoreleasepool(|| {
+            let descriptor = metal::BlitPassDescriptor::new();
             self.raw
                 .as_mut()
                 .unwrap()
-                .new_blit_command_encoder()
+                .blit_command_encoder_with_descriptor(&descriptor)
                 .to_owned()
         });
         super::TransferCommandEncoder {
@@ -120,7 +121,10 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn acceleration_structure(&mut self) -> super::AccelerationStructureCommandEncoder {
+    pub fn acceleration_structure(
+        &mut self,
+        _label: &str,
+    ) -> super::AccelerationStructureCommandEncoder {
         let raw = objc::rc::autoreleasepool(|| {
             self.raw
                 .as_mut()
@@ -134,12 +138,13 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn compute(&mut self) -> super::ComputeCommandEncoder {
+    pub fn compute(&mut self, _label: &str) -> super::ComputeCommandEncoder {
         let raw = objc::rc::autoreleasepool(|| {
+            let descriptor = metal::ComputePassDescriptor::new();
             self.raw
                 .as_mut()
                 .unwrap()
-                .new_compute_command_encoder()
+                .compute_command_encoder_with_descriptor(&descriptor)
                 .to_owned()
         });
         super::ComputeCommandEncoder {
@@ -148,7 +153,11 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn render(&mut self, targets: crate::RenderTargetSet) -> super::RenderCommandEncoder {
+    pub fn render(
+        &mut self,
+        _label: &str,
+        targets: crate::RenderTargetSet,
+    ) -> super::RenderCommandEncoder {
         let raw = objc::rc::autoreleasepool(|| {
             let descriptor = metal::RenderPassDescriptor::new();
 

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, mem};
+use std::{marker::PhantomData, mem, time::Duration};
 
 impl<T: bytemuck::Pod> crate::ShaderBindable for T {
     fn bind_to(&self, ctx: &mut super::PipelineContext, index: u32) {
@@ -225,6 +225,10 @@ impl super::CommandEncoder {
             raw,
             phantom: PhantomData,
         }
+    }
+
+    pub fn timings(&self) -> &[(String, Duration)] {
+        &[]
     }
 }
 

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -39,8 +39,10 @@ impl Frame {
     }
 }
 
-struct DeviceInfo {
+#[derive(Debug, Clone)]
+struct PrivateInfo {
     language_version: metal::MTLLanguageVersion,
+    supports_dispatch_type: bool,
 }
 
 pub struct Context {
@@ -48,7 +50,7 @@ pub struct Context {
     queue: Arc<Mutex<metal::CommandQueue>>,
     surface: Option<Mutex<Surface>>,
     capture: Option<metal::CaptureManager>,
-    info: DeviceInfo,
+    info: PrivateInfo,
     device_information: crate::DeviceInformation,
 }
 
@@ -183,6 +185,7 @@ pub struct CommandEncoder {
     raw: Option<metal::CommandBuffer>,
     name: String,
     queue: Arc<Mutex<metal::CommandQueue>>,
+    private_info: PrivateInfo,
 }
 
 #[derive(Debug)]
@@ -427,9 +430,10 @@ impl Context {
             queue: Arc::new(Mutex::new(queue)),
             surface: None,
             capture,
-            info: DeviceInfo {
+            info: PrivateInfo {
                 //TODO: determine based on OS version
                 language_version: metal::MTLLanguageVersion::V2_4,
+                supports_dispatch_type: true,
             },
             device_information,
         })
@@ -503,6 +507,7 @@ impl crate::traits::CommandDevice for Context {
             raw: None,
             name: desc.name.to_string(),
             queue: Arc::clone(&self.queue),
+            private_info: self.info.clone(),
         }
     }
 

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -330,27 +330,30 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn transfer(&mut self) -> super::TransferCommandEncoder {
+    pub fn transfer(&mut self, label: &str) -> super::TransferCommandEncoder {
         self.barrier();
-        self.mark("pass/transfer");
+        self.mark(label);
         super::TransferCommandEncoder {
             raw: self.buffers[0].raw,
             device: &self.device,
         }
     }
 
-    pub fn acceleration_structure(&mut self) -> super::AccelerationStructureCommandEncoder {
+    pub fn acceleration_structure(
+        &mut self,
+        label: &str,
+    ) -> super::AccelerationStructureCommandEncoder {
         self.barrier();
-        self.mark("pass/acc-struct");
+        self.mark(label);
         super::AccelerationStructureCommandEncoder {
             raw: self.buffers[0].raw,
             device: &self.device,
         }
     }
 
-    pub fn compute(&mut self) -> super::ComputeCommandEncoder {
+    pub fn compute(&mut self, label: &str) -> super::ComputeCommandEncoder {
         self.barrier();
-        self.mark("pass/compute");
+        self.mark(label);
         super::ComputeCommandEncoder {
             cmd_buf: self.buffers.first_mut().unwrap(),
             device: &self.device,
@@ -358,9 +361,13 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn render(&mut self, targets: crate::RenderTargetSet) -> super::RenderCommandEncoder {
+    pub fn render(
+        &mut self,
+        label: &str,
+        targets: crate::RenderTargetSet,
+    ) -> super::RenderCommandEncoder {
         self.barrier();
-        self.mark("pass/render");
+        self.mark(label);
 
         let mut target_size = [0u16; 2];
         let mut color_attachments = Vec::with_capacity(targets.colors.len());

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -564,6 +564,9 @@ impl super::Context {
             },
             core: device_core,
             device_information: capabilities.device_information,
+            toggles: super::Toggles {
+                command_scopes: desc.capture,
+            },
             //TODO: detect GPU family
             workarounds: super::Workarounds {
                 extra_sync_src_access: vk::AccessFlags::TRANSFER_WRITE,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -20,6 +20,11 @@ struct RayTracingDevice {
     acceleration_structure: khr::acceleration_structure::Device,
 }
 
+#[derive(Clone, Default)]
+struct Toggles {
+    command_scopes: bool,
+}
+
 #[derive(Clone)]
 struct Workarounds {
     extra_sync_src_access: vk::AccessFlags,
@@ -38,6 +43,7 @@ struct Device {
     buffer_marker: Option<ash::amd::buffer_marker::Device>,
     shader_info: Option<ash::amd::shader_info::Device>,
     full_screen_exclusive: Option<ash::ext::full_screen_exclusive::Device>,
+    toggles: Toggles,
     workarounds: Workarounds,
 }
 
@@ -239,6 +245,7 @@ pub struct CommandEncoder {
     update_data: Vec<u8>,
     present: Option<Presentation>,
     crash_handler: Option<CrashHandler>,
+    temp_label: Vec<u8>,
 }
 pub struct TransferCommandEncoder<'a> {
     raw: vk::CommandBuffer,
@@ -367,6 +374,7 @@ impl crate::traits::CommandDevice for Context {
             update_data: Vec::new(),
             present: None,
             crash_handler,
+            temp_label: Vec::new(),
         }
     }
 

--- a/blade-render/src/model/mod.rs
+++ b/blade-render/src/model/mod.rs
@@ -381,7 +381,7 @@ impl Baker {
     ) {
         let mut pending_ops = self.pending_operations.lock().unwrap();
         if !pending_ops.transfers.is_empty() {
-            let mut pass = encoder.transfer();
+            let mut pass = encoder.transfer("init models");
             for transfer in pending_ops.transfers.drain(..) {
                 pass.copy_buffer_to_buffer(
                     transfer.stage.into(),
@@ -392,7 +392,7 @@ impl Baker {
             }
         }
         if !pending_ops.blas_constructs.is_empty() {
-            let mut pass = encoder.acceleration_structure();
+            let mut pass = encoder.acceleration_structure("BLAS");
             for construct in pending_ops.blas_constructs.drain(..) {
                 pass.build_bottom_level(construct.dst, &construct.meshes, construct.scratch.into());
                 temp_buffers.push(construct.scratch);

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -194,7 +194,7 @@ impl DebugRender {
             );
         }
 
-        let mut transfers = encoder.transfer();
+        let mut transfers = encoder.transfer("upload debug");
         transfers.copy_buffer_to_buffer(
             this.entry_buffer.at(0),
             this.buffer.at(0),

--- a/blade-render/src/render/dummy.rs
+++ b/blade-render/src/render/dummy.rs
@@ -79,7 +79,7 @@ impl DummyResources {
         command_encoder.init_texture(white_texture);
         command_encoder.init_texture(black_texture);
         command_encoder.init_texture(red_texture);
-        let mut transfers = command_encoder.transfer();
+        let mut transfers = command_encoder.transfer("init dummy");
         let staging_buf = gpu.create_buffer(blade_graphics::BufferDesc {
             name: "dummy/staging",
             size: 4 * 3,

--- a/blade-render/src/render/env_map.rs
+++ b/blade-render/src/render/env_map.rs
@@ -144,7 +144,7 @@ impl EnvironmentMap {
             let groups = self
                 .prepare_pipeline
                 .get_dispatch_for(weight_extent.at_mip_level(target_level));
-            let mut compute = encoder.compute();
+            let mut compute = encoder.compute("pre-process env map");
             let mut pass = compute.with(&self.prepare_pipeline);
             pass.bind(
                 0,

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -81,7 +81,7 @@ impl Baker {
             encoder.init_texture(init.dst);
         }
         if !pending_ops.transfers.is_empty() {
-            let mut pass = encoder.transfer();
+            let mut pass = encoder.transfer("init textures");
             for transfer in pending_ops.transfers.drain(..) {
                 let dst = blade_graphics::TexturePiece {
                     texture: transfer.dst,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for Blade
 
 - graphics:
   - API for destruction of pipelines
+  - every pass now takes a label
   - Metal:
     - support for workgroup memory
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog for Blade
 - graphics:
   - API for destruction of pipelines
   - every pass now takes a label
+  - automatic GPU pass markers
+  - ability to capture pass GPU timings
   - Metal:
     - support for workgroup memory
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for Blade
   - ability to capture pass GPU timings
   - Metal:
     - support for workgroup memory
+    - concurrent compute dispatches
 
 ## blade-graphics-0.5, blade-macros-0.3, blade-egui-0.4, blade-util-0.1 (27 Aug 2024)
 

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -61,7 +61,6 @@ struct Example {
 
 impl Example {
     fn new(window: &winit::window::Window) -> Self {
-        let window_size = window.inner_size();
         let context = unsafe {
             gpu::Context::init_windowed(
                 window,
@@ -75,6 +74,8 @@ impl Example {
             .unwrap()
         };
         println!("{:?}", context.device_information());
+        let window_size = window.inner_size();
+        log::info!("Initial size: {:?}", window_size);
 
         let surface_info = context.resize(gpu::SurfaceConfig {
             size: gpu::Extent {
@@ -274,6 +275,9 @@ impl Example {
     }
 
     fn render(&mut self) {
+        if self.window_size == Default::default() {
+            return;
+        }
         let frame = self.context.acquire_frame();
 
         self.command_encoder.start();
@@ -354,7 +358,7 @@ fn main() {
     {
         use winit::platform::web::WindowExtWebSys as _;
 
-        std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+        console_error_panic_hook::set_once();
         console_log::init().expect("could not initialize logger");
         // On wasm, append the canvas to the document body
         let canvas = window.canvas().unwrap();

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -200,7 +200,7 @@ impl Example {
         });
         command_encoder.start();
         command_encoder.init_texture(texture);
-        if let mut transfer = command_encoder.transfer() {
+        if let mut transfer = command_encoder.transfer("init texture") {
             transfer.copy_buffer_to_texture(upload_buffer.into(), 4, texture.into(), extent);
         }
         let sync_point = context.submit(&mut command_encoder);
@@ -278,14 +278,17 @@ impl Example {
         self.command_encoder.start();
         self.command_encoder.init_texture(frame.texture());
 
-        if let mut pass = self.command_encoder.render(gpu::RenderTargetSet {
-            colors: &[gpu::RenderTarget {
-                view: frame.texture_view(),
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
-                finish_op: gpu::FinishOp::Store,
-            }],
-            depth_stencil: None,
-        }) {
+        if let mut pass = self.command_encoder.render(
+            "main",
+            gpu::RenderTargetSet {
+                colors: &[gpu::RenderTarget {
+                    view: frame.texture_view(),
+                    init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
+                    finish_op: gpu::FinishOp::Store,
+                }],
+                depth_stencil: None,
+            },
+        ) {
             let mut rc = pass.with(&self.pipeline);
             rc.bind(
                 0,

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -67,6 +67,7 @@ impl Example {
                 window,
                 gpu::ContextDesc {
                     validation: cfg!(debug_assertions),
+                    timing: false,
                     capture: false,
                     overlay: true,
                 },

--- a/examples/init/main.rs
+++ b/examples/init/main.rs
@@ -92,14 +92,17 @@ impl EnvMapSampler {
         env_weights: gpu::TextureView,
     ) {
         command_encoder.init_texture(self.accum_texture);
-        let mut pass = command_encoder.render(gpu::RenderTargetSet {
-            colors: &[gpu::RenderTarget {
-                view: self.accum_view,
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
-                finish_op: gpu::FinishOp::Store,
-            }],
-            depth_stencil: None,
-        });
+        let mut pass = command_encoder.render(
+            "accumulate",
+            gpu::RenderTargetSet {
+                colors: &[gpu::RenderTarget {
+                    view: self.accum_view,
+                    init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
+                    finish_op: gpu::FinishOp::Store,
+                }],
+                depth_stencil: None,
+            },
+        );
         if let mut encoder = pass.with(&self.init_pipeline) {
             encoder.bind(
                 0,

--- a/examples/mini/main.rs
+++ b/examples/mini/main.rs
@@ -111,7 +111,7 @@ fn main() {
     command_encoder.start();
     command_encoder.init_texture(texture);
 
-    if let mut transfer = command_encoder.transfer() {
+    if let mut transfer = command_encoder.transfer("gen-mips") {
         transfer.copy_buffer_to_texture(
             upload_buffer.into(),
             extent.width * 4,
@@ -120,7 +120,7 @@ fn main() {
         );
     }
     for i in 1..mip_level_count {
-        if let mut compute = command_encoder.compute() {
+        if let mut compute = command_encoder.compute("generate mips") {
             if let mut pc = compute.with(&pipeline) {
                 let groups = pipeline.get_dispatch_for(extent.at_mip_level(i));
                 pc.bind(
@@ -139,7 +139,7 @@ fn main() {
             }
         }
     }
-    if let mut tranfer = command_encoder.transfer() {
+    if let mut tranfer = command_encoder.transfer("init 1x2 texture") {
         tranfer.copy_texture_to_buffer(
             gpu::TexturePiece {
                 texture,

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -20,6 +20,7 @@ impl Example {
                 window,
                 gpu::ContextDesc {
                     validation: cfg!(debug_assertions),
+                    timing: true,
                     capture: false,
                     overlay: false,
                 },
@@ -113,6 +114,19 @@ impl Example {
         }
         self.prev_sync_point = Some(sync_point);
     }
+
+    fn add_gui(&mut self, ui: &mut egui::Ui) {
+        ui.heading("Particle System");
+        self.particle_system.add_gui(ui);
+        ui.heading("Timings");
+        for &(ref name, time) in self.command_encoder.timings() {
+            let millis = time.as_secs_f32() * 1000.0;
+            ui.horizontal(|ui| {
+                ui.label(name);
+                ui.colored_label(egui::Color32::WHITE, format!("{:.2} ms", millis));
+            });
+        }
+    }
 }
 
 fn main() {
@@ -167,9 +181,8 @@ fn main() {
                         winit::event::WindowEvent::RedrawRequested => {
                             let raw_input = egui_winit.take_egui_input(&window);
                             let egui_output = egui_winit.egui_ctx().run(raw_input, |egui_ctx| {
-                                egui::SidePanel::left("my_side_panel").show(egui_ctx, |ui| {
-                                    ui.heading("Particle System");
-                                    example.particle_system.add_gui(ui);
+                                egui::SidePanel::left("info").show(egui_ctx, |ui| {
+                                    example.add_gui(ui);
                                     if ui.button("Quit").clicked() {
                                         target.exit();
                                     }

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -89,14 +89,17 @@ impl Example {
 
         self.particle_system.update(&mut self.command_encoder);
 
-        if let mut pass = self.command_encoder.render(gpu::RenderTargetSet {
-            colors: &[gpu::RenderTarget {
-                view: frame.texture_view(),
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
-                finish_op: gpu::FinishOp::Store,
-            }],
-            depth_stencil: None,
-        }) {
+        if let mut pass = self.command_encoder.render(
+            "draw",
+            gpu::RenderTargetSet {
+                colors: &[gpu::RenderTarget {
+                    view: frame.texture_view(),
+                    init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
+                    finish_op: gpu::FinishOp::Store,
+                }],
+                depth_stencil: None,
+            },
+        ) {
             self.particle_system.draw(&mut pass);
             self.gui_painter
                 .paint(&mut pass, gui_primitives, screen_desc, &self.context);

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -21,7 +21,7 @@ impl Example {
                 gpu::ContextDesc {
                     validation: cfg!(debug_assertions),
                     timing: true,
-                    capture: false,
+                    capture: true,
                     overlay: false,
                 },
             )

--- a/examples/particle/particle.rs
+++ b/examples/particle/particle.rs
@@ -146,6 +146,10 @@ impl System {
     pub fn destroy(&mut self, context: &gpu::Context) {
         context.destroy_buffer(self.particle_buf);
         context.destroy_buffer(self.free_list_buf);
+        context.destroy_compute_pipeline(&mut self.reset_pipeline);
+        context.destroy_compute_pipeline(&mut self.emit_pipeline);
+        context.destroy_compute_pipeline(&mut self.update_pipeline);
+        context.destroy_render_pipeline(&mut self.draw_pipeline);
     }
 
     fn main_data(&self) -> MainData {

--- a/examples/particle/particle.rs
+++ b/examples/particle/particle.rs
@@ -156,7 +156,7 @@ impl System {
     }
 
     pub fn reset(&self, encoder: &mut gpu::CommandEncoder) {
-        let mut pass = encoder.compute();
+        let mut pass = encoder.compute("reset");
         let mut pc = pass.with(&self.reset_pipeline);
         pc.bind(0, &self.main_data());
         let group_size = self.reset_pipeline.get_workgroup_size();
@@ -166,7 +166,7 @@ impl System {
 
     pub fn update(&self, encoder: &mut gpu::CommandEncoder) {
         let main_data = self.main_data();
-        if let mut pass = encoder.compute() {
+        if let mut pass = encoder.compute("update") {
             let mut pc = pass.with(&self.update_pipeline);
             pc.bind(0, &main_data);
             pc.bind(
@@ -181,7 +181,7 @@ impl System {
             pc.dispatch([group_count, 1, 1]);
         }
         // new pass because both pipelines use the free list
-        if let mut pass = encoder.compute() {
+        if let mut pass = encoder.compute("emit") {
             let mut pc = pass.with(&self.emit_pipeline);
             pc.bind(0, &main_data);
             pc.bind(

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -51,8 +51,7 @@ impl Example {
                 window,
                 gpu::ContextDesc {
                     validation: cfg!(debug_assertions),
-                    capture: false,
-                    overlay: false,
+                    ..Default::default()
                 },
             )
             .unwrap()

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -210,11 +210,11 @@ impl Example {
         });
         command_encoder.start();
         command_encoder.init_texture(target);
-        if let mut pass = command_encoder.acceleration_structure() {
+        if let mut pass = command_encoder.acceleration_structure("BLAS") {
             pass.build_bottom_level(blas, &meshes, scratch_buffer.at(0));
         }
         //Note: separate pass in order to enforce synchronization
-        if let mut pass = command_encoder.acceleration_structure() {
+        if let mut pass = command_encoder.acceleration_structure("TLAS") {
             pass.build_top_level(
                 tlas,
                 &[blas],
@@ -264,7 +264,7 @@ impl Example {
     fn render(&mut self) {
         self.command_encoder.start();
 
-        if let mut pass = self.command_encoder.compute() {
+        if let mut pass = self.command_encoder.compute("ray-trace") {
             let groups = self.rt_pipeline.get_dispatch_for(self.screen_size);
             if let mut pc = pass.with(&self.rt_pipeline) {
                 let fov_y = 0.3;
@@ -293,14 +293,17 @@ impl Example {
         let frame = self.context.acquire_frame();
         self.command_encoder.init_texture(frame.texture());
 
-        if let mut pass = self.command_encoder.render(gpu::RenderTargetSet {
-            colors: &[gpu::RenderTarget {
-                view: frame.texture_view(),
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
-                finish_op: gpu::FinishOp::Store,
-            }],
-            depth_stencil: None,
-        }) {
+        if let mut pass = self.command_encoder.render(
+            "draw",
+            gpu::RenderTargetSet {
+                colors: &[gpu::RenderTarget {
+                    view: frame.texture_view(),
+                    init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
+                    finish_op: gpu::FinishOp::Store,
+                }],
+                depth_stencil: None,
+            },
+        ) {
             if let mut pc = pass.with(&self.draw_pipeline) {
                 pc.bind(
                     0,

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -476,14 +476,17 @@ impl Example {
         let frame = self.context.acquire_frame();
         command_encoder.init_texture(frame.texture());
 
-        if let mut pass = command_encoder.render(gpu::RenderTargetSet {
-            colors: &[gpu::RenderTarget {
-                view: frame.texture_view(),
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
-                finish_op: gpu::FinishOp::Store,
-            }],
-            depth_stencil: None,
-        }) {
+        if let mut pass = command_encoder.render(
+            "draw",
+            gpu::RenderTargetSet {
+                colors: &[gpu::RenderTarget {
+                    view: frame.texture_view(),
+                    init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
+                    finish_op: gpu::FinishOp::Store,
+                }],
+                depth_stencil: None,
+            },
+        ) {
             let screen_desc = blade_egui::ScreenDescriptor {
                 physical_size: (physical_size.width, physical_size.height),
                 scale_factor,

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -191,8 +191,7 @@ impl Example {
                 window,
                 gpu::ContextDesc {
                     validation: cfg!(debug_assertions),
-                    capture: false,
-                    overlay: false,
+                    ..Default::default()
                 },
             )
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,6 +415,7 @@ impl Engine {
                 window,
                 gpu::ContextDesc {
                     validation: cfg!(debug_assertions),
+                    timing: true,
                     capture: false,
                     overlay: false,
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,14 +679,17 @@ impl Engine {
         let frame = self.gpu_context.acquire_frame();
         command_encoder.init_texture(frame.texture());
 
-        if let mut pass = command_encoder.render(gpu::RenderTargetSet {
-            colors: &[gpu::RenderTarget {
-                view: frame.texture_view(),
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
-                finish_op: gpu::FinishOp::Store,
-            }],
-            depth_stencil: None,
-        }) {
+        if let mut pass = command_encoder.render(
+            "draw",
+            gpu::RenderTargetSet {
+                colors: &[gpu::RenderTarget {
+                    view: frame.texture_view(),
+                    init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
+                    finish_op: gpu::FinishOp::Store,
+                }],
+                depth_stencil: None,
+            },
+        ) {
             let screen_desc = blade_egui::ScreenDescriptor {
                 physical_size: (physical_size.width, physical_size.height),
                 scale_factor,


### PR DESCRIPTION
This helps us annotate the command scopes, capture the timers, and put GPU crash markers.
PR also adds the timing support.

Fixes #170
Closes #174
Depends on:
- https://github.com/gfx-rs/metal-rs/pull/335
- https://github.com/gfx-rs/metal-rs/pull/336
- https://github.com/gfx-rs/metal-rs/pull/337

- [x] API
  - every pass now gets a name. And there is a flag at context creation... That's it. That's all of the API.
- [x] Vulkan
  - ![Screenshot 2024-09-25 000230](https://github.com/user-attachments/assets/ba602ce4-accd-4090-b362-7d618aaeec2a)
- [x] Metal
  - ![Screenshot](https://github.com/user-attachments/assets/4e75ae12-9352-46e0-a262-e6284e8f02d0)
- [x] GLES
  - ![scoping-gles](https://github.com/user-attachments/assets/d784ef5e-e6d6-443b-b800-9ae0fdb5068a)

---
Particle example:
![gles-timing](https://github.com/user-attachments/assets/df67d3d5-f311-4dd2-8fa0-305315735f99)
