### PR TITLE
egui: switch to gamma space blending, fix blend mode

### DIFF
--- a/blade-egui/shader.wgsl
+++ b/blade-egui/shader.wgsl
@@ -21,10 +21,10 @@ struct Vertex {
 }
 var<storage, read> r_vertex_data: array<Vertex>;
 
-fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
-    let cutoff = srgb < vec3<f32>(10.31475);
-    let lower = srgb / vec3<f32>(3294.6);
-    let higher = pow((srgb + vec3<f32>(14.025)) / vec3<f32>(269.025), vec3<f32>(2.4));
+fn linear_from_gamma(srgb: vec3<f32>) -> vec3<f32> {
+    let cutoff = srgb < vec3<f32>(0.04045);
+    let lower = srgb / vec3<f32>(12.92);
+    let higher = pow((srgb + vec3<f32>(0.055)) / vec3<f32>(1.055), vec3<f32>(2.4));
     return select(higher, lower, cutoff);
 }
 
@@ -35,8 +35,7 @@ fn vs_main(
     let input = r_vertex_data[v_index];
     var out: VertexOutput;
     out.tex_coord = vec2<f32>(input.tex_coord_x, input.tex_coord_y);
-    let color = unpack4x8unorm(input.color);
-    out.color = vec4<f32>(pow(color.xyz, vec3<f32>(2.2)), color.a);
+    out.color = unpack4x8unorm(input.color);
     out.position = vec4<f32>(
         2.0 * input.pos_x / r_uniforms.screen_size.x - 1.0,
         1.0 - 2.0 * input.pos_y / r_uniforms.screen_size.y,
@@ -51,5 +50,9 @@ var r_sampler: sampler;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    return in.color * textureSample(r_texture, r_sampler, in.tex_coord);
+    //Note: we always assume rendering to linear color space,
+    // but Egui wants to blend in gamma space, see
+    // https://github.com/emilk/egui/pull/2071
+    let blended = in.color * textureSample(r_texture, r_sampler, in.tex_coord);
+    return vec4f(linear_from_gamma(blended.xyz), blended.a);
 }

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -62,7 +62,7 @@ struct GuiTexture {
 
 impl GuiTexture {
     fn create(context: &blade_graphics::Context, name: &str, size: blade_graphics::Extent) -> Self {
-        let format = blade_graphics::TextureFormat::Rgba8UnormSrgb;
+        let format = blade_graphics::TextureFormat::Rgba8Unorm;
         let allocation = context.create_texture(blade_graphics::TextureDesc {
             name,
             format,
@@ -147,7 +147,18 @@ impl GuiPainter {
             fragment: shader.at("fs_main"),
             color_targets: &[blade_graphics::ColorTargetState {
                 format: info.format,
-                blend: Some(blade_graphics::BlendState::ALPHA_BLENDING),
+                blend: Some(blade_graphics::BlendState {
+                    color: blade_graphics::BlendComponent {
+                        src_factor: blade_graphics::BlendFactor::One,
+                        dst_factor: blade_graphics::BlendFactor::OneMinusSrcAlpha,
+                        operation: blade_graphics::BlendOperation::Add,
+                    },
+                    alpha: blade_graphics::BlendComponent {
+                        src_factor: blade_graphics::BlendFactor::OneMinusDstAlpha,
+                        dst_factor: blade_graphics::BlendFactor::One,
+                        operation: blade_graphics::BlendOperation::Add,
+                    },
+                }),
                 write_mask: blade_graphics::ColorWrites::all(),
             }],
         });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ Changelog for Blade
     - destroy old surface on resize
   - Vulkan:
     - support unused bind groups
+- egui:
+  - fix blending color space
 
 ## blade-egui-0.5 (09 Nov 2024)
 


### PR DESCRIPTION
Fixes #215

Should match https://github.com/emilk/egui/pull/2071 now. With the caveat that upstream is still using an srgb target for some reason, while my PR is switching it to a regular unorm to avoid extra conversion.

Old:
![gamma-before](https://github.com/user-attachments/assets/d44de0b4-b724-484e-879b-e7559aa7511a)

New:
![gamma-after2](https://github.com/user-attachments/assets/40f1036c-179b-4ead-bc8d-2f12369f5732)
