### PR TITLE
Support some more texture formats

### DIFF
--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -632,12 +632,7 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
             glow::RGBA,
             glow::UNSIGNED_INT_2_10_10_10_REV,
         ),
-        Tf::Bgr10a2Unorm => (
-            glow::RGB10_A2, // TODO: Unsupported?
-            glow::BGRA,
-            glow::UNSIGNED_INT_2_10_10_10_REV,
-        ),
-        Tf::Rg11b10Float => (
+        Tf::Rg11b10Ufloat => (
             glow::R11F_G11F_B10F,
             glow::RGB,
             glow::UNSIGNED_INT_10F_11F_11F_REV,

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -624,7 +624,7 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
         Tf::Bc5Unorm => (glow::COMPRESSED_RG_RGTC2, glow::RG, 0),
         Tf::Bc5Snorm => (glow::COMPRESSED_SIGNED_RG_RGTC2, glow::RG, 0),
         Tf::Bc6hUfloat => (glow::COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT, glow::RGB, 0),
-        Tf::Bc6hSfloat => (glow::COMPRESSED_RGB_BPTC_SIGNED_FLOAT, glow::RGB, 0),
+        Tf::Bc6hFloat => (glow::COMPRESSED_RGB_BPTC_SIGNED_FLOAT, glow::RGB, 0),
         Tf::Bc7Unorm => (glow::COMPRESSED_RGBA_BPTC_UNORM, glow::RGBA, 0),
         Tf::Bc7UnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_BPTC_UNORM, glow::RGBA, 0),
         Tf::Rgb10a2Unorm => (

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -603,8 +603,9 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
         Tf::Bgra8Unorm => (glow::RGBA8, glow::BGRA, glow::UNSIGNED_BYTE),
         Tf::Bgra8UnormSrgb => (glow::SRGB8_ALPHA8, glow::BGRA, glow::UNSIGNED_BYTE),
         Tf::Rgba8Snorm => (glow::RGBA8, glow::RGBA, glow::BYTE),
-        Tf::R16Float => (glow::R16F, glow::RED, glow::FLOAT),
-        Tf::Rgba16Float => (glow::RGBA16F, glow::RGBA, glow::FLOAT),
+        Tf::R16Float => (glow::R16F, glow::RED, glow::HALF_FLOAT),
+        Tf::Rg16Float => (glow::RG16F, glow::RG, glow::HALF_FLOAT),
+        Tf::Rgba16Float => (glow::RGBA16F, glow::RGBA, glow::HALF_FLOAT),
         Tf::R32Float => (glow::R32F, glow::RED, glow::FLOAT),
         Tf::Rg32Float => (glow::RG32F, glow::RG, glow::FLOAT),
         Tf::Rgba32Float => (glow::RGBA32F, glow::RGBA, glow::FLOAT),
@@ -622,6 +623,26 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
         Tf::Bc4Snorm => (glow::COMPRESSED_SIGNED_RED_RGTC1, glow::RED, 0),
         Tf::Bc5Unorm => (glow::COMPRESSED_RG_RGTC2, glow::RG, 0),
         Tf::Bc5Snorm => (glow::COMPRESSED_SIGNED_RG_RGTC2, glow::RG, 0),
+        Tf::Bc6hUfloat => (glow::COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT, glow::RGB, 0),
+        Tf::Bc6hSfloat => (glow::COMPRESSED_RGB_BPTC_SIGNED_FLOAT, glow::RGB, 0),
+        Tf::Bc7Unorm => (glow::COMPRESSED_RGBA_BPTC_UNORM, glow::RGBA, 0),
+        Tf::Bc7UnormSrgb => (glow::COMPRESSED_SRGB_ALPHA_BPTC_UNORM, glow::RGBA, 0),
+        Tf::Rgb10a2Unorm => (
+            glow::RGB10_A2,
+            glow::RGBA,
+            glow::UNSIGNED_INT_2_10_10_10_REV,
+        ),
+        Tf::Bgr10a2Unorm => (
+            glow::RGB10_A2, // TODO: Unsupported?
+            glow::BGRA,
+            glow::UNSIGNED_INT_2_10_10_10_REV,
+        ),
+        Tf::Rg11b10Float => (
+            glow::R11F_G11F_B10F,
+            glow::RGB,
+            glow::UNSIGNED_INT_10F_11F_11F_REV,
+        ),
+        Tf::Rgb9e5Ufloat => (glow::RGB9_E5, glow::RGB, glow::UNSIGNED_INT_5_9_9_9_REV),
     };
     FormatInfo {
         internal,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -309,7 +309,7 @@ pub enum TextureFormat {
     Bc5Unorm,
     Bc5Snorm,
     Bc6hUfloat,
-    Bc6hSfloat,
+    Bc6hFloat,
     Bc7Unorm,
     Bc7UnormSrgb,
     // packed 32-bit

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -308,15 +308,15 @@ pub enum TextureFormat {
     Bc4Snorm,
     Bc5Unorm,
     Bc5Snorm,
-    Bc6UFloat,
-    Bc6SFloat,
+    Bc6hUfloat,
+    Bc6hSfloat,
     Bc7Unorm,
     Bc7UnormSrgb,
     // packed 32-bit
     Rgb10a2Unorm,
     Bgr10a2Unorm,
     Rg11b10Float,
-    Rgb9e5Float,
+    Rgb9e5Ufloat,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -287,6 +287,7 @@ pub enum TextureFormat {
     Bgra8UnormSrgb,
     Rgba8Snorm,
     R16Float,
+    Rg16Float,
     Rgba16Float,
     R32Float,
     Rg32Float,
@@ -307,6 +308,15 @@ pub enum TextureFormat {
     Bc4Snorm,
     Bc5Unorm,
     Bc5Snorm,
+    Bc6UFloat,
+    Bc6SFloat,
+    Bc7Unorm,
+    Bc7UnormSrgb,
+    // packed 32-bit
+    Rgb10a2Unorm,
+    Bgr10a2Unorm,
+    Rg11b10Float,
+    Rgb9e5Float,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -314,8 +314,7 @@ pub enum TextureFormat {
     Bc7UnormSrgb,
     // packed 32-bit
     Rgb10a2Unorm,
-    Bgr10a2Unorm,
-    Rg11b10Float,
+    Rg11b10Ufloat,
     Rgb9e5Ufloat,
 }
 

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -335,7 +335,7 @@ fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {
         Tf::Bc5Unorm => BC5_RGUnorm,
         Tf::Bc5Snorm => BC5_RGSnorm,
         Tf::Bc6hUfloat => BC6H_RGBUfloat,
-        Tf::Bc6hSfloat => BC6H_RGBFloat,
+        Tf::Bc6hFloat => BC6H_RGBFloat,
         Tf::Bc7Unorm => BC7_RGBAUnorm,
         Tf::Bc7UnormSrgb => BC7_RGBAUnorm_sRGB,
         Tf::Rgb10a2Unorm => RGB10A2Unorm,

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -315,6 +315,7 @@ fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {
         Tf::Bgra8UnormSrgb => BGRA8Unorm_sRGB,
         Tf::Rgba8Snorm => RGBA8Snorm,
         Tf::R16Float => R16Float,
+        Tf::Rg16Float => RG16Float,
         Tf::Rgba16Float => RGBA16Float,
         Tf::R32Float => R32Float,
         Tf::Rg32Float => RG32Float,
@@ -333,6 +334,14 @@ fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {
         Tf::Bc4Snorm => BC4_RSnorm,
         Tf::Bc5Unorm => BC5_RGUnorm,
         Tf::Bc5Snorm => BC5_RGSnorm,
+        Tf::Bc6hUfloat => BC6H_RGBUfloat,
+        Tf::Bc6hSfloat => BC6H_RGBFloat,
+        Tf::Bc7Unorm => BC7_RGBAUnorm,
+        Tf::Bc7UnormSrgb => BC7_RGBAUnorm_sRGB,
+        Tf::Rgb10a2Unorm => RGB10A2Unorm,
+        Tf::Bgr10a2Unorm => BGR10A2Unorm,
+        Tf::Rg11b10Float => RG11B10Float,
+        Tf::Rgb9e5Ufloat => RGB9E5Float,
     }
 }
 

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -339,8 +339,7 @@ fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {
         Tf::Bc7Unorm => BC7_RGBAUnorm,
         Tf::Bc7UnormSrgb => BC7_RGBAUnorm_sRGB,
         Tf::Rgb10a2Unorm => RGB10A2Unorm,
-        Tf::Bgr10a2Unorm => BGR10A2Unorm,
-        Tf::Rg11b10Float => RG11B10Float,
+        Tf::Rg11b10Ufloat => RG11B10Float,
         Tf::Rgb9e5Ufloat => RGB9E5Float,
     }
 }

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -84,14 +84,14 @@ impl super::TextureFormat {
             Self::Bc4Snorm => cx_bc(8),
             Self::Bc5Unorm => cx_bc(16),
             Self::Bc5Snorm => cx_bc(16),
-            Self::Bc6UFloat => cx_bc(16),
-            Self::Bc6SFloat => cx_bc(16),
+            Self::Bc6hUfloat => cx_bc(16),
+            Self::Bc6hSfloat => cx_bc(16),
             Self::Bc7Unorm => cx_bc(16),
             Self::Bc7UnormSrgb => cx_bc(16),
             Self::Rgb10a2Unorm => uncompressed(4),
             Self::Bgr10a2Unorm => uncompressed(4),
             Self::Rg11b10Float => uncompressed(4),
-            Self::Rgb9e5Float => uncompressed(4),
+            Self::Rgb9e5Ufloat => uncompressed(4),
         }
     }
 

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -65,6 +65,7 @@ impl super::TextureFormat {
             Self::Bgra8UnormSrgb => uncompressed(4),
             Self::Rgba8Snorm => uncompressed(4),
             Self::R16Float => uncompressed(2),
+            Self::Rg16Float => uncompressed(4),
             Self::Rgba16Float => uncompressed(8),
             Self::R32Float => uncompressed(4),
             Self::Rg32Float => uncompressed(8),
@@ -83,6 +84,14 @@ impl super::TextureFormat {
             Self::Bc4Snorm => cx_bc(8),
             Self::Bc5Unorm => cx_bc(16),
             Self::Bc5Snorm => cx_bc(16),
+            Self::Bc6UFloat => cx_bc(16),
+            Self::Bc6SFloat => cx_bc(16),
+            Self::Bc7Unorm => cx_bc(16),
+            Self::Bc7UnormSrgb => cx_bc(16),
+            Self::Rgb10a2Unorm => uncompressed(4),
+            Self::Bgr10a2Unorm => uncompressed(4),
+            Self::Rg11b10Float => uncompressed(4),
+            Self::Rgb9e5Float => uncompressed(4),
         }
     }
 

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -89,8 +89,7 @@ impl super::TextureFormat {
             Self::Bc7Unorm => cx_bc(16),
             Self::Bc7UnormSrgb => cx_bc(16),
             Self::Rgb10a2Unorm => uncompressed(4),
-            Self::Bgr10a2Unorm => uncompressed(4),
-            Self::Rg11b10Float => uncompressed(4),
+            Self::Rg11b10Ufloat => uncompressed(4),
             Self::Rgb9e5Ufloat => uncompressed(4),
         }
     }

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -85,7 +85,7 @@ impl super::TextureFormat {
             Self::Bc5Unorm => cx_bc(16),
             Self::Bc5Snorm => cx_bc(16),
             Self::Bc6hUfloat => cx_bc(16),
-            Self::Bc6hSfloat => cx_bc(16),
+            Self::Bc6hFloat => cx_bc(16),
             Self::Bc7Unorm => cx_bc(16),
             Self::Bc7UnormSrgb => cx_bc(16),
             Self::Rgb10a2Unorm => uncompressed(4),

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -558,7 +558,7 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::Bc5Unorm => vk::Format::BC5_UNORM_BLOCK,
         Tf::Bc5Snorm => vk::Format::BC5_SNORM_BLOCK,
         Tf::Bc6hUfloat => vk::Format::BC6H_UFLOAT_BLOCK,
-        Tf::Bc6hSfloat => vk::Format::BC6H_SFLOAT_BLOCK,
+        Tf::Bc6hFloat => vk::Format::BC6H_SFLOAT_BLOCK,
         Tf::Bc7Unorm => vk::Format::BC7_UNORM_BLOCK,
         Tf::Bc7UnormSrgb => vk::Format::BC7_SRGB_BLOCK,
         Tf::Rgb10a2Unorm => vk::Format::A2R10G10B10_UNORM_PACK32,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -538,6 +538,7 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::Bgra8UnormSrgb => vk::Format::B8G8R8A8_SRGB,
         Tf::Rgba8Snorm => vk::Format::R8G8B8A8_SNORM,
         Tf::R16Float => vk::Format::R16_SFLOAT,
+        Tf::Rg16Float => vk::Format::R16G16_SFLOAT,
         Tf::Rgba16Float => vk::Format::R16G16B16A16_SFLOAT,
         Tf::R32Float => vk::Format::R32_SFLOAT,
         Tf::Rg32Float => vk::Format::R32G32_SFLOAT,
@@ -556,6 +557,14 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::Bc4Snorm => vk::Format::BC4_SNORM_BLOCK,
         Tf::Bc5Unorm => vk::Format::BC5_UNORM_BLOCK,
         Tf::Bc5Snorm => vk::Format::BC5_SNORM_BLOCK,
+        Tf::Bc6UFloat => vk::Format::BC6H_UFLOAT_BLOCK,
+        Tf::Bc6SFloat => vk::Format::BC6H_SFLOAT_BLOCK,
+        Tf::Bc7Unorm => vk::Format::BC7_UNORM_BLOCK,
+        Tf::Bc7UnormSrgb => vk::Format::BC7_SRGB_BLOCK,
+        Tf::Rgb10a2Unorm => vk::Format::A2R10G10B10_UNORM_PACK32,
+        Tf::Bgr10a2Unorm => vk::Format::A2B10G10R10_UNORM_PACK32,
+        Tf::Rg11b10Float => vk::Format::B10G11R11_UFLOAT_PACK32,
+        Tf::Rgb9e5Float => vk::Format::E5B9G9R9_UFLOAT_PACK32,
     }
 }
 

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -561,9 +561,8 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::Bc6hFloat => vk::Format::BC6H_SFLOAT_BLOCK,
         Tf::Bc7Unorm => vk::Format::BC7_UNORM_BLOCK,
         Tf::Bc7UnormSrgb => vk::Format::BC7_SRGB_BLOCK,
-        Tf::Rgb10a2Unorm => vk::Format::A2R10G10B10_UNORM_PACK32,
-        Tf::Bgr10a2Unorm => vk::Format::A2B10G10R10_UNORM_PACK32,
-        Tf::Rg11b10Float => vk::Format::B10G11R11_UFLOAT_PACK32,
+        Tf::Rgb10a2Unorm => vk::Format::A2B10G10R10_UNORM_PACK32,
+        Tf::Rg11b10Ufloat => vk::Format::B10G11R11_UFLOAT_PACK32,
         Tf::Rgb9e5Ufloat => vk::Format::E5B9G9R9_UFLOAT_PACK32,
     }
 }

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -557,14 +557,14 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::Bc4Snorm => vk::Format::BC4_SNORM_BLOCK,
         Tf::Bc5Unorm => vk::Format::BC5_UNORM_BLOCK,
         Tf::Bc5Snorm => vk::Format::BC5_SNORM_BLOCK,
-        Tf::Bc6UFloat => vk::Format::BC6H_UFLOAT_BLOCK,
-        Tf::Bc6SFloat => vk::Format::BC6H_SFLOAT_BLOCK,
+        Tf::Bc6hUfloat => vk::Format::BC6H_UFLOAT_BLOCK,
+        Tf::Bc6hSfloat => vk::Format::BC6H_SFLOAT_BLOCK,
         Tf::Bc7Unorm => vk::Format::BC7_UNORM_BLOCK,
         Tf::Bc7UnormSrgb => vk::Format::BC7_SRGB_BLOCK,
         Tf::Rgb10a2Unorm => vk::Format::A2R10G10B10_UNORM_PACK32,
         Tf::Bgr10a2Unorm => vk::Format::A2B10G10R10_UNORM_PACK32,
         Tf::Rg11b10Float => vk::Format::B10G11R11_UFLOAT_PACK32,
-        Tf::Rgb9e5Float => vk::Format::E5B9G9R9_UFLOAT_PACK32,
+        Tf::Rgb9e5Ufloat => vk::Format::E5B9G9R9_UFLOAT_PACK32,
     }
 }
 


### PR DESCRIPTION
Closes #223 

Wasn't quite sure with the naming scheme for the formats so if you have a better capitalization or declaration order feel free to change or come with opinion and I'll change

Translated the gles-texture-descriptions from wgpu-hal though I don't know how to describe the BGR10_A2 format so just did RGBA10_A2 there as well and left a todo. 

I also noticed that some 16f formats in gles seemed incorrectly labeled 'FLOAT' when they according to wgpu-hal should have been 'HALF_FLOAT'