### PR TITLE
Egui, one sampler per texture

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -32,13 +32,13 @@ struct Uniforms {
 #[derive(blade_macros::ShaderData)]
 struct Globals {
     r_uniforms: Uniforms,
-    r_sampler: blade_graphics::Sampler,
 }
 
 #[derive(blade_macros::ShaderData)]
 struct Locals {
     r_vertex_data: blade_graphics::BufferPiece,
     r_texture: blade_graphics::TextureView,
+    r_sampler: blade_graphics::Sampler,
 }
 
 #[derive(Debug, PartialEq)]
@@ -58,10 +58,24 @@ impl ScreenDescriptor {
 struct GuiTexture {
     allocation: blade_graphics::Texture,
     view: blade_graphics::TextureView,
+    sampler: blade_graphics::Sampler,
+}
+
+#[inline]
+const fn egui_texture_filter_to_blade(filter: egui::TextureFilter) -> blade_graphics::FilterMode {
+    match filter {
+        egui::TextureFilter::Nearest => blade_graphics::FilterMode::Nearest,
+        egui::TextureFilter::Linear => blade_graphics::FilterMode::Linear,
+    }
 }
 
 impl GuiTexture {
-    fn create(context: &blade_graphics::Context, name: &str, size: blade_graphics::Extent) -> Self {
+    fn create(
+        context: &blade_graphics::Context,
+        name: &str,
+        size: blade_graphics::Extent,
+        options: egui::TextureOptions,
+    ) -> Self {
         let format = blade_graphics::TextureFormat::Rgba8Unorm;
         let allocation = context.create_texture(blade_graphics::TextureDesc {
             name,
@@ -81,12 +95,38 @@ impl GuiTexture {
                 subresources: &blade_graphics::TextureSubresources::default(),
             },
         );
-        Self { allocation, view }
+        let sampler = context.create_sampler(blade_graphics::SamplerDesc {
+            name,
+            address_modes: {
+                let mode = match options.wrap_mode {
+                    egui::TextureWrapMode::ClampToEdge => blade_graphics::AddressMode::ClampToEdge,
+                    egui::TextureWrapMode::Repeat => blade_graphics::AddressMode::Repeat,
+                    egui::TextureWrapMode::MirroredRepeat => {
+                        blade_graphics::AddressMode::MirrorRepeat
+                    }
+                };
+                [mode; 3]
+            },
+            mag_filter: egui_texture_filter_to_blade(options.magnification),
+            min_filter: egui_texture_filter_to_blade(options.minification),
+            mipmap_filter: options
+                .mipmap_mode
+                .map(egui_texture_filter_to_blade)
+                .unwrap_or_default(),
+
+            ..Default::default()
+        });
+        Self {
+            allocation,
+            view,
+            sampler,
+        }
     }
 
     fn delete(self, context: &blade_graphics::Context) {
         context.destroy_texture(self.allocation);
         context.destroy_texture_view(self.view);
+        context.destroy_sampler(self.sampler);
     }
 }
 
@@ -103,7 +143,6 @@ pub struct GuiPainter {
     //TODO: this could also look better
     textures_dropped: Vec<GuiTexture>,
     textures_to_delete: Vec<(GuiTexture, blade_graphics::SyncPoint)>,
-    sampler: blade_graphics::Sampler,
 }
 
 impl GuiPainter {
@@ -120,7 +159,6 @@ impl GuiPainter {
         for (gui_texture, _) in self.textures_to_delete.drain(..) {
             gui_texture.delete(context);
         }
-        context.destroy_sampler(self.sampler);
     }
 
     /// Create a new painter with a given GPU context.
@@ -169,21 +207,12 @@ impl GuiPainter {
             alignment: 4,
         });
 
-        let sampler = context.create_sampler(blade_graphics::SamplerDesc {
-            name: "gui",
-            address_modes: [blade_graphics::AddressMode::ClampToEdge; 3],
-            mag_filter: blade_graphics::FilterMode::Linear,
-            min_filter: blade_graphics::FilterMode::Linear,
-            ..Default::default()
-        });
-
         Self {
             pipeline,
             belt,
             textures: Default::default(),
             textures_dropped: Vec::new(),
             textures_to_delete: Vec::new(),
-            sampler,
         }
     }
 
@@ -250,7 +279,8 @@ impl GuiPainter {
             let texture = match self.textures.entry(texture_id) {
                 Entry::Occupied(mut o) => {
                     if image_delta.pos.is_none() {
-                        let texture = GuiTexture::create(context, &label, extent);
+                        let texture =
+                            GuiTexture::create(context, &label, extent, image_delta.options);
                         command_encoder.init_texture(texture.allocation);
                         let old = o.insert(texture);
                         self.textures_dropped.push(old);
@@ -258,7 +288,7 @@ impl GuiPainter {
                     o.into_mut()
                 }
                 Entry::Vacant(v) => {
-                    let texture = GuiTexture::create(context, &label, extent);
+                    let texture = GuiTexture::create(context, &label, extent, image_delta.options);
                     command_encoder.init_texture(texture.allocation);
                     v.insert(texture)
                 }
@@ -309,7 +339,6 @@ impl GuiPainter {
                     screen_size: [logical_size.0, logical_size.1],
                     padding: [0.0; 2],
                 },
-                r_sampler: self.sampler,
             },
         );
 
@@ -351,6 +380,7 @@ impl GuiPainter {
                     &Locals {
                         r_vertex_data: vertex_buf,
                         r_texture: texture.view,
+                        r_sampler: texture.sampler,
                     },
                 );
 


### PR DESCRIPTION
During the egui investigation you mentioned the difference in samplers in blade implementation https://github.com/kvark/blade/issues/215#issuecomment-2524854147.

Extracted the code from the PR #216 that creates a sampler per texture if interesting.

One could create only the sampler permutations requested and lookup based on the options hash during rendering, but this felt simpler

This does not address any issue I have seen, so could also be left as is.

