### PR TITLE
vk: respect the scratch buffer alignment when creating buffers

### DIFF
--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -154,6 +154,7 @@ pub struct Context {
     physical_device: vk::PhysicalDevice,
     naga_flags: naga::back::spv::WriterFlags,
     shader_debug_path: Option<PathBuf>,
+    min_buffer_alignment: u64,
     instance: Instance,
     entry: ash::Entry,
 }

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -312,7 +312,8 @@ impl crate::traits::ResourceDevice for super::Context {
         }
 
         let raw = unsafe { self.device.core.create_buffer(&vk_info, None).unwrap() };
-        let requirements = unsafe { self.device.core.get_buffer_memory_requirements(raw) };
+        let mut requirements = unsafe { self.device.core.get_buffer_memory_requirements(raw) };
+        requirements.alignment = requirements.alignment.max(self.min_buffer_alignment);
         let allocation = self.allocate_memory(requirements, desc.memory);
 
         log::info!(


### PR DESCRIPTION
We are just going to apply this alignment to all buffers.
