### PR TITLE
Support for Multisampled Anti-Aliasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /blade-asset/cooked
 /_failure.wgsl
 
+libEGL.dylib
+libGLESv2.dylib
+
 .DS_Store
 /.vs
 /.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ profiling = "1"
 slab = "0.4"
 strum = { version = "0.25", features = ["derive"] }
 web-sys = "0.3.60"
-winit = { version = "0.30" }
-# winit = { version = "0.30", default-features=false, features=["x11", "rwh_06"] }
+# winit = { version = "0.30" }
+winit = { version = "0.30", default-features=false, features=["x11", "rwh_06"] }
 
 [lib]
 
@@ -91,7 +91,7 @@ del-geo = "=0.1.29"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # see https://github.com/emilk/egui/issues/4270
-egui-winit = "0.29"
+egui-winit = { version="0.29", default-features=false, features=["links"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 # see https://github.com/emilk/egui/issues/4270

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ slab = "0.4"
 strum = { version = "0.25", features = ["derive"] }
 web-sys = "0.3.60"
 winit = { version = "0.30" }
+# winit = { version = "0.30", default-features=false, features=["x11", "rwh_06"] }
 
 [lib]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,8 @@ del-geo = "=0.1.29"
 egui-winit = "0.29"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+# see https://github.com/emilk/egui/issues/4270
+egui-winit = { version="0.29", default-features=false, features=["links"] }
 console_error_panic_hook = "0.1.7"
 console_log = "1"
 web-sys = { workspace = true, features = ["Window"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ profiling = "1"
 slab = "0.4"
 strum = { version = "0.25", features = ["derive"] }
 web-sys = "0.3.60"
-# winit = { version = "0.30" }
-winit = { version = "0.30", default-features=false, features=["x11", "rwh_06"] }
+winit = { version = "0.30" }
 
 [lib]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ profiling = "1"
 slab = "0.4"
 strum = { version = "0.25", features = ["derive"] }
 web-sys = "0.3.60"
-winit = "0.30"
+winit = { version = "0.30" }
 
 [lib]
 

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -129,7 +129,11 @@ impl GuiPainter {
     /// It supports renderpasses with only a color attachment,
     /// and this attachment format must be The `output_format`.
     #[profiling::function]
-    pub fn new(info: blade_graphics::SurfaceInfo, context: &blade_graphics::Context) -> Self {
+    pub fn new(
+        info: blade_graphics::SurfaceInfo,
+        context: &blade_graphics::Context,
+        sample_count: u32,
+    ) -> Self {
         let shader = context.create_shader(blade_graphics::ShaderDesc {
             source: SHADER_SOURCE,
         });
@@ -162,7 +166,10 @@ impl GuiPainter {
                 }),
                 write_mask: blade_graphics::ColorWrites::all(),
             }],
-            multisample_state: blade_graphics::MultisampleState::default(),
+            multisample_state: blade_graphics::MultisampleState {
+                sample_count,
+                ..Default::default()
+            },
         });
 
         let belt = BufferBelt::new(BufferBeltDescriptor {

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -129,11 +129,7 @@ impl GuiPainter {
     /// It supports renderpasses with only a color attachment,
     /// and this attachment format must be The `output_format`.
     #[profiling::function]
-    pub fn new(
-        info: blade_graphics::SurfaceInfo,
-        context: &blade_graphics::Context,
-        sample_count: u32,
-    ) -> Self {
+    pub fn new(info: blade_graphics::SurfaceInfo, context: &blade_graphics::Context) -> Self {
         let shader = context.create_shader(blade_graphics::ShaderDesc {
             source: SHADER_SOURCE,
         });
@@ -166,10 +162,7 @@ impl GuiPainter {
                 }),
                 write_mask: blade_graphics::ColorWrites::all(),
             }],
-            multisample_state: blade_graphics::MultisampleState {
-                sample_count,
-                ..Default::default()
-            },
+            multisample_state: Default::default(),
         });
 
         let belt = BufferBelt::new(BufferBeltDescriptor {

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -71,6 +71,7 @@ impl GuiTexture {
             mip_level_count: 1,
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
+            sample_count: 1,
         });
         let view = context.create_texture_view(
             allocation,
@@ -161,6 +162,7 @@ impl GuiPainter {
                 }),
                 write_mask: blade_graphics::ColorWrites::all(),
             }],
+            multisample_state: blade_graphics::MultisampleState::default(),
         });
 
         let belt = BufferBelt::new(BufferBeltDescriptor {

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -357,7 +357,8 @@ impl super::Context {
                 let window_ptr = unsafe {
                     use objc::{msg_send, runtime::Object, sel, sel_impl};
                     // ns_view always have a layer and don't need to verify that it exists.
-                    let layer: *mut Object = msg_send![handle.ns_view.as_ptr(), layer];
+                    let layer: *mut Object =
+                        msg_send![handle.ns_view.as_ptr() as *mut Object, layer];
                     layer as *mut ffi::c_void
                 };
                 window_ptr

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -274,6 +274,10 @@ enum Command {
         size: crate::Extent,
     },
     ResetFramebuffer,
+    BlitFramebuffer {
+        from: TextureView,
+        to: TextureView,
+    },
     BindAttachment {
         attachment: u32,
         view: TextureView,

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -128,12 +128,24 @@ impl crate::traits::ResourceDevice for super::Context {
             let raw = unsafe { gl.create_renderbuffer().unwrap() };
             unsafe {
                 gl.bind_renderbuffer(glow::RENDERBUFFER, Some(raw));
-                gl.renderbuffer_storage(
-                    glow::RENDERBUFFER,
-                    format_desc.internal,
-                    desc.size.width as i32,
-                    desc.size.height as i32,
-                );
+
+                if desc.sample_count <= 1 {
+                    gl.renderbuffer_storage(
+                        glow::RENDERBUFFER,
+                        format_desc.internal,
+                        desc.size.width as i32,
+                        desc.size.height as i32,
+                    );
+                } else {
+                    gl.renderbuffer_storage_multisample(
+                        glow::RENDERBUFFER,
+                        desc.sample_count as i32,
+                        format_desc.internal,
+                        desc.size.width as i32,
+                        desc.size.height as i32,
+                    );
+                }
+
                 gl.bind_renderbuffer(glow::RENDERBUFFER, None);
                 #[cfg(not(target_arch = "wasm32"))]
                 if !desc.name.is_empty() && gl.supports_debug() {
@@ -144,6 +156,7 @@ impl crate::traits::ResourceDevice for super::Context {
                     );
                 }
             }
+
             super::TextureInner::Renderbuffer { raw }
         } else {
             let raw = unsafe { gl.create_texture().unwrap() };
@@ -159,7 +172,11 @@ impl crate::traits::ResourceDevice for super::Context {
                     if desc.array_layer_count > 1 {
                         glow::TEXTURE_2D_ARRAY
                     } else {
-                        glow::TEXTURE_2D
+                        if desc.sample_count <= 1 {
+                            glow::TEXTURE_2D
+                        } else {
+                            glow::TEXTURE_2D_MULTISAMPLE
+                        }
                     }
                 }
                 crate::TextureDimension::D3 => glow::TEXTURE_3D,
@@ -184,13 +201,27 @@ impl crate::traits::ResourceDevice for super::Context {
                         );
                     }
                     crate::TextureDimension::D2 => {
-                        gl.tex_storage_2d(
-                            target,
-                            desc.mip_level_count as i32,
-                            format_desc.internal,
-                            desc.size.width as i32,
-                            desc.size.height as i32,
-                        );
+                        if desc.sample_count <= 1 {
+                            gl.tex_storage_2d(
+                                target,
+                                desc.mip_level_count as i32,
+                                format_desc.internal,
+                                desc.size.width as i32,
+                                desc.size.height as i32,
+                            );
+                        } else {
+                            /*
+                                TODO(ErikWDev): How to set mip count and sample count? Not possible in gles?
+                            */
+                            gl.tex_storage_2d_multisample(
+                                target,
+                                desc.sample_count as i32,
+                                format_desc.internal,
+                                desc.size.width as i32,
+                                desc.size.height as i32,
+                                true,
+                            );
+                        }
                     }
                     crate::TextureDimension::D1 => {
                         gl.tex_storage_1d(

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -161,7 +161,6 @@ impl crate::traits::ResourceDevice for super::Context {
         } else {
             let raw = unsafe { gl.create_texture().unwrap() };
 
-            let mut ignoring_sample_count = false;
             let target = match desc.dimension {
                 crate::TextureDimension::D1 => {
                     if desc.sample_count > 1 {
@@ -178,7 +177,7 @@ impl crate::traits::ResourceDevice for super::Context {
                         if desc.sample_count <= 1 {
                             glow::TEXTURE_2D_ARRAY
                         } else {
-                            glow::TEXTURE_2D_ARRAY_MULTISAMPLE
+                            glow::TEXTURE_2D_MULTISAMPLE_ARRAY
                         }
                     } else {
                         if desc.sample_count <= 1 {

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -402,6 +402,7 @@ pub struct TextureDesc<'a> {
     pub size: Extent,
     pub array_layer_count: u32,
     pub mip_level_count: u32,
+    pub sample_count: u32,
     pub dimension: TextureDimension,
     pub usage: TextureUsage,
 }
@@ -1018,12 +1019,31 @@ pub struct RenderPipelineDesc<'a> {
     pub depth_stencil: Option<DepthStencilState>,
     pub fragment: ShaderFunction<'a>,
     pub color_targets: &'a [ColorTargetState],
+    pub multisample_state: MultisampleState,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MultisampleState {
+    pub sample_count: u32,
+    pub sample_mask: u64,
+    pub alpha_to_coverage: bool,
+}
+
+impl Default for MultisampleState {
+    fn default() -> Self {
+        Self {
+            sample_count: 1,
+            sample_mask: !0,
+            alpha_to_coverage: false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
 pub enum InitOp {
     Load,
     Clear(TextureColor),
+    DontCare,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -1050,7 +1050,7 @@ pub enum InitOp {
 pub enum FinishOp {
     Store,
     Discard,
-    /// The resolved texture will be stored but it is undefined what
+    /// The texture specified here will be stored but it is undefined what
     /// happens to the original render target
     ResolveTo(TextureView),
     Ignore,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -1050,6 +1050,8 @@ pub enum InitOp {
 pub enum FinishOp {
     Store,
     Discard,
+    /// The resolved texture will be stored but it is undefined what
+    /// happens to the original render target
     ResolveTo(TextureView),
     Ignore,
 }

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -217,6 +217,7 @@ impl super::CommandEncoder {
                         at_descriptor.set_clear_color(clear_color);
                         metal::MTLLoadAction::Clear
                     }
+                    crate::InitOp::DontCare => metal::MTLLoadAction::DontCare,
                 };
                 at_descriptor.set_load_action(load_action);
 
@@ -247,6 +248,7 @@ impl super::CommandEncoder {
                         at_descriptor.set_clear_depth(clear_depth);
                         metal::MTLLoadAction::Clear
                     }
+                    crate::InitOp::DontCare => metal::MTLLoadAction::DontCare,
                 };
                 let store_action = match rt.finish_op {
                     crate::FinishOp::Store | crate::FinishOp::Ignore => {

--- a/blade-graphics/src/metal/pipeline.rs
+++ b/blade-graphics/src/metal/pipeline.rs
@@ -420,6 +420,8 @@ impl crate::traits::ShaderDevice for super::Context {
                 },
             );
             descriptor.set_vertex_function(Some(&vs.function));
+            descriptor.set_raster_sample_count(desc.multisample_state.sample_count as _);
+            descriptor.set_alpha_to_coverage_enabled(desc.multisample_state.alpha_to_coverage);
 
             // Fragment shader
             let fs = self.load_shader(

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -181,7 +181,11 @@ impl crate::traits::ResourceDevice for super::Context {
                 if desc.array_layer_count > 1 {
                     metal::MTLTextureType::D2Array
                 } else {
-                    metal::MTLTextureType::D2
+                    if desc.sample_count <= 1 {
+                        metal::MTLTextureType::D2
+                    } else {
+                        metal::MTLTextureType::D2Multisample
+                    }
                 }
             }
             crate::TextureDimension::D3 => metal::MTLTextureType::D3,
@@ -198,6 +202,7 @@ impl crate::traits::ResourceDevice for super::Context {
             descriptor.set_array_length(desc.array_layer_count as u64);
             descriptor.set_mipmap_level_count(desc.mip_level_count as u64);
             descriptor.set_pixel_format(mtl_format);
+            descriptor.set_sample_count(desc.sample_count as _);
             descriptor.set_usage(mtl_usage);
             descriptor.set_storage_mode(metal::MTLStorageMode::Private);
 

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -179,7 +179,11 @@ impl crate::traits::ResourceDevice for super::Context {
             }
             crate::TextureDimension::D2 => {
                 if desc.array_layer_count > 1 {
-                    metal::MTLTextureType::D2Array
+                    if desc.sample_count <= 1 {
+                        metal::MTLTextureType::D2Array
+                    } else {
+                        metal::MTLTextureType::D2MultisampleArray
+                    }
                 } else {
                     if desc.sample_count <= 1 {
                         metal::MTLTextureType::D2

--- a/blade-graphics/src/vulkan/pipeline.rs
+++ b/blade-graphics/src/vulkan/pipeline.rs
@@ -503,9 +503,16 @@ impl crate::traits::ShaderDevice for super::Context {
             .scissor_count(1)
             .viewport_count(1);
 
-        let vk_sample_mask = [1u32, 0];
+        let vk_sample_mask = [
+            desc.multisample_state.sample_mask as u32,
+            (desc.multisample_state.sample_mask >> 32) as u32,
+        ];
+
         let vk_multisample = vk::PipelineMultisampleStateCreateInfo::default()
-            .rasterization_samples(vk::SampleCountFlags::TYPE_1)
+            .rasterization_samples(vk::SampleCountFlags::from_raw(
+                desc.multisample_state.sample_count,
+            ))
+            .alpha_to_coverage_enable(desc.multisample_state.alpha_to_coverage)
             .sample_mask(&vk_sample_mask);
 
         let mut d_format = vk::Format::UNDEFINED;

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -252,7 +252,7 @@ impl crate::traits::ResourceDevice for super::Context {
         let mut create_flags = vk::ImageCreateFlags::empty();
         if desc.dimension == crate::TextureDimension::D2
             && desc.size.depth % 6 == 0
-            //&& desc.sample_count == 1
+            && desc.sample_count == 1
             && desc.size.width == desc.size.height
         {
             create_flags |= vk::ImageCreateFlags::CUBE_COMPATIBLE;
@@ -265,13 +265,17 @@ impl crate::traits::ResourceDevice for super::Context {
             extent: super::map_extent_3d(&desc.size),
             mip_levels: desc.mip_level_count,
             array_layers: desc.array_layer_count,
-            samples: vk::SampleCountFlags::from_raw(1), // desc.sample_count
+            samples: vk::SampleCountFlags::from_raw(desc.sample_count),
             tiling: vk::ImageTiling::OPTIMAL,
             usage: map_texture_usage(desc.usage, desc.format.aspects()),
             sharing_mode: vk::SharingMode::EXCLUSIVE,
             ..Default::default()
         };
 
+        /*
+            TODO(ErikWDev): Support lazily allocated texture with transient allocation for efficient msaa?
+                            Measure bandwidth usage!
+        */
         let raw = unsafe { self.device.core.create_image(&vk_info, None).unwrap() };
         let requirements = unsafe { self.device.core.get_image_memory_requirements(raw) };
         let allocation = self.allocate_memory(requirements, crate::Memory::Device);

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -95,6 +95,7 @@ fn create_draw_pipeline(
             blend: Some(blade_graphics::BlendState::ALPHA_BLENDING),
             write_mask: blade_graphics::ColorWrites::all(),
         }],
+        multisample_state: blade_graphics::MultisampleState::default(),
     })
 }
 
@@ -117,6 +118,7 @@ fn create_blit_pipeline(
         depth_stencil: None,
         fragment: shader.at("blit_fs"),
         color_targets: &[format.into()],
+        multisample_state: blade_graphics::MultisampleState::default(),
     })
 }
 

--- a/blade-render/src/render/dummy.rs
+++ b/blade-render/src/render/dummy.rs
@@ -29,6 +29,7 @@ impl DummyResources {
             mip_level_count: 1,
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
+            sample_count: 1,
         });
         let white_view = gpu.create_texture_view(
             white_texture,
@@ -47,6 +48,7 @@ impl DummyResources {
             mip_level_count: 1,
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
+            sample_count: 1,
         });
         let black_view = gpu.create_texture_view(
             black_texture,
@@ -65,6 +67,7 @@ impl DummyResources {
             mip_level_count: 1,
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
+            sample_count: 1,
         });
         let red_view = gpu.create_texture_view(
             red_texture,

--- a/blade-render/src/render/env_map.rs
+++ b/blade-render/src/render/env_map.rs
@@ -112,6 +112,7 @@ impl EnvironmentMap {
             array_layer_count: 1,
             mip_level_count,
             usage: blade_graphics::TextureUsage::RESOURCE | blade_graphics::TextureUsage::STORAGE,
+            sample_count: 1,
         });
         self.weight_view = gpu.create_texture_view(
             self.weight_texture,

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -178,6 +178,7 @@ impl<const N: usize> RenderTarget<N> {
             array_layer_count: N as u32,
             mip_level_count: 1,
             usage: blade_graphics::TextureUsage::RESOURCE | blade_graphics::TextureUsage::STORAGE,
+            sample_count: 1,
         });
         encoder.init_texture(texture);
 
@@ -605,6 +606,7 @@ impl ShaderPipelines {
             fragment: shader.at("postfx_fs"),
             color_targets: &[info.format.into()],
             depth_stencil: None,
+            multisample_state: blade_graphics::MultisampleState::default(),
         })
     }
 

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -396,6 +396,7 @@ impl blade_asset::Baker for Baker {
                 mip_level_count: image.mips.len() as u32,
                 dimension: blade_graphics::TextureDimension::D2,
                 usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
+                sample_count: 1,
             });
         let view = self.gpu_context.create_texture_view(
             texture,

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -123,6 +123,7 @@ impl Example {
                 blend: Some(gpu::BlendState::ALPHA_BLENDING),
                 write_mask: gpu::ColorWrites::default(),
             }],
+            multisample_state: gpu::MultisampleState::default(),
         });
 
         let extent = gpu::Extent {
@@ -138,6 +139,7 @@ impl Example {
             array_layer_count: 1,
             mip_level_count: 1,
             usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::COPY,
+            sample_count: 1,
         });
         let view = context.create_texture_view(
             texture,

--- a/examples/init/main.rs
+++ b/examples/init/main.rs
@@ -29,6 +29,7 @@ impl EnvMapSampler {
             mip_level_count: 1,
             dimension: gpu::TextureDimension::D2,
             usage: gpu::TextureUsage::TARGET,
+            sample_count: 1,
         });
         let accum_view = context.create_texture_view(
             accum_texture,
@@ -57,6 +58,7 @@ impl EnvMapSampler {
                 blend: None,
                 write_mask: gpu::ColorWrites::ALL,
             }],
+            multisample_state: gpu::MultisampleState::default(),
         });
         let accum_pipeline = context.create_render_pipeline(gpu::RenderPipelineDesc {
             name: "env-accum",
@@ -74,6 +76,7 @@ impl EnvMapSampler {
                 blend: Some(gpu::BlendState::ADDITIVE),
                 write_mask: gpu::ColorWrites::RED,
             }],
+            multisample_state: gpu::MultisampleState::default(),
         });
 
         Self {

--- a/examples/mini/main.rs
+++ b/examples/mini/main.rs
@@ -59,6 +59,7 @@ fn main() {
         array_layer_count: 1,
         mip_level_count,
         usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::STORAGE | gpu::TextureUsage::COPY,
+        sample_count: 1,
     });
     let views = (0..mip_level_count)
         .map(|i| {

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -371,7 +371,9 @@ fn main() {
                             let control_flow = if let Some(repaint_after_instant) =
                                 std::time::Instant::now().checked_add(repaint_delay)
                             {
-                                winit::event_loop::ControlFlow::WaitUntil(repaint_after_instant)
+                                winit::event_loop::ControlFlow::WaitUntil(
+                                    repaint_after_instant.into(),
+                                )
                             } else {
                                 winit::event_loop::ControlFlow::Wait
                             };

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -242,7 +242,6 @@ impl Example {
     }
 
     fn add_gui(&mut self, ui: &mut egui::Ui) {
-        ui.add_space(5.0);
         ui.heading("Particle System");
         self.particle_system.add_gui(ui);
 
@@ -260,6 +259,7 @@ impl Example {
                             self.context.wait_for(&sp, !0);
                         }
 
+                        let old_params = self.particle_system.params;
                         self.particle_system.destroy(&self.context);
                         self.particle_system = particle::System::new(
                             &self.context,
@@ -270,6 +270,8 @@ impl Example {
                             },
                             self.sample_count,
                         );
+                        self.particle_system.params = old_params;
+
                         if let Some(msaa_view) = self.msaa_view.take() {
                             self.context.destroy_texture_view(msaa_view);
                         }
@@ -351,7 +353,10 @@ fn main() {
                             let raw_input = egui_winit.take_egui_input(&window);
                             let egui_output = egui_winit.egui_ctx().run(raw_input, |egui_ctx| {
                                 egui::SidePanel::left("info").show(egui_ctx, |ui| {
+                                    ui.add_space(5.0);
                                     example.add_gui(ui);
+
+                                    ui.add_space(5.0);
                                     if ui.button("Quit").clicked() {
                                         target.exit();
                                     }

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -251,7 +251,7 @@ impl Example {
         egui::ComboBox::new("msaa dropdown", "MSAA samples")
             .selected_text(format!("x{}", self.sample_count))
             .show_ui(ui, |ui| {
-                for i in [1, 2, 4, 8] {
+                for i in [1, 2, 4] {
                     if ui
                         .selectable_value(&mut self.sample_count, i, format!("x{i}"))
                         .changed()
@@ -266,7 +266,7 @@ impl Example {
                             particle::SystemDesc {
                                 name: "particle system",
                                 capacity: 100_000,
-                                draw_format: gpu::TextureFormat::Bgra8Unorm, // TODO: get real surface format..
+                                draw_format: self.surface.info().format,
                             },
                             self.sample_count,
                         );

--- a/examples/particle/particle.rs
+++ b/examples/particle/particle.rs
@@ -112,6 +112,7 @@ impl System {
                 write_mask: gpu::ColorWrites::default(),
             }],
             depth_stencil: None,
+            multisample_state: gpu::MultisampleState::default(),
         });
 
         let wg_width = reset_pipeline.get_workgroup_size()[0] as usize;

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -82,6 +82,7 @@ impl Example {
             dimension: gpu::TextureDimension::D2,
             array_layer_count: 1,
             mip_level_count: 1,
+            sample_count: 1,
             usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::STORAGE,
         });
         let target_view = context.create_texture_view(
@@ -115,6 +116,7 @@ impl Example {
             fragment: shader.at("draw_fs"),
             color_targets: &[surface.info().format.into()],
             depth_stencil: None,
+            multisample_state: Default::default(),
         });
 
         let (indices, vertex_values) =

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -228,7 +228,7 @@ impl Example {
             &render_config,
         );
         pacer.end_frame(&context);
-        let gui_painter = blade_egui::GuiPainter::new(surface_info, &context);
+        let gui_painter = blade_egui::GuiPainter::new(surface_info, &context, 1);
 
         Self {
             scene_path: PathBuf::new(),

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -228,7 +228,7 @@ impl Example {
             &render_config,
         );
         pacer.end_frame(&context);
-        let gui_painter = blade_egui::GuiPainter::new(surface_info, &context, 1);
+        let gui_painter = blade_egui::GuiPainter::new(surface_info, &context);
 
         Self {
             scene_path: PathBuf::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ impl Engine {
 
         pacer.end_frame(&gpu_context);
 
-        let gui_painter = blade_egui::GuiPainter::new(surface_info, &gpu_context, 1);
+        let gui_painter = blade_egui::GuiPainter::new(surface_info, &gpu_context);
         let mut physics = Physics::default();
         physics.debug_pipeline.mode = rapier3d::pipeline::DebugRenderMode::empty();
         physics.integration_params.dt = config.time_step;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ impl Engine {
 
         pacer.end_frame(&gpu_context);
 
-        let gui_painter = blade_egui::GuiPainter::new(surface_info, &gpu_context);
+        let gui_painter = blade_egui::GuiPainter::new(surface_info, &gpu_context, 1);
         let mut physics = Physics::default();
         physics.debug_pipeline.mode = rapier3d::pipeline::DebugRenderMode::empty();
         physics.integration_params.dt = config.time_step;


### PR DESCRIPTION
closes #198 

### Changes
This PR introduces a `sample_count: u32` to `TextureDesc` as well as a `multisample_state: MultisampleState` to the `RenderPipelineDesc`. Also added `alpha_to_coverage` while at it.

```rust
#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
pub struct MultisampleState {
    pub sample_count: u32,
    pub sample_mask: u64,
    pub alpha_to_coverage: bool,
}

impl Default for MultisampleState {
    fn default() -> Self {
        Self {
            sample_count: 1,
            sample_mask: !0,
            alpha_to_coverage: false,
        }
    }
}
```

Together with the existing `FinishOp::ResolveTo(TextureView)`, a multisampled renderpass can now be described and executed


### Implementations
<details>
  <summary>Vulkan</summary>


The rendering attachment needs to be told to resolve
```rust
if let crate::FinishOp::ResolveTo(resolve_view) = rt.finish_op {
    vk_info = vk_info
        .resolve_image_view(resolve_view.raw)
        .resolve_image_layout(vk::ImageLayout::GENERAL)
        .resolve_mode(vk::ResolveModeFlags::AVERAGE);
}

```

The store_op is currently always set to `DONT_CARE` as in many cases for msaa rendering the resolved texture is the only one required. Would be nice to be able to specify this behaviour in blade as well though: 

```rust
vk_info.store_op = match rt.finish_op {
    crate::FinishOp::ResolveTo(..) => {
        /*
            TODO: DONT_CARE is most optimal in many cases where the msaa texture itself is never read afterwards but only the resolved,
                  but how can the user specify this in blade?
                  https://docs.vulkan.org/samples/latest/samples/performance/msaa/README.html#_best_practice_summary
        */

        // vk::AttachmentStoreOp::STORE
        vk::AttachmentStoreOp::DONT_CARE
    }
};

```

For the texture creation, a `SampleCountFlags` is constructed for the `vk::ImageCreateInfo`:
```rust
/// in vulkan/resource.rs:268
samples: vk::SampleCountFlags::from_raw(desc.sample_count),
```

and for the pipeline, I looked at how wgpu does it and came to the following code

```rust
let vk_sample_mask = [
    desc.multisample_state.sample_mask as u32,
    (desc.multisample_state.sample_mask >> 32) as u32,
];

let vk_multisample = vk::PipelineMultisampleStateCreateInfo::default()
    .rasterization_samples(vk::SampleCountFlags::from_raw(
        desc.multisample_state.sample_count,
    ))
    .alpha_to_coverage_enable(desc.multisample_state.alpha_to_coverage)
    .sample_mask(&vk_sample_mask);

```
  
</details>

<details>
  <summary>Metal</summary>
The metal backend already had support for the `ResolveTo` finishop so no changes needed for the renderpipeline. The creation of the renderpipeline required description though:

```rust
descriptor.set_raster_sample_count(desc.multisample_state.sample_count);
descriptor.set_alpha_to_coverage_enabled(desc.multisample_state.alpha_to_coverage);
```

For the texture, only specifying the sample_count was required

```rust
/// in metal/resource.rs:205
descriptor.set_sample_count(desc.sample_count as u64);
```
</details>

<details>
  <summary>OpenGL ES</summary>

This was the hardest one as I am very unfamiliar with msaa in opengl, but in summary the texture needs to be created with `renderbuffer_storage_multisample` if it is a rendertarget and with a `glow::TEXTURE_2D_MULTISAMPLE` target type if it is a normal texture.

The sample count is then set with `tex_storage_2d_multisample`, but there is now no-longer a way to specify `mip_count` so don't know if that is even possible.
```rust
/*
    TODO(ErikWDev): How to set mip count and sample count? Not possible in gles?
*/
gl.tex_storage_2d_multisample(
    target,
    desc.sample_count as i32,
    format_desc.internal,
    desc.size.width as i32,
    desc.size.height as i32,
    true,
);
```


For the rendering, I use `blit_framebuffer` to blit the msaa texture onto the resolve target which required turning the renderbuffers into FBO:s. Currently, the FBO:s are created and deleted ad-hoc but could be saved as done in wgpu-hal. See #198

```rust
/// in gles/command.rs:814
Self::BlitFramebuffer { from, to } => {
    /*
        TODO(ErikWDev): Validate
    */

    let target_from = match from.inner {
        super::TextureInner::Renderbuffer { raw } => raw,
        _ => panic!("Unsupported resolve between non-renderbuffers"),
    };
    let target_to = match to.inner {
        super::TextureInner::Renderbuffer { raw } => raw,
        _ => panic!("Unsupported resolve between non-renderbuffers"),
    };

    let framebuf_from = gl.create_framebuffer().unwrap();
    let framebuf_to = gl.create_framebuffer().unwrap();

    gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(framebuf_from));
    gl.framebuffer_renderbuffer(
        glow::READ_FRAMEBUFFER,
        glow::COLOR_ATTACHMENT0, // NOTE: Assuming color attachment
        glow::RENDERBUFFER,
        Some(target_from),
    );

    gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, Some(framebuf_to));
    gl.framebuffer_renderbuffer(
        glow::DRAW_FRAMEBUFFER,
        glow::COLOR_ATTACHMENT0, // NOTE: Assuming color attachment
        glow::RENDERBUFFER,
        Some(target_to),
    );
    assert_eq!(
        gl.check_framebuffer_status(glow::DRAW_FRAMEBUFFER),
        glow::FRAMEBUFFER_COMPLETE,
        "DRAW_FRAMEBUFFER is not complete"
    );

    gl.blit_framebuffer(
        0,
        0,
        from.target_size[0] as _,
        from.target_size[1] as _,
        0,
        0,
        to.target_size[0] as _,
        to.target_size[1] as _,
        glow::COLOR_BUFFER_BIT, // NOTE: Assuming color
        glow::NEAREST,
    );

    gl.bind_framebuffer(glow::READ_FRAMEBUFFER, None);
    gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None);

    gl.delete_framebuffer(framebuf_from);
    gl.delete_framebuffer(framebuf_to);
}


``` 


</details>

### Testing
The vulkan implementation has been validated on an AMD RX 6600 on debian, an integrated intel GPU on Fedora as well as a GTX 1050 on Windows and it all seems to work (the particle sample). After inspection in renderdoc the result is as expected.

The metal implementation has been tested on a Mac Mini M4 and works. However, particle example seems to break after the sample count is adjusted in runtime for some reason.

The Opengl ES implementation has **not been tested**!!!

### Particle Example
I changed the particle example to now utilize msaa which requires it to keep a msaa texture with the desired `sample_count` available and recreated upon resizing as well as a FinishOp::ResolveTo to resolve the msaa texture to the acquired frame texture as such:

```rust
if let mut pass = self.command_encoder.render(
    "draw",
    gpu::RenderTargetSet {
        colors: &[gpu::RenderTarget {
            view: self.msaa_view,
            init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
            finish_op: gpu::FinishOp::ResolveTo(frame.texture_view()),
        }],
        depth_stencil: None,
    },
) {
    self.particle_system
        .draw(&mut pass, screen_desc.physical_size);
    self.gui_painter
        .paint(&mut pass, gui_primitives, screen_desc, &self.context);
}
``` 

### Egui
Furthermore, the `blade_egui` renderer also requires information about the multisample state since it has a pipeline that now needs information about the texture it's going to render to so it's initializer now takes a sample_count as well:

```rust
pub fn new(
    info: blade_graphics::SurfaceInfo,
    context: &blade_graphics::Context,
    sample_count: u32,
) -> GuiPainter {
// ...
}
```

---

Let me know what needs changing or if testing fails somewhere. Especially the Opengl ES implementation as I didn't know how to run using it