### PR TITLE
stencil/depth unification

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -239,14 +239,15 @@ impl super::CommandEncoder {
             if let crate::InitOp::Clear(color) = rt.init_op {
                 self.commands.push(super::Command::ClearDepthStencil {
                     depth: if rt.view.aspects.contains(crate::TexelAspects::DEPTH) {
-                        Some(match color {
-                            crate::TextureColor::White => 1.0,
-                            _ => 0.0,
-                        })
+                        Some(color.depth_clear_value())
                     } else {
                         None
                     },
-                    stencil: None, //TODO
+                    stencil: if rt.view.aspects.contains(crate::TexelAspects::STENCIL) {
+                        Some(color.stencil_clear_value())
+                    } else {
+                        None
+                    },
                 });
             }
         }

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -355,7 +355,7 @@ impl super::Context {
                 let window_ptr = handle.ns_view.as_ptr();
                 #[cfg(target_os = "macos")]
                 let window_ptr = unsafe {
-                    use objc::{msg_send, runtime::Object, sel, sel_impl};
+                    use objc2::{msg_send, runtime::Object};
                     // ns_view always have a layer and don't need to verify that it exists.
                     let layer: *mut Object =
                         msg_send![handle.ns_view.as_ptr() as *mut Object, layer];

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -262,12 +262,8 @@ impl super::CommandEncoder {
                     let load_action = match rt.init_op {
                         crate::InitOp::Load => metal::MTLLoadAction::Load,
                         crate::InitOp::Clear(color) => {
-                            let clear_depth = match color {
-                                crate::TextureColor::TransparentBlack
-                                | crate::TextureColor::OpaqueBlack => 0.0,
-                                crate::TextureColor::White => 1.0,
-                            };
-                            at_descriptor.setClearDepth(clear_depth);
+                            let clear_depth = color.depth_clear_value();
+                            at_descriptor.setClearDepth(clear_depth as f64);
                             metal::MTLLoadAction::Clear
                         }
                         crate::InitOp::DontCare => metal::MTLLoadAction::DontCare,
@@ -290,11 +286,7 @@ impl super::CommandEncoder {
                     let load_action = match rt.init_op {
                         crate::InitOp::Load => metal::MTLLoadAction::Load,
                         crate::InitOp::Clear(color) => {
-                            let clear_stencil = match color {
-                                crate::TextureColor::TransparentBlack
-                                | crate::TextureColor::OpaqueBlack => 0,
-                                crate::TextureColor::White => !0,
-                            };
+                            let clear_stencil = color.stencil_clear_value();
                             at_descriptor.setClearStencil(clear_stencil);
                             metal::MTLLoadAction::Clear
                         }

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -111,6 +111,24 @@ impl super::TextureFormat {
     }
 }
 
+impl super::TextureColor {
+    pub fn stencil_clear_value(&self) -> u32 {
+        match self {
+            crate::TextureColor::TransparentBlack => 0,
+            crate::TextureColor::OpaqueBlack => !0,
+            crate::TextureColor::White => !0,
+        }
+    }
+
+    pub fn depth_clear_value(&self) -> f32 {
+        match self {
+            crate::TextureColor::TransparentBlack => 0.0,
+            crate::TextureColor::OpaqueBlack => 0.0,
+            crate::TextureColor::White => 1.0,
+        }
+    }
+}
+
 impl super::ComputePipeline {
     /// Return the dispatch group counts sufficient to cover the given extent.
     pub fn get_dispatch_for(&self, extent: super::Extent) -> [u32; 3] {

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -171,7 +171,9 @@ fn map_render_target(rt: &crate::RenderTarget) -> vk::RenderingAttachmentInfo<'s
             let cv = if rt.view.aspects.contains(crate::TexelAspects::COLOR) {
                 vk::ClearValue {
                     color: match color {
-                        crate::TextureColor::TransparentBlack => vk::ClearColorValue::default(),
+                        crate::TextureColor::TransparentBlack => {
+                            vk::ClearColorValue { float32: [0.0; 4] }
+                        }
                         crate::TextureColor::OpaqueBlack => vk::ClearColorValue {
                             float32: [0.0, 0.0, 0.0, 1.0],
                         },
@@ -180,18 +182,9 @@ fn map_render_target(rt: &crate::RenderTarget) -> vk::RenderingAttachmentInfo<'s
                 }
             } else {
                 vk::ClearValue {
-                    depth_stencil: match color {
-                        crate::TextureColor::TransparentBlack => {
-                            vk::ClearDepthStencilValue::default()
-                        }
-                        crate::TextureColor::OpaqueBlack => vk::ClearDepthStencilValue {
-                            depth: 1.0,
-                            stencil: 0,
-                        },
-                        crate::TextureColor::White => vk::ClearDepthStencilValue {
-                            depth: 1.0,
-                            stencil: !0,
-                        },
+                    depth_stencil: vk::ClearDepthStencilValue {
+                        depth: color.depth_clear_value(),
+                        stencil: color.stencil_clear_value(),
                     },
                 }
             };


### PR DESCRIPTION
per #246 the depths and stencils were not matching up between the backends, and was inconsistent with naming. I moved the declaration of these clear values to a single spot to avoid this.

I think I would've preferred to just specify them manually though