### PR TITLE
metal: prepare for `objc2` frameworks v0.3

### DIFF
--- a/blade-graphics/Cargo.toml
+++ b/blade-graphics/Cargo.toml
@@ -21,8 +21,12 @@ raw-window-handle = "0.6"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc2 = "0.5"
-objc2-foundation = { version = "0.2", features = ["NSArray"] }
-objc2-metal = { version = "0.2", features = [
+objc2-foundation = { version = "0.2", default-features = false, features = [
+    "std",
+    "NSArray",
+] }
+objc2-metal = { version = "0.2", default-features = false, features = [
+    "std",
     "MTLTypes",
     "MTLPixelFormat",
     "MTLResource",
@@ -55,7 +59,8 @@ objc2-metal = { version = "0.2", features = [
     "MTLCaptureScope",
     "block2",
 ] }
-objc2-quartz-core = { version = "0.2", features = [
+objc2-quartz-core = { version = "0.2", default-features = false, features = [
+    "std",
     "objc2-metal",
     "CALayer",
     "CAMetalLayer",
@@ -63,7 +68,8 @@ objc2-quartz-core = { version = "0.2", features = [
 naga = { workspace = true, features = ["msl-out"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.2", features = [
+objc2-app-kit = { version = "0.2", default-features = false, features = [
+    "std",
     "objc2-quartz-core",
     "NSResponder",
     "NSView",
@@ -71,7 +77,8 @@ objc2-app-kit = { version = "0.2", features = [
 ] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-objc2-ui-kit = { version = "0.2", features = [
+objc2-ui-kit = { version = "0.2", default-features = false, features = [
+    "std",
     "objc2-quartz-core",
     "UIResponder",
     "UIView",


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).