### PR TITLE
Unfused ReSTIR

### DIFF
--- a/blade-helpers/src/hud.rs
+++ b/blade-helpers/src/hud.rs
@@ -17,6 +17,7 @@ impl ExposeHud for blade_render::RayConfig {
         ui.add(
             egui::widgets::Slider::new(&mut self.temporal_history, 0..=50).text("Temporal history"),
         );
+        ui.checkbox(&mut self.spatial_pass, "Spatial pass");
         ui.add(egui::widgets::Slider::new(&mut self.spatial_taps, 0..=10).text("Spatial taps"));
         ui.add(
             egui::widgets::Slider::new(&mut self.spatial_tap_history, 0..=50)

--- a/blade-helpers/src/lib.rs
+++ b/blade-helpers/src/lib.rs
@@ -13,6 +13,7 @@ pub fn default_ray_config() -> blade_render::RayConfig {
         environment_importance_sampling: false,
         temporal_tap: true,
         temporal_history: 10,
+        spatial_pass: true,
         spatial_taps: 1,
         spatial_tap_history: 10,
         spatial_radius: 20,

--- a/blade-render/code/fill-gbuf.wgsl
+++ b/blade-render/code/fill-gbuf.wgsl
@@ -177,6 +177,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         }
 
         if (WRITE_DEBUG_IMAGE) {
+            if (debug.view_mode == DebugMode_Depth) {
+                textureStore(out_debug, global_id.xy, vec4<f32>(1.0 / depth));
+            }
             if (debug.view_mode == DebugMode_DiffuseAlbedoTexture) {
                 textureStore(out_debug, global_id.xy, vec4<f32>(albedo, 0.0));
             }


### PR DESCRIPTION
Originally in #184

Un-fusing temporal and spatial sampling may provide the following benefit:
  - faster convergence because the spatial resampling is done on fresh results
  - higher occupancy of the smaller shader stages

# Correctness

![Screenshot 2024-10-12 221101](https://github.com/user-attachments/assets/55bf4887-6c66-4da5-972b-b0791ba68e7a)

Testing with 4 spatial samples
Before:
![ball4-fused](https://github.com/user-attachments/assets/643687b9-20db-4f96-bd6d-5846391c0a23)

After:
![ball4-unfused](https://github.com/user-attachments/assets/281b35e8-4676-4688-a446-0dbfee7db918)

# Performance

Before: (10.58ms)
![Screenshot 2024-10-12 221158](https://github.com/user-attachments/assets/be9f9d1b-c1ea-4d49-b937-74e5572fd959)

After: (11.06ms)
![Screenshot 2024-10-12 223640](https://github.com/user-attachments/assets/bed51878-b29e-4ad5-a4ea-e3a45284d84b)

Overall, we are 0.5ms slower

I also checked the numbers without the spatial tap altogether, and they matched as they should.