### PR TITLE
Surface API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "2"
 bytemuck = { version = "1", features = ["derive"] }
 choir = "0.7"
 egui = "0.29"
-glam = { version = "0.27", features = ["mint"] }
+glam = { version = "0.28", features = ["mint"] }
 gltf = { version = "1.1", default-features = false }
 log = "0.4"
 mint = "0.5"

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -12,6 +12,8 @@ const DEBUG_ID: u32 = 0;
 const MAX_TIMEOUT: u64 = 1_000_000_000; // MAX_CLIENT_WAIT_TIMEOUT_WEBGL;
 const MAX_QUERIES: usize = crate::limits::PASS_COUNT + 1;
 
+pub use platform::PlatformError;
+
 bitflags::bitflags! {
     struct Capabilities: u32 {
         const BUFFER_STORAGE = 1 << 0;

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -41,6 +41,8 @@ pub struct Context {
 
 pub struct Surface {
     platform: platform::PlatformSurface,
+    renderbuf: glow::Renderbuffer,
+    framebuf: glow::Framebuffer,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -131,7 +131,7 @@ impl super::Context {
             let attribute_mappings =
                 crate::Shader::fill_vertex_locations(&mut module, ep_index, vertex_fetch_states);
 
-            for (index, mapping) in attribute_mappings.into_iter().enumerate() {
+            for mapping in attribute_mappings {
                 let vf = &vertex_fetch_states[mapping.buffer_index];
                 let (_, attrib) = vf.layout.attributes[mapping.attribute_index];
                 attributes.push(super::VertexAttributeInfo {

--- a/blade-graphics/src/gles/web.rs
+++ b/blade-graphics/src/gles/web.rs
@@ -17,6 +17,8 @@ pub struct PlatformFrame {
     extent: crate::Extent,
 }
 
+pub type PlatformError = ();
+
 impl super::Surface {
     pub fn info(&self) -> crate::SurfaceInfo {
         self.platform.info

--- a/blade-graphics/src/gles/web.rs
+++ b/blade-graphics/src/gles/web.rs
@@ -101,7 +101,6 @@ impl super::Context {
     pub fn create_surface<I>(
         &self,
         _window: &I,
-        config: crate::SurfaceConfig,
     ) -> Result<super::Surface, crate::NotSupportedError> {
         let platform = PlatformSurface {
             info: crate::SurfaceInfo {
@@ -110,16 +109,16 @@ impl super::Context {
             },
             extent: crate::Extent::default(),
         };
-        let mut surface = unsafe {
+        Ok(unsafe {
             super::Surface {
                 platform,
                 renderbuf: self.platform.glow.create_renderbuffer().unwrap(),
                 framebuf: self.platform.glow.create_framebuffer().unwrap(),
             }
-        };
-        self.reconfigure_surface(&mut surface, config);
-        Ok(surface)
+        })
     }
+
+    pub fn destroy_surface(&self, _surface: &mut super::Surface) {}
 
     pub fn reconfigure_surface(&self, surface: &mut super::Surface, config: crate::SurfaceConfig) {
         //TODO: create WebGL context here
@@ -145,8 +144,6 @@ impl super::Context {
         }
         surface.platform.extent = config.size;
     }
-
-    pub fn destroy_surface(&self, _surface: &mut super::Surface) {}
 
     /// Obtain a lock to the EGL context and get handle to the [`glow::Context`] that can be used to
     /// do rendering.

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -86,6 +86,9 @@ pub mod limits {
 
 pub use hal::*;
 
+#[cfg(target_arch = "wasm32")]
+pub const CANVAS_ID: &str = "blade";
+
 use std::{fmt, num::NonZeroU32};
 
 #[derive(Clone, Debug, Default)]
@@ -128,9 +131,9 @@ pub enum NotSupportedError {
     ))]
     VulkanError(ash::vk::Result),
 
-    #[cfg(gles)]
+    #[cfg(all(gles, not(target_arch = "wasm32")))]
     GLESLoadingError(egl::LoadError<libloading::Error>),
-    #[cfg(gles)]
+    #[cfg(all(gles, not(target_arch = "wasm32")))]
     GLESError(egl::Error),
 
     NoSupportedDeviceFound,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -108,36 +108,15 @@ pub struct ContextDesc {
 
 #[derive(Debug)]
 pub enum NotSupportedError {
-    #[cfg(all(
-        not(gles),
-        any(
-            vulkan,
-            windows,
-            target_os = "linux",
-            target_os = "android",
-            target_os = "freebsd"
-        )
-    ))]
-    VulkanLoadingError(ash::LoadingError),
-    #[cfg(all(
-        not(gles),
-        any(
-            vulkan,
-            windows,
-            target_os = "linux",
-            target_os = "android",
-            target_os = "freebsd"
-        )
-    ))]
-    VulkanError(ash::vk::Result),
-
-    #[cfg(all(gles, not(target_arch = "wasm32")))]
-    GLESLoadingError(egl::LoadError<libloading::Error>),
-    #[cfg(all(gles, not(target_arch = "wasm32")))]
-    GLESError(egl::Error),
-
+    Platform(PlatformError),
     NoSupportedDeviceFound,
     PlatformNotSupported,
+}
+
+impl From<PlatformError> for NotSupportedError {
+    fn from(error: PlatformError) -> Self {
+        Self::Platform(error)
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -90,6 +90,8 @@ use std::{fmt, num::NonZeroU32};
 
 #[derive(Clone, Debug, Default)]
 pub struct ContextDesc {
+    /// Ability to present contents to a window.
+    pub presentation: bool,
     /// Enable validation of the GAPI, shaders,
     /// and insert crash markers into command buffers.
     pub validation: bool,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -137,6 +137,20 @@ pub struct DeviceInformation {
     pub driver_info: String,
 }
 
+impl Context {
+    pub fn create_surface_configured<
+        I: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
+    >(
+        &self,
+        window: &I,
+        config: SurfaceConfig,
+    ) -> Result<Surface, NotSupportedError> {
+        let mut surface = self.create_surface(window)?;
+        self.reconfigure_surface(&mut surface, config);
+        Ok(surface)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Memory {
     /// Device-local memory. Fast for GPU operations.

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -14,6 +14,9 @@ mod surface;
 
 const MAX_TIMESTAMPS: u64 = crate::limits::PASS_COUNT as u64 * 2;
 
+//TODO: better errors
+pub type PlatformError = ();
+
 struct Surface {
     view: *mut objc::runtime::Object,
     render_layer: metal::MetalLayer,

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -515,21 +515,22 @@ impl crate::traits::CommandEncoder for super::CommandEncoder {
     }
 
     fn present(&mut self, frame: super::Frame) {
-        if frame.acquire_semaphore == vk::Semaphore::null() {
+        if frame.internal.acquire_semaphore == vk::Semaphore::null() {
             return;
         }
 
         assert_eq!(self.present, None);
         let wa = &self.device.workarounds;
         self.present = Some(super::Presentation {
+            acquire_semaphore: frame.internal.acquire_semaphore,
+            swapchain: frame.swapchain.raw,
             image_index: frame.image_index,
-            acquire_semaphore: frame.acquire_semaphore,
         });
 
         let barrier = vk::ImageMemoryBarrier {
             old_layout: vk::ImageLayout::GENERAL,
             new_layout: vk::ImageLayout::PRESENT_SRC_KHR,
-            image: frame.image,
+            image: frame.internal.image,
             subresource_range: vk::ImageSubresourceRange {
                 aspect_mask: vk::ImageAspectFlags::COLOR,
                 base_mip_level: 0,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -6,6 +6,7 @@ mod descriptor;
 mod init;
 mod pipeline;
 mod resource;
+mod surface;
 
 const QUERY_POOL_SIZE: usize = crate::limits::PASS_COUNT + 1;
 
@@ -40,6 +41,7 @@ struct Workarounds {
 struct Device {
     core: ash::Device,
     device_information: crate::DeviceInformation,
+    swapchain: Option<khr::swapchain::Device>,
     debug_utils: ash::ext::debug_utils::Device,
     timeline_semaphore: khr::timeline_semaphore::Device,
     dynamic_rendering: khr::dynamic_rendering::Device,
@@ -65,41 +67,59 @@ struct Queue {
     last_progress: u64,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Frame {
-    image_index: u32,
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+struct InternalFrame {
+    acquire_semaphore: vk::Semaphore,
     image: vk::Image,
     view: vk::ImageView,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Swapchain {
+    raw: vk::SwapchainKHR,
     format: crate::TextureFormat,
-    acquire_semaphore: vk::Semaphore,
     target_size: [u16; 2],
+}
+
+pub struct Surface {
+    raw: vk::SurfaceKHR,
+    frames: Vec<InternalFrame>,
+    next_semaphore: vk::Semaphore,
+    swapchain: Swapchain,
+    _full_screen_exclusive: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Presentation {
+    swapchain: vk::SwapchainKHR,
+    image_index: u32,
+    acquire_semaphore: vk::Semaphore,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Frame {
+    swapchain: Swapchain,
+    image_index: u32,
+    internal: InternalFrame,
 }
 
 impl Frame {
     pub fn texture(&self) -> Texture {
         Texture {
-            raw: self.image,
+            raw: self.internal.image,
             memory_handle: !0,
-            target_size: self.target_size,
-            format: self.format,
+            target_size: self.swapchain.target_size,
+            format: self.swapchain.format,
         }
     }
 
     pub fn texture_view(&self) -> TextureView {
         TextureView {
-            raw: self.view,
-            target_size: self.target_size,
+            raw: self.internal.view,
+            target_size: self.swapchain.target_size,
             aspects: crate::TexelAspects::COLOR,
         }
     }
-}
-
-struct Surface {
-    raw: vk::SurfaceKHR,
-    frames: Vec<Frame>,
-    next_semaphore: vk::Semaphore,
-    swapchain: vk::SwapchainKHR,
-    extension: khr::swapchain::Device,
 }
 
 fn map_timeout(millis: u32) -> u64 {
@@ -115,12 +135,11 @@ pub struct Context {
     device: Device,
     queue_family_index: u32,
     queue: Mutex<Queue>,
-    surface: Option<Mutex<Surface>>,
     physical_device: vk::PhysicalDevice,
     naga_flags: naga::back::spv::WriterFlags,
     shader_debug_path: Option<PathBuf>,
     instance: Instance,
-    _entry: ash::Entry,
+    entry: ash::Entry,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
@@ -230,12 +249,6 @@ struct CommandBuffer {
     descriptor_pool: descriptor::DescriptorPool,
     query_pool: vk::QueryPool,
     timed_pass_names: Vec<String>,
-}
-
-#[derive(Debug, PartialEq)]
-struct Presentation {
-    image_index: u32,
-    acquire_semaphore: vk::Semaphore,
 }
 
 struct CrashHandler {
@@ -465,15 +478,15 @@ impl crate::traits::CommandDevice for Context {
         encoder.check_gpu_crash(ret);
 
         if let Some(presentation) = encoder.present.take() {
-            let surface = self.surface.as_ref().unwrap().lock().unwrap();
-            let swapchains = [surface.swapchain];
+            let khr_swapchain = self.device.swapchain.as_ref().unwrap();
+            let swapchains = [presentation.swapchain];
             let image_indices = [presentation.image_index];
             let wait_semaphores = [queue.present_semaphore];
             let present_info = vk::PresentInfoKHR::default()
                 .swapchains(&swapchains)
                 .image_indices(&image_indices)
                 .wait_semaphores(&wait_semaphores);
-            let ret = unsafe { surface.extension.queue_present(queue.raw, &present_info) };
+            let ret = unsafe { khr_swapchain.queue_present(queue.raw, &present_info) };
             let _ = encoder.check_gpu_crash(ret);
         }
 

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -10,6 +10,12 @@ mod surface;
 
 const QUERY_POOL_SIZE: usize = crate::limits::PASS_COUNT + 1;
 
+#[derive(Debug)]
+pub enum PlatformError {
+    Loading(ash::LoadingError),
+    Init(vk::Result),
+}
+
 struct Instance {
     core: ash::Instance,
     _debug_utils: ash::ext::debug_utils::Instance,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -78,6 +78,7 @@ struct InternalFrame {
 struct Swapchain {
     raw: vk::SwapchainKHR,
     format: crate::TextureFormat,
+    alpha: crate::AlphaMode,
     target_size: [u16; 2],
 }
 

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -83,6 +83,7 @@ struct Swapchain {
 }
 
 pub struct Surface {
+    device: khr::swapchain::Device,
     raw: vk::SurfaceKHR,
     frames: Vec<InternalFrame>,
     next_semaphore: vk::Semaphore,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -94,7 +94,7 @@ pub struct Surface {
     frames: Vec<InternalFrame>,
     next_semaphore: vk::Semaphore,
     swapchain: Swapchain,
-    _full_screen_exclusive: bool,
+    full_screen_exclusive: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/blade-graphics/src/vulkan/surface.rs
+++ b/blade-graphics/src/vulkan/surface.rs
@@ -129,7 +129,7 @@ impl super::Context {
                 alpha: crate::AlphaMode::Ignored,
                 target_size: [0; 2],
             },
-            _full_screen_exclusive: fullscreen_exclusive_ext.full_screen_exclusive_supported != 0,
+            full_screen_exclusive: fullscreen_exclusive_ext.full_screen_exclusive_supported != 0,
         })
     }
 
@@ -327,10 +327,13 @@ impl super::Context {
         }
         .queue_family_indices(&queue_families);
 
-        if self.device.full_screen_exclusive.is_some() {
+        if surface.full_screen_exclusive {
+            assert!(self.device.full_screen_exclusive.is_some());
             create_info = create_info.push_next(&mut full_screen_exclusive_info);
-        } else if !config.allow_exclusive_full_screen {
-            log::info!("Unable to forbid exclusive full screen");
+            log::info!(
+                "Configuring exclusive full screen: {}",
+                config.allow_exclusive_full_screen
+            );
         }
         let raw_swapchain = unsafe { surface.device.create_swapchain(&create_info, None).unwrap() };
 

--- a/blade-graphics/src/vulkan/surface.rs
+++ b/blade-graphics/src/vulkan/surface.rs
@@ -58,7 +58,6 @@ impl super::Context {
     >(
         &self,
         window: &I,
-        config: crate::SurfaceConfig,
     ) -> Result<super::Surface, crate::NotSupportedError> {
         let khr_swapchain = self
             .device
@@ -119,7 +118,7 @@ impl super::Context {
                 .unwrap()
         };
 
-        let mut this = super::Surface {
+        Ok(super::Surface {
             device: khr_swapchain,
             raw,
             frames: Vec::new(),
@@ -131,9 +130,7 @@ impl super::Context {
                 target_size: [0; 2],
             },
             _full_screen_exclusive: fullscreen_exclusive_ext.full_screen_exclusive_supported != 0,
-        };
-        self.reconfigure_surface(&mut this, config);
-        Ok(this)
+        })
     }
 
     pub fn destroy_surface(&self, surface: &mut super::Surface) {

--- a/blade-graphics/src/vulkan/surface.rs
+++ b/blade-graphics/src/vulkan/surface.rs
@@ -74,7 +74,7 @@ impl super::Context {
                 window.window_handle().unwrap().as_raw(),
                 None,
             )
-            .map_err(|e| crate::NotSupportedError::VulkanError(e))?
+            .map_err(super::PlatformError::Init)?
         };
 
         let khr_surface = self

--- a/blade-graphics/src/vulkan/surface.rs
+++ b/blade-graphics/src/vulkan/surface.rs
@@ -1,0 +1,375 @@
+use ash::vk;
+use std::mem;
+
+impl super::Context {
+    pub fn create_surface<
+        I: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
+    >(
+        &self,
+        window: &I,
+    ) -> Result<super::Surface, crate::NotSupportedError> {
+        let raw = unsafe {
+            ash_window::create_surface(
+                &self.entry,
+                &self.instance.core,
+                window.display_handle().unwrap().as_raw(),
+                window.window_handle().unwrap().as_raw(),
+                None,
+            )
+            .map_err(|e| crate::NotSupportedError::VulkanError(e))?
+        };
+
+        let khr_surface = self
+            .instance
+            .surface
+            .as_ref()
+            .ok_or(crate::NotSupportedError::PlatformNotSupported)?;
+        if unsafe {
+            khr_surface.get_physical_device_surface_support(
+                self.physical_device,
+                self.queue_family_index,
+                raw,
+            ) != Ok(true)
+        } {
+            log::warn!("Rejected for not presenting to the window surface");
+            return Err(crate::NotSupportedError::PlatformNotSupported);
+        }
+
+        let surface_info = vk::PhysicalDeviceSurfaceInfo2KHR {
+            surface: raw,
+            ..Default::default()
+        };
+        let mut fullscreen_exclusive_ext = vk::SurfaceCapabilitiesFullScreenExclusiveEXT::default();
+        let mut capabilities2_khr =
+            vk::SurfaceCapabilities2KHR::default().push_next(&mut fullscreen_exclusive_ext);
+        let _ = unsafe {
+            self.instance
+                .get_surface_capabilities2
+                .get_physical_device_surface_capabilities2(
+                    self.physical_device,
+                    &surface_info,
+                    &mut capabilities2_khr,
+                )
+        };
+        log::debug!("{:?}", capabilities2_khr.surface_capabilities);
+
+        let semaphore_create_info = vk::SemaphoreCreateInfo::default();
+        let next_semaphore = unsafe {
+            self.device
+                .core
+                .create_semaphore(&semaphore_create_info, None)
+                .unwrap()
+        };
+        Ok(super::Surface {
+            raw,
+            frames: Vec::new(),
+            next_semaphore,
+            swapchain: super::Swapchain {
+                raw: vk::SwapchainKHR::null(),
+                target_size: [0; 2],
+                format: crate::TextureFormat::Rgba8Unorm,
+            },
+            _full_screen_exclusive: fullscreen_exclusive_ext.full_screen_exclusive_supported != 0,
+        })
+    }
+
+    pub fn destroy_surface(&self, surface: &mut super::Surface) {
+        unsafe {
+            self.deinit_swapchain(surface);
+            self.device
+                .core
+                .destroy_semaphore(surface.next_semaphore, None)
+        };
+        if let Some(ref surface_instance) = self.instance.surface {
+            unsafe { surface_instance.destroy_surface(surface.raw, None) };
+        }
+    }
+
+    unsafe fn deinit_swapchain(&self, surface: &mut super::Surface) {
+        let khr_swapchain = self.device.swapchain.as_ref().unwrap();
+        khr_swapchain.destroy_swapchain(mem::take(&mut surface.swapchain.raw), None);
+        for frame in surface.frames.drain(..) {
+            self.device.core.destroy_image_view(frame.view, None);
+            self.device
+                .core
+                .destroy_semaphore(frame.acquire_semaphore, None);
+        }
+    }
+
+    pub fn configure_surface(
+        &self,
+        surface: &mut super::Surface,
+        config: crate::SurfaceConfig,
+    ) -> crate::SurfaceInfo {
+        let khr_swapchain = self.device.swapchain.as_ref().unwrap();
+        let khr_surface = self.instance.surface.as_ref().unwrap();
+
+        let capabilities = unsafe {
+            khr_surface
+                .get_physical_device_surface_capabilities(self.physical_device, surface.raw)
+                .unwrap()
+        };
+        if config.size.width < capabilities.min_image_extent.width
+            || config.size.width > capabilities.max_image_extent.width
+            || config.size.height < capabilities.min_image_extent.height
+            || config.size.height > capabilities.max_image_extent.height
+        {
+            log::warn!(
+                "Requested size {}x{} is outside of surface capabilities",
+                config.size.width,
+                config.size.height
+            );
+        }
+
+        let (alpha, composite_alpha) = if config.transparent {
+            if capabilities
+                .supported_composite_alpha
+                .contains(vk::CompositeAlphaFlagsKHR::POST_MULTIPLIED)
+            {
+                (
+                    crate::AlphaMode::PostMultiplied,
+                    vk::CompositeAlphaFlagsKHR::POST_MULTIPLIED,
+                )
+            } else if capabilities
+                .supported_composite_alpha
+                .contains(vk::CompositeAlphaFlagsKHR::PRE_MULTIPLIED)
+            {
+                (
+                    crate::AlphaMode::PreMultiplied,
+                    vk::CompositeAlphaFlagsKHR::PRE_MULTIPLIED,
+                )
+            } else {
+                log::error!(
+                    "No composite alpha flag for transparency: {:?}",
+                    capabilities.supported_composite_alpha
+                );
+                (
+                    crate::AlphaMode::Ignored,
+                    vk::CompositeAlphaFlagsKHR::OPAQUE,
+                )
+            }
+        } else {
+            (
+                crate::AlphaMode::Ignored,
+                vk::CompositeAlphaFlagsKHR::OPAQUE,
+            )
+        };
+
+        let (requested_frame_count, mode_preferences) = match config.display_sync {
+            crate::DisplaySync::Block => (3, [vk::PresentModeKHR::FIFO].as_slice()),
+            crate::DisplaySync::Recent => (
+                3,
+                [
+                    vk::PresentModeKHR::MAILBOX,
+                    vk::PresentModeKHR::FIFO_RELAXED,
+                    vk::PresentModeKHR::IMMEDIATE,
+                ]
+                .as_slice(),
+            ),
+            crate::DisplaySync::Tear => (2, [vk::PresentModeKHR::IMMEDIATE].as_slice()),
+        };
+        let effective_frame_count = requested_frame_count.max(capabilities.min_image_count);
+
+        let present_modes = unsafe {
+            khr_surface
+                .get_physical_device_surface_present_modes(self.physical_device, surface.raw)
+                .unwrap()
+        };
+        let present_mode = *mode_preferences
+            .iter()
+            .find(|mode| present_modes.contains(mode))
+            .unwrap();
+        log::info!("Using surface present mode {:?}", present_mode);
+
+        let queue_families = [self.queue_family_index];
+
+        let mut supported_formats = Vec::new();
+        let (format, surface_format) = if surface.swapchain.target_size[0] > 0 {
+            let format = surface.swapchain.format;
+            log::info!("Retaining current format: {:?}", format);
+            let vk_color_space = match (format, config.color_space) {
+                (crate::TextureFormat::Bgra8Unorm, crate::ColorSpace::Srgb) => {
+                    vk::ColorSpaceKHR::SRGB_NONLINEAR
+                }
+                (crate::TextureFormat::Bgra8Unorm, crate::ColorSpace::Linear) => {
+                    vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT
+                }
+                (crate::TextureFormat::Bgra8UnormSrgb, crate::ColorSpace::Linear) => {
+                    vk::ColorSpaceKHR::default()
+                }
+                _ => panic!(
+                    "Unexpected format {:?} under color space {:?}",
+                    format, config.color_space
+                ),
+            };
+            (
+                format,
+                vk::SurfaceFormatKHR {
+                    format: super::map_texture_format(format),
+                    color_space: vk_color_space,
+                },
+            )
+        } else {
+            supported_formats = unsafe {
+                khr_surface
+                    .get_physical_device_surface_formats(self.physical_device, surface.raw)
+                    .unwrap()
+            };
+            match config.color_space {
+                crate::ColorSpace::Linear => {
+                    let surface_format = vk::SurfaceFormatKHR {
+                        format: vk::Format::B8G8R8A8_UNORM,
+                        color_space: vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT,
+                    };
+                    if supported_formats.contains(&surface_format) {
+                        log::info!("Using linear SRGB color space");
+                        (crate::TextureFormat::Bgra8Unorm, surface_format)
+                    } else {
+                        (
+                            crate::TextureFormat::Bgra8UnormSrgb,
+                            vk::SurfaceFormatKHR {
+                                format: vk::Format::B8G8R8A8_SRGB,
+                                color_space: vk::ColorSpaceKHR::default(),
+                            },
+                        )
+                    }
+                }
+                crate::ColorSpace::Srgb => (
+                    crate::TextureFormat::Bgra8Unorm,
+                    vk::SurfaceFormatKHR {
+                        format: vk::Format::B8G8R8A8_UNORM,
+                        color_space: vk::ColorSpaceKHR::SRGB_NONLINEAR,
+                    },
+                ),
+            }
+        };
+        if !supported_formats.is_empty() && !supported_formats.contains(&surface_format) {
+            log::error!("Surface formats are incompatible: {:?}", supported_formats);
+        }
+
+        let vk_usage = super::resource::map_texture_usage(config.usage, crate::TexelAspects::COLOR);
+        if !capabilities.supported_usage_flags.contains(vk_usage) {
+            log::error!(
+                "Surface usages are incompatible: {:?}",
+                capabilities.supported_usage_flags
+            );
+        }
+
+        let mut full_screen_exclusive_info = vk::SurfaceFullScreenExclusiveInfoEXT {
+            full_screen_exclusive: if config.allow_exclusive_full_screen {
+                vk::FullScreenExclusiveEXT::ALLOWED
+            } else {
+                vk::FullScreenExclusiveEXT::DISALLOWED
+            },
+            ..Default::default()
+        };
+
+        let mut create_info = vk::SwapchainCreateInfoKHR {
+            surface: surface.raw,
+            min_image_count: effective_frame_count,
+            image_format: surface_format.format,
+            image_color_space: surface_format.color_space,
+            image_extent: vk::Extent2D {
+                width: config.size.width,
+                height: config.size.height,
+            },
+            image_array_layers: 1,
+            image_usage: vk_usage,
+            pre_transform: vk::SurfaceTransformFlagsKHR::IDENTITY,
+            composite_alpha,
+            present_mode,
+            old_swapchain: surface.swapchain.raw,
+            ..Default::default()
+        }
+        .queue_family_indices(&queue_families);
+
+        if self.device.full_screen_exclusive.is_some() {
+            create_info = create_info.push_next(&mut full_screen_exclusive_info);
+        } else if !config.allow_exclusive_full_screen {
+            log::info!("Unable to forbid exclusive full screen");
+        }
+        let raw_swapchain = unsafe { khr_swapchain.create_swapchain(&create_info, None).unwrap() };
+
+        unsafe {
+            self.deinit_swapchain(surface);
+        }
+
+        let images = unsafe { khr_swapchain.get_swapchain_images(raw_swapchain).unwrap() };
+        let target_size = [config.size.width as u16, config.size.height as u16];
+        let subresource_range = vk::ImageSubresourceRange {
+            aspect_mask: vk::ImageAspectFlags::COLOR,
+            base_mip_level: 0,
+            level_count: 1,
+            base_array_layer: 0,
+            layer_count: 1,
+        };
+        for image in images {
+            let view_create_info = vk::ImageViewCreateInfo {
+                image,
+                view_type: vk::ImageViewType::TYPE_2D,
+                format: surface_format.format,
+                subresource_range,
+                ..Default::default()
+            };
+            let view = unsafe {
+                self.device
+                    .core
+                    .create_image_view(&view_create_info, None)
+                    .unwrap()
+            };
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
+            let acquire_semaphore = unsafe {
+                self.device
+                    .core
+                    .create_semaphore(&semaphore_create_info, None)
+                    .unwrap()
+            };
+            surface.frames.push(super::InternalFrame {
+                acquire_semaphore,
+                image,
+                view,
+            });
+        }
+        surface.swapchain = super::Swapchain {
+            raw: raw_swapchain,
+            format,
+            target_size,
+        };
+
+        crate::SurfaceInfo { format, alpha }
+    }
+
+    pub fn acquire_frame(&self, surface: &mut super::Surface) -> super::Frame {
+        let khr_swapchain = self.device.swapchain.as_ref().unwrap();
+        let acquire_semaphore = surface.next_semaphore;
+        match unsafe {
+            khr_swapchain.acquire_next_image(
+                surface.swapchain.raw,
+                !0,
+                acquire_semaphore,
+                vk::Fence::null(),
+            )
+        } {
+            Ok((index, _suboptimal)) => {
+                surface.next_semaphore = mem::replace(
+                    &mut surface.frames[index as usize].acquire_semaphore,
+                    acquire_semaphore,
+                );
+                super::Frame {
+                    internal: surface.frames[index as usize],
+                    swapchain: surface.swapchain,
+                    image_index: index,
+                }
+            }
+            Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
+                log::warn!("Acquire failed because the surface is out of date");
+                super::Frame {
+                    internal: super::InternalFrame::default(),
+                    swapchain: surface.swapchain,
+                    image_index: 0,
+                }
+            }
+            Err(other) => panic!("Aquire image error {}", other),
+        }
+    }
+}

--- a/blade-render/Cargo.toml
+++ b/blade-render/Cargo.toml
@@ -37,7 +37,7 @@ exr = { version = "1.6", optional = true }
 gltf = { workspace = true, features = ["names", "utils"], optional = true }
 glam = { workspace = true }
 log = { workspace = true }
-mikktspace = { package = "bevy_mikktspace", version = "0.12", optional = true }
+mikktspace = { package = "bevy_mikktspace", version = "0.15.0-rc.3", optional = true }
 mint = { workspace = true }
 profiling = { workspace = true }
 slab = { workspace = true, optional = true }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog for Blade
 ## blade-graphics-0.6 (TBD)
 
 - graphics:
+  - API for surface creation
+    - allows multiple windows used by the same context
   - API for destruction of pipelines
   - every pass now takes a label
   - automatic GPU pass markers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog for Blade
 ## blade-graphics-0.6 (TBD)
 
 - graphics:
+  - return detailed initialization errors
   - API for surface creation
     - allows multiple windows used by the same context
   - API for destruction of pipelines

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -279,7 +279,7 @@ impl Example {
         if self.window_size == Default::default() {
             return;
         }
-        let frame = self.context.acquire_frame(&mut self.surface);
+        let frame = self.surface.acquire_frame();
 
         self.command_encoder.start();
         self.command_encoder.init_texture(frame.texture());

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -90,7 +90,7 @@ impl Example {
         let window_size = window.inner_size();
 
         let surface = context
-            .create_surface(window, Self::make_surface_config(window_size))
+            .create_surface_configured(window, Self::make_surface_config(window_size))
             .unwrap();
 
         let global_layout = <Params as gpu::ShaderData>::layout();

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -36,7 +36,9 @@ impl Example {
             display_sync: gpu::DisplaySync::Block,
             ..Default::default()
         };
-        let surface = context.create_surface(window, surface_config).unwrap();
+        let surface = context
+            .create_surface_configured(window, surface_config)
+            .unwrap();
         let surface_info = surface.info();
 
         let gui_painter = blade_egui::GuiPainter::new(surface_info, &context);

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -84,7 +84,7 @@ impl Example {
         gui_textures: &egui::TexturesDelta,
         screen_desc: &blade_egui::ScreenDescriptor,
     ) {
-        let frame = self.context.acquire_frame(&mut self.surface);
+        let frame = self.surface.acquire_frame();
         self.command_encoder.start();
         self.command_encoder.init_texture(frame.texture());
 

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -71,7 +71,9 @@ impl Example {
             transparent: true,
             ..Default::default()
         };
-        let surface = context.create_surface(window, surface_config).unwrap();
+        let surface = context
+            .create_surface_configured(window, surface_config)
+            .unwrap();
 
         let target = context.create_texture(gpu::TextureDesc {
             name: "main",

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -290,7 +290,7 @@ impl Example {
             }
         }
 
-        let frame = self.context.acquire_frame(&mut self.surface);
+        let frame = self.surface.acquire_frame();
         self.command_encoder.init_texture(frame.texture());
 
         if let mut pass = self.command_encoder.render(

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -195,7 +195,9 @@ impl Example {
 
         let surface_config = Self::make_surface_config(window.inner_size());
         let surface_size = surface_config.size;
-        let surface = context.create_surface(window, surface_config).unwrap();
+        let surface = context
+            .create_surface_configured(window, surface_config)
+            .unwrap();
         let surface_info = surface.info();
 
         let num_workers = num_cpus::get_physical().max((num_cpus::get() * 3 + 2) / 4);

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -470,7 +470,7 @@ impl Example {
             }
         }
 
-        let frame = self.context.acquire_frame(&mut self.surface);
+        let frame = self.surface.acquire_frame();
         command_encoder.init_texture(frame.texture());
 
         if let mut pass = command_encoder.render(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,10 +422,10 @@ impl Engine {
             .unwrap()
         });
 
-        let mut gpu_surface = gpu_context.create_surface(window).unwrap();
         let surface_config = Self::make_surface_config(window.inner_size());
         let surface_size = surface_config.size;
-        let surface_info = gpu_context.configure_surface(&mut gpu_surface, surface_config);
+        let gpu_surface = gpu_context.create_surface(window, surface_config).unwrap();
+        let surface_info = gpu_surface.info();
 
         let num_workers = num_cpus::get_physical().max((num_cpus::get() * 3 + 2) / 4);
         log::info!("Initializing Choir with {} workers", num_workers);
@@ -547,7 +547,7 @@ impl Engine {
             log::info!("Resizing to {}", new_render_size);
             self.pacer.wait_for_previous_frame(&self.gpu_context);
             self.gpu_context
-                .configure_surface(&mut self.gpu_surface, surface_config);
+                .reconfigure_surface(&mut self.gpu_surface, surface_config);
         }
 
         let (command_encoder, temp) = self.pacer.begin_frame();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,9 @@ impl Engine {
 
         let surface_config = Self::make_surface_config(window.inner_size());
         let surface_size = surface_config.size;
-        let gpu_surface = gpu_context.create_surface(window, surface_config).unwrap();
+        let gpu_surface = gpu_context
+            .create_surface_configured(window, surface_config)
+            .unwrap();
         let surface_info = gpu_surface.info();
 
         let num_workers = num_cpus::get_physical().max((num_cpus::get() * 3 + 2) / 4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -680,7 +680,7 @@ impl Engine {
             }
         }
 
-        let frame = self.gpu_context.acquire_frame(&mut self.gpu_surface);
+        let frame = self.gpu_surface.acquire_frame();
         command_encoder.init_texture(frame.texture());
 
         if let mut pass = command_encoder.render(


### PR DESCRIPTION
Closes #82
TODO:
- [x] API
- [x] Vulkan
- [x] Metal
- [x] GLES
- [ ] Update in Zed
  - I'm confident in the direction here, so testing on Zed can be done in follow-up

Begone the `init_windowed` method. There is only one `init` now. The other one is replaced by `create_surface`.
