### PR TITLE
Adds support for external buffers and images

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -15,7 +15,6 @@
 
 const SHADER_SOURCE: &'static str = include_str!("../shader.wgsl");
 
-use blade_graphics::Memory;
 use blade_util::{BufferBelt, BufferBeltDescriptor};
 use std::{
     collections::hash_map::{Entry, HashMap},
@@ -87,7 +86,7 @@ impl GuiTexture {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
-            memory: Memory::Device,
+            memory: blade_graphics::Memory::Device,
         });
         let view = context.create_texture_view(
             allocation,

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -86,7 +86,7 @@ impl GuiTexture {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
-            memory: blade_graphics::Memory::Device,
+            external: None,
         });
         let view = context.create_texture_view(
             allocation,

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -15,6 +15,7 @@
 
 const SHADER_SOURCE: &'static str = include_str!("../shader.wgsl");
 
+use blade_graphics::Memory;
 use blade_util::{BufferBelt, BufferBeltDescriptor};
 use std::{
     collections::hash_map::{Entry, HashMap},
@@ -86,6 +87,7 @@ impl GuiTexture {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
+            memory: Memory::Device,
         });
         let view = context.create_texture_view(
             allocation,

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -58,6 +58,7 @@ impl crate::traits::ResourceDevice for super::Context {
                     glow::MAP_PERSISTENT_BIT | glow::MAP_COHERENT_BIT | glow::MAP_WRITE_BIT;
                 glow::DYNAMIC_DRAW
             }
+            crate::Memory::External(_) => unimplemented!(),
         };
 
         unsafe {

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -166,7 +166,7 @@ pub enum Memory {
 
 /// If the source contains None it will export it otherwise it will import the value in Some
 //TODO add D3D11, D3D12 and metal support
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum ExternalMemorySource {
     #[cfg(target_os = "windows")]
     Win32(Option<isize>),
@@ -180,13 +180,16 @@ pub enum ExternalMemorySource {
     #[cfg(target_os = "linux")]
     Dma(Option<i32>),
 
-    HostAllocation(*mut std::ffi::c_void),
+    /// Is a pointer cast to usize, reason being it otherwise can't be used as sync and send, you should manage memory access to this yourself
+    HostAllocation(usize),
 }
 
 impl Memory {
     pub fn is_host_visible(&self) -> bool {
         match *self {
-            Self::Shared | Self::Upload | Self::External(ExternalMemorySource::HostAllocation(_)) => true,
+            Self::Shared
+            | Self::Upload
+            | Self::External(ExternalMemorySource::HostAllocation(_)) => true,
             Self::Device | Self::External(_) => false,
         }
     }

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -165,27 +165,29 @@ pub enum Memory {
 }
 
 /// If the source contains None it will export it otherwise it will import the value in Some
+//TODO add D3D11, D3D12 and metal support
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ExternalMemorySource {
     #[cfg(target_os = "windows")]
     Win32(Option<isize>),
+
     #[cfg(target_os = "windows")]
     Win32KMT(Option<isize>),
-    //TODO add D3D11, D3D12 and metal support
+
     #[cfg(not(target_os = "windows"))]
     Fd(Option<i32>),
 
     #[cfg(target_os = "linux")]
     Dma(Option<i32>),
 
-    HostAllocation(Option<*mut std::ffi::c_void>),
+    HostAllocation(*mut std::ffi::c_void),
 }
 
 impl Memory {
     pub fn is_host_visible(&self) -> bool {
         match *self {
+            Self::Shared | Self::Upload | Self::External(ExternalMemorySource::HostAllocation(_)) => true,
             Self::Device | Self::External(_) => false,
-            Self::Shared | Self::Upload => true,
         }
     }
 }

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -160,12 +160,14 @@ pub enum Memory {
     Shared,
     /// Upload memory. Can only be transferred on GPU.
     Upload,
+    /// External memory, None if it exports, Some(fd) if it's an import.
+    External { import_fd: Option<isize> },
 }
 
 impl Memory {
     pub fn is_host_visible(&self) -> bool {
         match *self {
-            Self::Device => false,
+            Self::Device | Self::External { import_fd: _ } => false,
             Self::Shared | Self::Upload => true,
         }
     }
@@ -415,6 +417,7 @@ pub struct TextureDesc<'a> {
     pub sample_count: u32,
     pub dimension: TextureDimension,
     pub usage: TextureUsage,
+    pub memory: Memory,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -185,6 +185,7 @@ impl crate::traits::ResourceDevice for super::Context {
                 metal::MTLResourceOptions::MTLResourceStorageModeShared
                     | metal::MTLResourceOptions::MTLResourceCPUCacheModeWriteCombined
             }
+            crate::Memory::External(_) => unimplemented!(),
         };
         let object = objc2::rc::autoreleasepool(|_| {
             self.device

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -563,6 +563,16 @@ impl super::Context {
             } else {
                 None
             },
+            external_memory: if capabilities.external_memory {
+                #[cfg(target_os = "windows")]
+                use khr::external_memory_win32::Device;
+                #[cfg(not(target_os = "windows"))]
+                use khr::external_memory_fd::Device;
+
+                Some(Device::new(&instance.core, &device_core))
+            } else {
+                None
+            },
             core: device_core,
             device_information: capabilities.device_information,
             command_scope: if desc.capture {

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -187,8 +187,7 @@ unsafe fn inspect_adapter(
         return None;
     }
 
-    let external_memory = supported_extensions.contains(&vk::KHR_EXTERNAL_MEMORY_WIN32_NAME)
-        || supported_extensions.contains(&vk::KHR_EXTERNAL_MEMORY_FD_NAME);
+    let external_memory = supported_extensions.contains(&vk::KHR_EXTERNAL_MEMORY_NAME);
 
     let timing = if properties.limits.timestamp_compute_and_graphics == vk::FALSE {
         log::info!("No timing because of queue support");
@@ -456,7 +455,7 @@ impl super::Context {
                 device_extensions.push(vk::EXT_FULL_SCREEN_EXCLUSIVE_NAME);
             }
             if capabilities.external_memory {
-                log::info!("Enabling external memory support");
+                device_extensions.push(vk::KHR_EXTERNAL_MEMORY_NAME);
                 #[cfg(target_os = "windows")]
                 device_extensions.push(vk::KHR_EXTERNAL_MEMORY_WIN32_NAME);
                 #[cfg(not(target_os = "windows"))]
@@ -564,10 +563,10 @@ impl super::Context {
                 None
             },
             external_memory: if capabilities.external_memory {
-                #[cfg(target_os = "windows")]
-                use khr::external_memory_win32::Device;
                 #[cfg(not(target_os = "windows"))]
                 use khr::external_memory_fd::Device;
+                #[cfg(target_os = "windows")]
+                use khr::external_memory_win32::Device;
 
                 Some(Device::new(&instance.core, &device_core))
             } else {

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -58,6 +58,10 @@ struct Device {
     buffer_marker: Option<ash::amd::buffer_marker::Device>,
     shader_info: Option<ash::amd::shader_info::Device>,
     full_screen_exclusive: Option<ash::ext::full_screen_exclusive::Device>,
+    #[cfg(target_os = "windows")]
+    external_memory: Option<ash::khr::external_memory_win32::Device>,
+    #[cfg(not(target_os = "windows"))]
+    external_memory: Option<ash::khr::external_memory_fd::Device>,
     command_scope: Option<CommandScopeDevice>,
     timing: Option<TimingDevice>,
     workarounds: Workarounds,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -125,6 +125,7 @@ impl Frame {
             memory_handle: !0,
             target_size: self.swapchain.target_size,
             format: self.swapchain.format,
+            external: None,
         }
     }
 
@@ -187,6 +188,7 @@ pub struct Buffer {
     raw: vk::Buffer,
     memory_handle: usize,
     mapped_data: *mut u8,
+    external: Option<crate::ExternalMemorySource>,
 }
 
 impl Default for Buffer {
@@ -195,6 +197,7 @@ impl Default for Buffer {
             raw: vk::Buffer::null(),
             memory_handle: !0,
             mapped_data: ptr::null_mut(),
+            external: None,
         }
     }
 }
@@ -214,6 +217,7 @@ pub struct Texture {
     memory_handle: usize,
     target_size: [u16; 2],
     format: crate::TextureFormat,
+    external: Option<crate::ExternalMemorySource>,
 }
 
 impl Default for Texture {
@@ -223,6 +227,7 @@ impl Default for Texture {
             memory_handle: !0,
             target_size: [0; 2],
             format: crate::TextureFormat::Rgba8Unorm,
+            external: None,
         }
     }
 }

--- a/blade-render/src/render/dummy.rs
+++ b/blade-render/src/render/dummy.rs
@@ -31,7 +31,7 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
-            memory: Memory::Device,
+            external: None,
         });
         let white_view = gpu.create_texture_view(
             white_texture,
@@ -51,7 +51,7 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
-            memory: Memory::Device,
+            external: None,
         });
         let black_view = gpu.create_texture_view(
             black_texture,
@@ -71,7 +71,7 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
-            memory: Memory::Device,
+            external: None,
         });
         let red_view = gpu.create_texture_view(
             red_texture,

--- a/blade-render/src/render/dummy.rs
+++ b/blade-render/src/render/dummy.rs
@@ -1,4 +1,3 @@
-use blade_graphics::Memory;
 use std::ptr;
 
 pub struct DummyResources {

--- a/blade-render/src/render/dummy.rs
+++ b/blade-render/src/render/dummy.rs
@@ -1,3 +1,4 @@
+use blade_graphics::Memory;
 use std::ptr;
 
 pub struct DummyResources {
@@ -30,6 +31,7 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
+            memory: Memory::Device,
         });
         let white_view = gpu.create_texture_view(
             white_texture,
@@ -49,6 +51,7 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
+            memory: Memory::Device,
         });
         let black_view = gpu.create_texture_view(
             black_texture,
@@ -68,6 +71,7 @@ impl DummyResources {
             dimension: blade_graphics::TextureDimension::D2,
             usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
             sample_count: 1,
+            memory: Memory::Device,
         });
         let red_view = gpu.create_texture_view(
             red_texture,

--- a/blade-render/src/render/env_map.rs
+++ b/blade-render/src/render/env_map.rs
@@ -1,5 +1,4 @@
 use crate::DummyResources;
-use blade_graphics::Memory;
 use std::num::NonZeroU32;
 
 #[repr(C)]

--- a/blade-render/src/render/env_map.rs
+++ b/blade-render/src/render/env_map.rs
@@ -113,7 +113,7 @@ impl EnvironmentMap {
             mip_level_count,
             usage: blade_graphics::TextureUsage::RESOURCE | blade_graphics::TextureUsage::STORAGE,
             sample_count: 1,
-            memory: Memory::Device,
+            external: None,
         });
         self.weight_view = gpu.create_texture_view(
             self.weight_texture,

--- a/blade-render/src/render/env_map.rs
+++ b/blade-render/src/render/env_map.rs
@@ -1,6 +1,6 @@
-use std::num::NonZeroU32;
-
 use crate::DummyResources;
+use blade_graphics::Memory;
+use std::num::NonZeroU32;
 
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
@@ -113,6 +113,7 @@ impl EnvironmentMap {
             mip_level_count,
             usage: blade_graphics::TextureUsage::RESOURCE | blade_graphics::TextureUsage::STORAGE,
             sample_count: 1,
+            memory: Memory::Device,
         });
         self.weight_view = gpu.create_texture_view(
             self.weight_texture,

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -8,6 +8,7 @@ pub use debug::{DebugBlit, DebugLine, DebugPoint};
 pub use dummy::DummyResources;
 pub use env_map::EnvironmentMap;
 
+use blade_graphics::Memory;
 use std::{collections::HashMap, mem, num::NonZeroU32, path::Path, ptr};
 
 const MAX_RESOURCES: u32 = 8192;
@@ -179,6 +180,7 @@ impl<const N: usize> RenderTarget<N> {
             mip_level_count: 1,
             usage: blade_graphics::TextureUsage::RESOURCE | blade_graphics::TextureUsage::STORAGE,
             sample_count: 1,
+            memory: Memory::Device,
         });
         encoder.init_texture(texture);
 

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -8,7 +8,6 @@ pub use debug::{DebugBlit, DebugLine, DebugPoint};
 pub use dummy::DummyResources;
 pub use env_map::EnvironmentMap;
 
-use blade_graphics::Memory;
 use std::{collections::HashMap, mem, num::NonZeroU32, path::Path, ptr};
 
 const MAX_RESOURCES: u32 = 8192;

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -180,7 +180,7 @@ impl<const N: usize> RenderTarget<N> {
             mip_level_count: 1,
             usage: blade_graphics::TextureUsage::RESOURCE | blade_graphics::TextureUsage::STORAGE,
             sample_count: 1,
-            memory: Memory::Device,
+            external: None,
         });
         encoder.init_texture(texture);
 

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -1,4 +1,3 @@
-use blade_graphics::Memory;
 use std::{
     fmt, io, mem, ptr, slice, str,
     sync::{Arc, Mutex},

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -1,3 +1,4 @@
+use blade_graphics::Memory;
 use std::{
     fmt, io, mem, ptr, slice, str,
     sync::{Arc, Mutex},
@@ -397,6 +398,7 @@ impl blade_asset::Baker for Baker {
                 dimension: blade_graphics::TextureDimension::D2,
                 usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
                 sample_count: 1,
+                memory: Memory::Device,
             });
         let view = self.gpu_context.create_texture_view(
             texture,

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -398,7 +398,7 @@ impl blade_asset::Baker for Baker {
                 dimension: blade_graphics::TextureDimension::D2,
                 usage: blade_graphics::TextureUsage::COPY | blade_graphics::TextureUsage::RESOURCE,
                 sample_count: 1,
-                memory: Memory::Device,
+                external: None,
             });
         let view = self.gpu_context.create_texture_view(
             texture,

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -1,7 +1,6 @@
 #![allow(irrefutable_let_patterns)]
 
 use blade_graphics as gpu;
-use blade_graphics::Memory;
 use bytemuck::{Pod, Zeroable};
 use std::{mem, ptr};
 

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -1,6 +1,7 @@
 #![allow(irrefutable_let_patterns)]
 
 use blade_graphics as gpu;
+use blade_graphics::Memory;
 use bytemuck::{Pod, Zeroable};
 use std::{mem, ptr};
 
@@ -140,6 +141,7 @@ impl Example {
             mip_level_count: 1,
             usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::COPY,
             sample_count: 1,
+            memory: Memory::Device,
         });
         let view = context.create_texture_view(
             texture,

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -141,7 +141,7 @@ impl Example {
             mip_level_count: 1,
             usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::COPY,
             sample_count: 1,
-            memory: Memory::Device,
+            external: None,
         });
         let view = context.create_texture_view(
             texture,

--- a/examples/init/main.rs
+++ b/examples/init/main.rs
@@ -30,6 +30,7 @@ impl EnvMapSampler {
             dimension: gpu::TextureDimension::D2,
             usage: gpu::TextureUsage::TARGET,
             sample_count: 1,
+            external: None,
         });
         let accum_view = context.create_texture_view(
             accum_texture,

--- a/examples/mini/main.rs
+++ b/examples/mini/main.rs
@@ -60,7 +60,7 @@ fn main() {
         mip_level_count,
         usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::STORAGE | gpu::TextureUsage::COPY,
         sample_count: 1,
-        memory: gpu::Memory::Device,
+        external: None,
     });
     let views = (0..mip_level_count)
         .map(|i| {

--- a/examples/mini/main.rs
+++ b/examples/mini/main.rs
@@ -60,6 +60,7 @@ fn main() {
         mip_level_count,
         usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::STORAGE | gpu::TextureUsage::COPY,
         sample_count: 1,
+        memory: gpu::Memory::Device,
     });
     let views = (0..mip_level_count)
         .map(|i| {

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -62,12 +62,20 @@ impl Example {
                 array_layer_count: 1,
                 mip_level_count: 1,
                 external: if self.export_image {
-                    Some(gpu::ExternalMemorySource::Win32KMT(None))
+                    #[cfg(target_os = "windows")]
+                    {
+                        Some(gpu::ExternalMemorySource::Win32KMT(None))
+                    }
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        Some(gpu::ExternalMemorySource::Fd(None))
+                    }
                 } else {
                     None
                 },
             });
 
+            #[cfg(not(target_os = "macos"))]
             if self.export_image {
                 println!(
                     "msaa_texture_fd: {:?}",

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -71,7 +71,7 @@ impl Example {
             if self.export_image {
                 println!(
                     "msaa_texture_fd: {:?}",
-                    self.context.get_texture_fd(msaa_texture)
+                    self.context.get_external_texture_source(msaa_texture)
                 );
             }
 

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -84,6 +84,7 @@ impl Example {
             mip_level_count: 1,
             sample_count: 1,
             usage: gpu::TextureUsage::RESOURCE | gpu::TextureUsage::STORAGE,
+            external: None,
         });
         let target_view = context.create_texture_view(
             target,


### PR DESCRIPTION
The use I'm using it for is to have external images using a Win32 handle. Because this is very platform specific and niche I instead made a way to import self-made images and memory.

Specifically i exposed the vulkan device, the `Allocation` struct, `allocate_memory` and `free_memory`.
I added 2 functions to the vulkan context for importing memory and textures.
And added `select_memory_type` as a utility function.

I also added a way to add extensions when creating the context using a new struct `PlatformSpecificContextDesc`.
Which is used by the new function `init_with_platform_desc`. The original init function is still the same so it doesn't break anything.