### PR TITLE
gles: re-flip the viewport

### DIFF
--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -568,11 +568,16 @@ unsafe fn present_blit(gl: &glow::Context, source: glow::Framebuffer, size: crat
     gl.color_mask(true, true, true, true);
     gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None);
     gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(source));
+    // Note: the Y-flipping here. GL's presentation is not flipped,
+    // but main rendering is. Therefore, we Y-flip the output positions
+    // in the shader, and also this blit.
+    // Note2: we could avoid doing both and get correct rendering for the main window
+    // but then other render targets would be screwed.
     gl.blit_framebuffer(
         0,
-        0,
-        size.width as i32,
         size.height as i32,
+        size.width as i32,
+        0,
         0,
         0,
         size.width as i32,

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -35,7 +35,7 @@ impl super::Context {
                 version: if force_explicit_bindings { 320 } else { 300 },
                 is_webgl: cfg!(target_arch = "wasm32"),
             },
-            writer_flags: extra_flags,
+            writer_flags: extra_flags | glsl::WriterFlags::ADJUST_COORDINATE_SPACE,
             binding_map: Default::default(),
             zero_initialize_workgroup_memory: false,
         };

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -281,7 +281,7 @@ impl Example {
         if let mut pass = self.command_encoder.render(gpu::RenderTargetSet {
             colors: &[gpu::RenderTarget {
                 view: frame.texture_view(),
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
+                init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
                 finish_op: gpu::FinishOp::Store,
             }],
             depth_stencil: None,

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -92,7 +92,7 @@ impl Example {
         if let mut pass = self.command_encoder.render(gpu::RenderTargetSet {
             colors: &[gpu::RenderTarget {
                 view: frame.texture_view(),
-                init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
+                init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
                 finish_op: gpu::FinishOp::Store,
             }],
             depth_stencil: None,


### PR DESCRIPTION
Follow-up to #180

I realized that, while the main viewport looks correct, the flipping was important for the other targets.
So we'll have to live with the inverse view when debugging in Render doc