### PR TITLE
change to ordered timings over hashmap

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -145,7 +145,7 @@ impl super::CommandEncoder {
                         );
                     }
                     let time = Duration::from_nanos(result - prev);
-                    *self.timings.entry(pass_name).or_default() += time;
+                    self.timings.push((pass_name, time));
                     prev = result
                 }
             }

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -1150,4 +1150,4 @@ pub struct Viewport {
     pub depth: std::ops::Range<f32>,
 }
 
-pub type Timings = std::collections::HashMap<String, std::time::Duration>;
+pub type Timings = Vec<(String, std::time::Duration)>;

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -333,7 +333,7 @@ impl crate::traits::CommandEncoder for super::CommandEncoder {
                 };
                 for (name, chunk) in td.pass_names.drain(..).zip(counters.chunks(2)) {
                     let duration = Duration::from_nanos(chunk[1] - chunk[0]);
-                    *self.timings.entry(name).or_default() += duration;
+                    self.timings.push((name, duration));
                 }
             }
         }

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -497,7 +497,7 @@ impl crate::traits::CommandEncoder for super::CommandEncoder {
                 {
                     let diff = (ts - prev) as f32 * timing.period;
                     prev = ts;
-                    *self.timings.entry(name).or_default() += Duration::from_nanos(diff as _);
+                    self.timings.push((name, Duration::from_nanos(diff as _)));
                 }
             }
             unsafe {


### PR DESCRIPTION
Closes #231 

The motivation is that the order of the timings was information that got lost in the current approach but seems present in all implementations. 

Same-named data was previously being merged (might have been concidered a feature), though considering how easy it is to get that behavior if so desired I think the blade API not imposing removal of information is better. I prefer reading timings in the order of submission which was previously only possible if names were kept somewhere else in order and if merged same-names were desired.

Particles demo tested on linux with vulkan as well as with metal on M4, macos. Gles compiles on linux.  