### PR TITLE
Update `egui` to `0.29` and `winit` to `0.30`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ blade-macros = { version = "0.3", path = "blade-macros" }
 bytemuck = { workspace = true }
 choir = { workspace = true }
 egui = { workspace = true }
-transform-gizmo-egui = { git = "https://github.com/urholaukkarinen/transform-gizmo", rev = "5be085444468ff7059abcd4e4872ab4510f65a06" }
+transform-gizmo-egui = { git = "https://github.com/urholaukkarinen/transform-gizmo", rev = "7556fb38b37f3772c57dd0fae6a276976d314f9b" }
 env_logger = "0.11"
 glam = { workspace = true }
 log = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.21"
 bitflags = "2"
 bytemuck = { version = "1", features = ["derive"] }
 choir = "0.7"
-egui = "0.28"
+egui = "0.29"
 glam = { version = "0.27", features = ["mint"] }
 gltf = { version = "1.1", default-features = false }
 log = "0.4"
@@ -29,7 +29,7 @@ profiling = "1"
 slab = "0.4"
 strum = { version = "0.25", features = ["derive"] }
 web-sys = "0.3.60"
-winit = "0.29"
+winit = "0.30"
 
 [lib]
 
@@ -91,7 +91,7 @@ del-geo = "=0.1.29"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # see https://github.com/emilk/egui/issues/4270
-egui-winit = "0.28"
+egui-winit = "0.29"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.7"

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -349,10 +349,10 @@ fn main() {
     env_logger::init();
 
     let event_loop = winit::event_loop::EventLoop::new().unwrap();
-    let window = winit::window::WindowBuilder::new()
-        .with_title("blade-bunnymark")
-        .build(&event_loop)
-        .unwrap();
+    let window_attributes =
+        winit::window::Window::default_attributes().with_title("blade-bunnymark");
+
+    let window = event_loop.create_window(window_attributes).unwrap();
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/examples/move/main.rs
+++ b/examples/move/main.rs
@@ -34,10 +34,10 @@ impl Game {
     fn new(event_loop: &winit::event_loop::EventLoop<()>) -> Self {
         log::info!("Initializing");
 
-        let window = winit::window::WindowBuilder::new()
-            .with_title("Move")
-            .build(event_loop)
-            .unwrap();
+        let window_attributes =
+            winit::window::Window::default_attributes().with_title("blade-move");
+
+        let window = event_loop.create_window(window_attributes).unwrap();
 
         let camera = ControlledCamera {
             inner: Camera {
@@ -89,7 +89,7 @@ impl Game {
         let egui_context = egui::Context::default();
         let egui_viewport_id = egui_context.viewport_id();
         let egui_state =
-            egui_winit::State::new(egui_context, egui_viewport_id, &window, None, None);
+            egui_winit::State::new(egui_context, egui_viewport_id, &window, None, None, None);
 
         Self {
             engine,

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -133,14 +133,14 @@ fn main() {
     env_logger::init();
 
     let event_loop = winit::event_loop::EventLoop::new().unwrap();
-    let window = winit::window::WindowBuilder::new()
-        .with_title("blade-particle")
-        .build(&event_loop)
-        .unwrap();
+    let window_attributes =
+        winit::window::Window::default_attributes().with_title("blade-particle");
+
+    let window = event_loop.create_window(window_attributes).unwrap();
 
     let egui_ctx = egui::Context::default();
     let viewport_id = egui_ctx.viewport_id();
-    let mut egui_winit = egui_winit::State::new(egui_ctx, viewport_id, &window, None, None);
+    let mut egui_winit = egui_winit::State::new(egui_ctx, viewport_id, &window, None, None, None);
 
     let mut example = Example::new(&window);
 

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -328,11 +328,10 @@ fn main() {
     env_logger::init();
 
     let event_loop = winit::event_loop::EventLoop::new().unwrap();
-    let window = winit::window::WindowBuilder::new()
-        .with_title("blade-ray-query")
-        .with_transparent(true)
-        .build(&event_loop)
-        .unwrap();
+    let window_attributes =
+        winit::window::Window::default_attributes().with_title("blade-ray-query");
+
+    let window = event_loop.create_window(window_attributes).unwrap();
 
     let mut example = Example::new(&window);
 

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -792,14 +792,13 @@ fn main() {
     env_logger::init();
 
     let event_loop = winit::event_loop::EventLoop::new().unwrap();
-    let window = winit::window::WindowBuilder::new()
-        .with_title("blade-scene")
-        .build(&event_loop)
-        .unwrap();
+    let window_attributes = winit::window::Window::default_attributes().with_title("blade-scene");
+
+    let window = event_loop.create_window(window_attributes).unwrap();
 
     let egui_ctx = egui::Context::default();
     let viewport_id = egui_ctx.viewport_id();
-    let mut egui_winit = egui_winit::State::new(egui_ctx, viewport_id, &window, None, None);
+    let mut egui_winit = egui_winit::State::new(egui_ctx, viewport_id, &window, None, None, None);
 
     let mut args = std::env::args();
     let path_to_scene = args

--- a/examples/vehicle/main.rs
+++ b/examples/vehicle/main.rs
@@ -87,10 +87,9 @@ impl Game {
     fn new(event_loop: &winit::event_loop::EventLoop<()>) -> Self {
         log::info!("Initializing");
 
-        let window = winit::window::WindowBuilder::new()
-            .with_title("RayCraft")
-            .build(event_loop)
-            .unwrap();
+        let window_attributes = winit::window::Window::default_attributes().with_title("RayCraft");
+
+        let window = event_loop.create_window(window_attributes).unwrap();
 
         let cam_config = config::Camera {
             distance: 5.0,
@@ -306,7 +305,7 @@ impl Game {
         let egui_context = egui::Context::default();
         let egui_viewport_id = egui_context.viewport_id();
         let egui_state =
-            egui_winit::State::new(egui_context, egui_viewport_id, &window, None, None);
+            egui_winit::State::new(egui_context, egui_viewport_id, &window, None, None, None);
 
         Self {
             engine,


### PR DESCRIPTION
Fixes #196

`winit` in `0.30` dropped `WindowBuilder` in favour of `WindowAttributes`, so this has be fixed in the examples.

`EventLoop::run_app` should probably be used instead of deprecated `EventLoop::run` in examples too
