### PR TITLE
Add `supports_texture_sample_count` method to Metal and Vulkan.

### DIFF
--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -530,6 +530,12 @@ impl Context {
     pub fn metal_device(&self) -> Retained<ProtocolObject<dyn metal::MTLDevice>> {
         self.device.lock().unwrap().clone()
     }
+
+    /// Check if the device supports a specific texture sample count.
+    pub fn supports_texture_sample_count(&self, sample_count: u32) -> bool {
+        self.metal_device()
+            .supportsTextureSampleCount(sample_count as _)
+    }
 }
 
 #[hidden_trait::expose]

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -1,4 +1,7 @@
-use ash::{khr, vk};
+use ash::{
+    khr,
+    vk::{self},
+};
 use std::{mem, num::NonZeroU32, path::PathBuf, ptr, sync::Mutex};
 
 mod command;
@@ -148,6 +151,31 @@ pub struct Context {
     shader_debug_path: Option<PathBuf>,
     instance: Instance,
     entry: ash::Entry,
+}
+
+impl Context {
+    /// Check if the device supports a specific texture sample count.
+    pub fn supports_texture_sample_count(&self, sample_count: u32) -> bool {
+        let properties = unsafe {
+            self.instance
+                .core
+                .get_physical_device_properties(self.physical_device)
+        };
+
+        let max_count = properties.limits.framebuffer_color_sample_counts
+            & properties.limits.framebuffer_depth_sample_counts;
+
+        match sample_count {
+            1 => true,
+            2 => max_count.contains(vk::SampleCountFlags::TYPE_2),
+            4 => max_count.contains(vk::SampleCountFlags::TYPE_4),
+            8 => max_count.contains(vk::SampleCountFlags::TYPE_8),
+            16 => max_count.contains(vk::SampleCountFlags::TYPE_16),
+            32 => max_count.contains(vk::SampleCountFlags::TYPE_32),
+            64 => max_count.contains(vk::SampleCountFlags::TYPE_64),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -18,11 +18,6 @@ struct Example {
     msaa_view: Option<gpu::TextureView>,
 }
 
-// pub const INITIAL_SAMPLE_COUNT: u32 = 1;
-// pub const INITIAL_SAMPLE_COUNT: u32 = 2;
-pub const INITIAL_SAMPLE_COUNT: u32 = 4;
-// pub const INITIAL_SAMPLE_COUNT: u32 = 8;
-
 impl Example {
     fn resize(&mut self, size: winit::dpi::PhysicalSize<u32>) {
         let config = Self::make_surface_config(size);
@@ -110,6 +105,11 @@ impl Example {
             .unwrap();
         let surface_info = surface.info();
 
+        let sample_count = [4, 2, 1]
+            .into_iter()
+            .find(|&n| context.supports_texture_sample_count(n))
+            .unwrap_or(1);
+
         let gui_painter = blade_egui::GuiPainter::new(surface_info, &context);
         let particle_system = particle::System::new(
             &context,
@@ -118,7 +118,7 @@ impl Example {
                 capacity: 100_000,
                 draw_format: surface_info.format,
             },
-            INITIAL_SAMPLE_COUNT,
+            sample_count,
         );
 
         let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
@@ -136,7 +136,7 @@ impl Example {
             surface,
             gui_painter,
             particle_system,
-            sample_count: INITIAL_SAMPLE_COUNT,
+            sample_count,
             msaa_texture: None,
             msaa_view: None,
         }

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -245,12 +245,17 @@ impl Example {
         ui.heading("Particle System");
         self.particle_system.add_gui(ui);
 
+        let supported_samples = [1, 2, 4]
+            .into_iter()
+            .filter(|&n| self.context.supports_texture_sample_count(n))
+            .collect::<Vec<_>>();
+
         ui.add_space(5.0);
         ui.heading("Rendering Settings");
         egui::ComboBox::new("msaa dropdown", "MSAA samples")
             .selected_text(format!("x{}", self.sample_count))
             .show_ui(ui, |ui| {
-                for i in [1, 2, 4] {
+                for i in supported_samples {
                     if ui
                         .selectable_value(&mut self.sample_count, i, format!("x{i}"))
                         .changed()


### PR DESCRIPTION
There need a method to check if the system supports a specific sample count.

Ref https://github.com/zed-industries/zed/pull/22812 need this feature to setup sample_count.
