### PR TITLE
Fix external_memory access when not needed

### DIFF
--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -677,12 +677,12 @@ fn fetch_external_source(
     device: &super::Device,
     allocation: Allocation,
 ) -> Option<crate::ExternalMemorySource> {
-    let device = device
-        .external_memory
-        .as_ref()
-        .expect("External memory is not supported");
     match allocation.memory_type {
         crate::Memory::External(e) => {
+            let device = device
+                .external_memory
+                .as_ref()
+                .expect("External memory is not supported");
             let memory = allocation.memory;
             let handle_type = external_source_handle_type(e);
 


### PR DESCRIPTION
Moved getting the external_memory device into the match itself.
This should be the only spot where i access this device, so the same kind of oopsie shouldn't be at another spot.
Fixes https://github.com/kvark/blade/issues/255#issuecomment-2877408678