### PR TITLE
Optional fragment shader

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -183,7 +183,7 @@ impl GuiPainter {
                 ..Default::default()
             },
             depth_stencil: None, //TODO?
-            fragment: shader.at("fs_main"),
+            fragment: Some(shader.at("fs_main")),
             color_targets: &[blade_graphics::ColorTargetState {
                 format: info.format,
                 blend: Some(blade_graphics::BlendState {

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -335,9 +335,15 @@ impl crate::traits::ShaderDevice for super::Context {
         } else {
             glsl::WriterFlags::empty()
         };
+
+        let shaders = match desc.fragment {
+            Some(fs) => vec![desc.vertex, fs],
+            None => vec![desc.vertex],
+        };
+
         let mut inner = unsafe {
             self.create_pipeline(
-                &[desc.vertex, desc.fragment],
+                &shaders,
                 desc.data_layouts,
                 desc.vertex_fetches,
                 desc.name,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -1026,7 +1026,7 @@ pub struct RenderPipelineDesc<'a> {
     pub vertex_fetches: &'a [VertexFetchState<'a>],
     pub primitive: PrimitiveState,
     pub depth_stencil: Option<DepthStencilState>,
-    pub fragment: ShaderFunction<'a>,
+    pub fragment: Option<ShaderFunction<'a>>,
     pub color_targets: &'a [ColorTargetState],
     pub multisample_state: MultisampleState,
 }

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -246,7 +246,7 @@ pub struct RenderPipeline {
     #[allow(dead_code)]
     vs_lib: metal::Library,
     #[allow(dead_code)]
-    fs_lib: metal::Library,
+    fs_lib: Option<metal::Library>,
     layout: PipelineLayout,
     primitive_type: metal::MTLPrimitiveType,
     triangle_fill_mode: metal::MTLTriangleFillMode,

--- a/blade-graphics/src/metal/pipeline.rs
+++ b/blade-graphics/src/metal/pipeline.rs
@@ -424,14 +424,16 @@ impl crate::traits::ShaderDevice for super::Context {
             descriptor.set_alpha_to_coverage_enabled(desc.multisample_state.alpha_to_coverage);
 
             // Fragment shader
-            let fs = self.load_shader(
-                desc.fragment,
-                desc.data_layouts,
-                &[],
-                &mut layout,
-                ShaderFlags::empty(),
-            );
-            descriptor.set_fragment_function(Some(&fs.function));
+            let fs = desc.fragment.map(|desc_fragment| {
+                self.load_shader(
+                    desc_fragment,
+                    desc.data_layouts,
+                    &[],
+                    &mut layout,
+                    ShaderFlags::empty(),
+                )
+            });
+            descriptor.set_fragment_function(fs.as_ref().map(|fs| fs.function.as_ref()));
 
             let vertex_descriptor = metal::VertexDescriptor::new();
             for (i, vf) in desc.vertex_fetches.iter().enumerate() {
@@ -520,7 +522,7 @@ impl crate::traits::ShaderDevice for super::Context {
                 raw,
                 name: desc.name.to_string(),
                 vs_lib: vs.library,
-                fs_lib: fs.library,
+                fs_lib: fs.map(|fs| fs.library),
                 layout,
                 primitive_type,
                 triangle_fill_mode,

--- a/blade-graphics/src/vulkan/pipeline.rs
+++ b/blade-graphics/src/vulkan/pipeline.rs
@@ -435,19 +435,12 @@ impl crate::traits::ShaderDevice for super::Context {
             )
         });
 
-        let mut stages = [vk::PipelineShaderStageCreateInfo::default(); 2];
-        let stage_count;
-        match fs {
-            Some(ref fs) => {
-                stages[0] = vs.create_info;
-                stages[1] = fs.create_info;
-                stage_count = 2;
-            }
-            None => {
-                stages[0] = vs.create_info;
-                stage_count = 1;
-            }
-        };
+        let mut stages = [vs.create_info, vk::PipelineShaderStageCreateInfo::default()];
+        let mut stage_count = 1;
+        if let Some(ref fs) = fs {
+            stages[1] = fs.create_info;
+            stage_count += 1;
+        }
         let stages = &stages[..stage_count]; // 'dynamic' stack allocated array
 
         let layout = self.create_pipeline_layout(desc.data_layouts, &group_infos);

--- a/blade-graphics/src/vulkan/pipeline.rs
+++ b/blade-graphics/src/vulkan/pipeline.rs
@@ -425,15 +425,31 @@ impl crate::traits::ShaderDevice for super::Context {
             &mut group_infos,
             desc.vertex_fetches,
         );
-        let fs = self.load_shader(
-            desc.fragment,
-            &options,
-            desc.data_layouts,
-            &mut group_infos,
-            &[],
-        );
+        let fs = desc.fragment.map(|desc_fragment| {
+            self.load_shader(
+                desc_fragment,
+                &options,
+                desc.data_layouts,
+                &mut group_infos,
+                &[],
+            )
+        });
 
-        let stages = [vs.create_info, fs.create_info];
+        let mut stages = [vk::PipelineShaderStageCreateInfo::default(); 2];
+        let stage_count;
+        match fs {
+            Some(ref fs) => {
+                stages[0] = vs.create_info;
+                stages[1] = fs.create_info;
+                stage_count = 2;
+            }
+            None => {
+                stages[0] = vs.create_info;
+                stage_count = 1;
+            }
+        };
+        let stages = &stages[..stage_count]; // 'dynamic' stack allocated array
+
         let layout = self.create_pipeline_layout(desc.data_layouts, &group_infos);
 
         let vertex_buffers = desc
@@ -603,7 +619,9 @@ impl crate::traits::ShaderDevice for super::Context {
         let raw = raw_vec.pop().unwrap();
 
         unsafe { self.device.core.destroy_shader_module(vs.vk_module, None) };
-        unsafe { self.device.core.destroy_shader_module(fs.vk_module, None) };
+        if let Some(fs) = fs {
+            unsafe { self.device.core.destroy_shader_module(fs.vk_module, None) };
+        }
 
         if !desc.name.is_empty() {
             self.set_object_name(raw, desc.name);

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -89,7 +89,7 @@ fn create_draw_pipeline(
             ..Default::default()
         },
         depth_stencil: None,
-        fragment: shader.at("debug_fs"),
+        fragment: Some(shader.at("debug_fs")),
         color_targets: &[blade_graphics::ColorTargetState {
             format,
             blend: Some(blade_graphics::BlendState::ALPHA_BLENDING),
@@ -116,7 +116,7 @@ fn create_blit_pipeline(
             ..Default::default()
         },
         depth_stencil: None,
-        fragment: shader.at("blit_fs"),
+        fragment: Some(shader.at("blit_fs")),
         color_targets: &[format.into()],
         multisample_state: blade_graphics::MultisampleState::default(),
     })

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -603,7 +603,7 @@ impl ShaderPipelines {
             },
             vertex: shader.at("postfx_vs"),
             vertex_fetches: &[],
-            fragment: shader.at("postfx_fs"),
+            fragment: Some(shader.at("postfx_fs")),
             color_targets: &[info.format.into()],
             depth_stencil: None,
             multisample_state: blade_graphics::MultisampleState::default(),

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -117,7 +117,7 @@ impl Example {
                 ..Default::default()
             },
             depth_stencil: None,
-            fragment: shader.at("fs_main"),
+            fragment: Some(shader.at("fs_main")),
             color_targets: &[gpu::ColorTargetState {
                 format: surface.info().format,
                 blend: Some(gpu::BlendState::ALPHA_BLENDING),

--- a/examples/init/main.rs
+++ b/examples/init/main.rs
@@ -47,7 +47,7 @@ impl EnvMapSampler {
             data_layouts: &[&layout],
             vertex: shader.at("vs_init"),
             vertex_fetches: &[],
-            fragment: shader.at("fs_init"),
+            fragment: Some(shader.at("fs_init")),
             primitive: gpu::PrimitiveState {
                 topology: gpu::PrimitiveTopology::TriangleStrip,
                 ..Default::default()
@@ -65,7 +65,7 @@ impl EnvMapSampler {
             data_layouts: &[&layout],
             vertex: shader.at("vs_accum"),
             vertex_fetches: &[],
-            fragment: shader.at("fs_accum"),
+            fragment: Some(shader.at("fs_accum")),
             primitive: gpu::PrimitiveState {
                 topology: gpu::PrimitiveTopology::PointList,
                 ..Default::default()

--- a/examples/particle/particle.rs
+++ b/examples/particle/particle.rs
@@ -105,7 +105,7 @@ impl System {
             },
             vertex: shader.at("draw_vs"),
             vertex_fetches: &[],
-            fragment: shader.at("draw_fs"),
+            fragment: Some(shader.at("draw_fs")),
             color_targets: &[gpu::ColorTargetState {
                 format: desc.draw_format,
                 blend: Some(gpu::BlendState::ALPHA_BLENDING),

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -113,7 +113,7 @@ impl Example {
             },
             vertex: shader.at("draw_vs"),
             vertex_fetches: &[],
-            fragment: shader.at("draw_fs"),
+            fragment: Some(shader.at("draw_fs")),
             color_targets: &[surface.info().format.into()],
             depth_stencil: None,
             multisample_state: Default::default(),


### PR DESCRIPTION
Closes #226 

This changes the declaration of the fragment function from being mandatory to instead be optional.

Vulkan and Metal have been tested in the sense that bunnymark with fragment shader set to None compiles and runs. Upon inspection of vulkan run of the bunnymark example without fragment specified, I observed that the vertex shader is executed correctly but renderdoc states there is no fragment shader stage as expected. 