### PR TITLE
fix: draw_indirect & draw_indexed_indirect

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -537,7 +537,7 @@ impl crate::traits::RenderPipelineEncoder for super::PipelineEncoder<'_> {
         });
     }
 
-    fn draw_indirect(&mut self, _indirect_buf: crate::BufferPiece) {
+    fn draw_indirect(&mut self, _indirect_buf: crate::BufferPiece, _draw_count: u32) {
         unimplemented!()
     }
 
@@ -546,6 +546,7 @@ impl crate::traits::RenderPipelineEncoder for super::PipelineEncoder<'_> {
         _index_buf: crate::BufferPiece,
         _index_type: crate::IndexType,
         _indirect_buf: crate::BufferPiece,
+        _draw_count: u32,
     ) {
         unimplemented!()
     }

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -88,6 +88,7 @@ pub use hal::*;
 #[cfg(target_arch = "wasm32")]
 pub const CANVAS_ID: &str = "blade";
 
+use bytemuck::{Pod, Zeroable};
 use std::{fmt, num::NonZeroU32};
 
 #[derive(Clone, Debug, Default)]
@@ -1189,3 +1190,37 @@ pub struct Viewport {
 }
 
 pub type Timings = Vec<(String, std::time::Duration)>;
+
+/// Argument buffer layout for `draw_indirect` commands.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+pub struct DrawIndirectArgs {
+    /// The number of vertices to draw.
+    pub vertex_count: u32,
+    /// The number of instances to draw.
+    pub instance_count: u32,
+    /// The Index of the first vertex to draw.
+    pub first_vertex: u32,
+    /// The instance ID of the first instance to draw.
+    ///
+    /// Has to be 0, unless [`Features::INDIRECT_FIRST_INSTANCE`](crate::Features::INDIRECT_FIRST_INSTANCE) is enabled.
+    pub first_instance: u32,
+}
+
+/// Argument buffer layout for `draw_indexed_indirect` commands.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+pub struct DrawIndexedIndirectArgs {
+    /// The number of indices to draw.
+    pub index_count: u32,
+    /// The number of instances to draw.
+    pub instance_count: u32,
+    /// The first index within the index buffer.
+    pub first_index: u32,
+    /// The value added to the vertex index before indexing into the vertex buffer.
+    pub base_vertex: i32,
+    /// The instance ID of the first instance to draw.
+    ///
+    /// Has to be 0, unless [`Features::INDIRECT_FIRST_INSTANCE`](crate::Features::INDIRECT_FIRST_INSTANCE) is enabled.
+    pub first_instance: u32,
+}

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -146,11 +146,12 @@ pub trait RenderPipelineEncoder: PipelineEncoder + RenderEncoder {
         start_instance: u32,
         instance_count: u32,
     );
-    fn draw_indirect(&mut self, indirect_buf: Self::BufferPiece);
+    fn draw_indirect(&mut self, indirect_buf: Self::BufferPiece, draw_count: u32);
     fn draw_indexed_indirect(
         &mut self,
         index_buf: Self::BufferPiece,
         index_type: crate::IndexType,
         indirect_buf: Self::BufferPiece,
+        draw_count: u32,
     );
 }

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -277,7 +277,7 @@ impl DebugRender {
                 depth,
             },
         );
-        pc.draw_indirect(self.buffer.at(0));
+        pc.draw_indirect(self.buffer.at(0), 1);
 
         if !debug_lines.is_empty() {
             let (lines_buf, count) = self.add_lines(debug_lines);


### PR DESCRIPTION
The `draw_indirect` and `draw_indexed_indirect` functions were missing the `draw_count` parameter. I added it, and now these two functions are working correctly.

Additionally, I copied the `DrawIndirectArgs` and `DrawIndexedIndirectArgs` structs from the `wgpu` project.
