### PR TITLE
make traits mod public

### DIFF
--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -68,7 +68,7 @@ pub mod derive;
 #[cfg_attr(any(gles, target_arch = "wasm32"), path = "gles/mod.rs")]
 mod hal;
 mod shader;
-mod traits;
+pub mod traits;
 pub mod util;
 pub mod limits {
     /// Max number of passes inside a command encoder.


### PR DESCRIPTION

While keeping the traits opaque to the user using the current `hidden_trait` proc-macro makes it very simple for the user, having access to the traits in order to write utility-functions that compile on all backends is still a nice ability.

I read the `hidden_trait` code and I believe making this public would still work, get a concrete function implementation as well as the trait implementation available if needed.

Arose from: https://github.com/kvark/blade/pull/227#issuecomment-2560604563