### PR TITLE
Add and implement dispatch indirect

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -449,8 +449,16 @@ impl crate::traits::PipelineEncoder for super::PipelineEncoder<'_> {
 
 #[hidden_trait::expose]
 impl crate::traits::ComputePipelineEncoder for super::PipelineEncoder<'_> {
+    type BufferPiece = crate::BufferPiece;
+
     fn dispatch(&mut self, groups: [u32; 3]) {
         self.commands.push(super::Command::Dispatch(groups));
+    }
+
+    fn dispatch_indirect(&mut self, indirect_buf: crate::BufferPiece) {
+        self.commands.push(super::Command::DispatchIndirect {
+            indirect_buf: indirect_buf.into(),
+        });
     }
 }
 

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -712,6 +712,8 @@ impl crate::traits::PipelineEncoder for super::ComputePipelineContext<'_> {
 
 #[hidden_trait::expose]
 impl crate::traits::ComputePipelineEncoder for super::ComputePipelineContext<'_> {
+    type BufferPiece = crate::BufferPiece;
+
     fn dispatch(&mut self, groups: [u32; 3]) {
         let raw_count = metal::MTLSize {
             width: groups[0] as usize,
@@ -720,6 +722,17 @@ impl crate::traits::ComputePipelineEncoder for super::ComputePipelineContext<'_>
         };
         self.encoder
             .dispatchThreadgroups_threadsPerThreadgroup(raw_count, self.wg_size);
+    }
+
+    fn dispatch_indirect(&mut self, indirect_buf: crate::BufferPiece) {
+        unsafe {
+            self.encoder
+                .dispatchThreadgroupsWithIndirectBuffer_indirectBufferOffset_threadsPerThreadgroup(
+                    indirect_buf.buffer.as_ref(),
+                    indirect_buf.offset as usize,
+                    self.wg_size,
+                );
+        }
     }
 }
 

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -119,7 +119,10 @@ pub trait PipelineEncoder {
 }
 
 pub trait ComputePipelineEncoder: PipelineEncoder {
+    type BufferPiece: Send + Sync + Clone + Copy + Debug;
+
     fn dispatch(&mut self, groups: [u32; 3]);
+    fn dispatch_indirect(&mut self, indirect_buf: Self::BufferPiece);
 }
 
 pub trait RenderPipelineEncoder: PipelineEncoder + RenderEncoder {

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -940,11 +940,22 @@ impl crate::traits::PipelineEncoder for super::PipelineEncoder<'_, '_> {
 
 #[hidden_trait::expose]
 impl crate::traits::ComputePipelineEncoder for super::PipelineEncoder<'_, '_> {
+    type BufferPiece = crate::BufferPiece;
+
     fn dispatch(&mut self, groups: [u32; 3]) {
         unsafe {
             self.device
                 .core
                 .cmd_dispatch(self.cmd_buf.raw, groups[0], groups[1], groups[2])
+        };
+    }
+    fn dispatch_indirect(&mut self, indirect_buf: crate::BufferPiece) {
+        unsafe {
+            self.device.core.cmd_dispatch_indirect(
+                self.cmd_buf.raw,
+                indirect_buf.buffer.raw,
+                indirect_buf.offset,
+            )
         };
     }
 }


### PR DESCRIPTION
Existed in Vulkan since 1.0, in metal and in opengl ES since 3.1.

Gles compiles on linux, tested on macos and linux with vulkan.

Motivation is that we are doing compute-based culling and would like to dispatch a sorting compute afterwards. The input to the sort function depends on the results from the cull. `dispatch_indirect` allows us to avoid dispatching unnecessarily many groups or doing a cpu read-back 