### PR TITLE
feat: Add window handle to graphics context init

### DIFF
--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -442,6 +442,24 @@ struct ExecutionContext {
 }
 
 impl Context {
+    pub unsafe fn init<
+        W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
+    >(
+        desc: crate::ContextDesc,
+        window: Option<&W>,
+    ) -> Result<Self, crate::NotSupportedError> {
+        let (platform_context, capabilities, toggles, limits, device_information) =
+            platform::init_platform(desc, window)?;
+
+        Ok(Self {
+            platform: platform_context,
+            capabilities,
+            toggles,
+            limits,
+            device_information,
+        })
+    }
+
     pub fn capabilities(&self) -> crate::Capabilities {
         crate::Capabilities {
             ray_query: crate::ShaderVisibility::empty(),

--- a/blade-graphics/src/gles/web.rs
+++ b/blade-graphics/src/gles/web.rs
@@ -50,7 +50,21 @@ impl PlatformContext {
 }
 
 impl super::Context {
-    pub unsafe fn init(_desc: crate::ContextDesc) -> Result<Self, crate::NotSupportedError> {
+    pub unsafe fn init<
+        W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
+    >(
+        _desc: crate::ContextDesc,
+        _window: Option<&W>,
+    ) -> Result<
+        (
+            PlatformContext,
+            super::Capabilities,
+            super::Toggles,
+            super::Limits,
+            crate::DeviceInformation,
+        ),
+        crate::NotSupportedError,
+    > {
         let canvas = web_sys::window()
             .and_then(|win| win.document())
             .expect("Cannot get document")
@@ -89,13 +103,13 @@ impl super::Context {
             driver_info: glow.get_parameter_string(glow::VERSION),
         };
 
-        Ok(super::Context {
-            platform: PlatformContext { webgl2, glow },
+        Ok((
+            PlatformContext { webgl2, glow },
             capabilities,
-            toggles: super::Toggles::default(),
+            super::Toggles::default(),
             limits,
             device_information,
-        })
+        ))
     }
 
     pub fn create_surface<I>(

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -439,7 +439,12 @@ fn map_vertex_format(
 }
 
 impl Context {
-    pub unsafe fn init(desc: super::ContextDesc) -> Result<Self, super::NotSupportedError> {
+    pub unsafe fn init<
+        W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
+    >(
+        desc: super::ContextDesc,
+        _window: Option<&W>,
+    ) -> Result<Self, super::NotSupportedError> {
         if desc.validation {
             std::env::set_var("METAL_DEVICE_WRAPPER_TYPE", "1");
         }

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -329,7 +329,7 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn transfer(&mut self, label: &str) -> super::TransferCommandEncoder {
+    pub fn transfer(&mut self, label: &str) -> super::TransferCommandEncoder<'_> {
         self.begin_pass(label);
         super::TransferCommandEncoder {
             raw: self.buffers[0].raw,
@@ -340,7 +340,7 @@ impl super::CommandEncoder {
     pub fn acceleration_structure(
         &mut self,
         label: &str,
-    ) -> super::AccelerationStructureCommandEncoder {
+    ) -> super::AccelerationStructureCommandEncoder<'_> {
         self.begin_pass(label);
         super::AccelerationStructureCommandEncoder {
             raw: self.buffers[0].raw,
@@ -348,7 +348,7 @@ impl super::CommandEncoder {
         }
     }
 
-    pub fn compute(&mut self, label: &str) -> super::ComputeCommandEncoder {
+    pub fn compute(&mut self, label: &str) -> super::ComputeCommandEncoder<'_> {
         self.begin_pass(label);
         super::ComputeCommandEncoder {
             cmd_buf: self.buffers.first_mut().unwrap(),
@@ -361,7 +361,7 @@ impl super::CommandEncoder {
         &mut self,
         label: &str,
         targets: crate::RenderTargetSet,
-    ) -> super::RenderCommandEncoder {
+    ) -> super::RenderCommandEncoder<'_> {
         self.begin_pass(label);
 
         let mut target_size = [0u16; 2];

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -710,7 +710,7 @@ impl Device {
     fn map_acceleration_structure_meshes(
         &self,
         meshes: &[crate::AccelerationStructureMesh],
-    ) -> BottomLevelAccelerationStructureInput {
+    ) -> BottomLevelAccelerationStructureInput<'_> {
         let mut total_primitive_count = 0;
         let mut max_primitive_counts = Vec::with_capacity(meshes.len());
         let mut build_range_infos = Vec::with_capacity(meshes.len());

--- a/blade-graphics/src/vulkan/pipeline.rs
+++ b/blade-graphics/src/vulkan/pipeline.rs
@@ -13,7 +13,7 @@ struct CompiledShader<'a> {
 }
 
 impl super::Context {
-    fn make_spv_options(&self, data_layouts: &[&crate::ShaderDataLayout]) -> spv::Options {
+    fn make_spv_options(&self, data_layouts: &[&crate::ShaderDataLayout]) -> spv::Options<'_> {
         // collect all the array bindings into overrides
         let mut binding_map = spv::BindingMap::default();
         for (group_index, layout) in data_layouts.iter().enumerate() {
@@ -60,7 +60,7 @@ impl super::Context {
         group_layouts: &[&crate::ShaderDataLayout],
         group_infos: &mut [crate::ShaderDataInfo],
         vertex_fetch_states: &[crate::VertexFetchState],
-    ) -> CompiledShader {
+    ) -> CompiledShader<'_> {
         let ep_index = sf.entry_point_index();
         let ep = &sf.shader.module.entry_points[ep_index];
         let ep_info = sf.shader.info.get_entry_point(ep_index);

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -77,14 +77,17 @@ impl Example {
 
     fn new(window: &winit::window::Window) -> Self {
         let context = unsafe {
-            gpu::Context::init(gpu::ContextDesc {
-                presentation: true,
-                validation: cfg!(debug_assertions),
-                timing: false,
-                capture: false,
-                overlay: true,
-                device_id: 0,
-            })
+            gpu::Context::init(
+                gpu::ContextDesc {
+                    presentation: true,
+                    validation: cfg!(debug_assertions),
+                    timing: false,
+                    capture: false,
+                    overlay: true,
+                    device_id: 0,
+                },
+                Some(window),
+            )
             .unwrap()
         };
         println!("{:?}", context.device_information());

--- a/examples/init/main.rs
+++ b/examples/init/main.rs
@@ -143,7 +143,13 @@ fn main() {
     let mut rd = renderdoc::RenderDoc::<renderdoc::V120>::new();
 
     println!("Initializing");
-    let context = Arc::new(unsafe { gpu::Context::init(gpu::ContextDesc::default()).unwrap() });
+    let context = Arc::new(unsafe {
+        gpu::Context::init(
+            gpu::ContextDesc::default(),
+            None as Option<&winit::window::Window>,
+        )
+        .unwrap()
+    });
 
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     if let Ok(ref mut rd) = rd {

--- a/examples/mini/main.rs
+++ b/examples/mini/main.rs
@@ -31,7 +31,13 @@ impl gpu::ShaderData for Globals {
 
 fn main() {
     env_logger::init();
-    let context = unsafe { gpu::Context::init(gpu::ContextDesc::default()).unwrap() };
+    let context = unsafe {
+        gpu::Context::init(
+            gpu::ContextDesc::default(),
+            None as Option<&winit::window::Window>,
+        )
+        .unwrap()
+    };
 
     let global_layout = <Globals as gpu::ShaderData>::layout();
     let shader_source = std::fs::read_to_string("examples/mini/shader.wgsl").unwrap();

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -115,14 +115,16 @@ impl Example {
     fn new(window: &winit::window::Window) -> Self {
         let window_size = window.inner_size();
         let context = unsafe {
-            gpu::Context::init(gpu::ContextDesc {
-                presentation: true,
-                validation: cfg!(debug_assertions),
-                timing: true,
-                capture: false,
-
-                ..Default::default()
-            })
+            gpu::Context::init(
+                gpu::ContextDesc {
+                    presentation: true,
+                    validation: cfg!(debug_assertions),
+                    timing: true,
+                    capture: false,
+                    ..Default::default()
+                },
+                Some(window),
+            )
             .unwrap()
         };
         let surface = context

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -48,11 +48,14 @@ impl Example {
     fn new(window: &winit::window::Window) -> Self {
         let window_size = window.inner_size();
         let context = unsafe {
-            gpu::Context::init(gpu::ContextDesc {
-                presentation: true,
-                validation: cfg!(debug_assertions),
-                ..Default::default()
-            })
+            gpu::Context::init(
+                gpu::ContextDesc {
+                    presentation: true,
+                    validation: cfg!(debug_assertions),
+                    ..Default::default()
+                },
+                Some(window),
+            )
             .unwrap()
         };
         let capabilities = context.capabilities();

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -184,12 +184,15 @@ impl Example {
         log::info!("Initializing");
 
         let context = Arc::new(unsafe {
-            gpu::Context::init(gpu::ContextDesc {
-                presentation: true,
-                validation: cfg!(debug_assertions),
-                capture: true,
-                ..Default::default()
-            })
+            gpu::Context::init(
+                gpu::ContextDesc {
+                    presentation: true,
+                    validation: cfg!(debug_assertions),
+                    capture: true,
+                    ..Default::default()
+                },
+                Some(window),
+            )
             .unwrap()
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,14 +412,17 @@ impl Engine {
         log::info!("Initializing the engine");
 
         let gpu_context = Arc::new(unsafe {
-            gpu::Context::init(gpu::ContextDesc {
-                presentation: true,
-                validation: cfg!(debug_assertions),
-                timing: true,
-                capture: false,
-                overlay: false,
-                device_id: 0,
-            })
+            gpu::Context::init(
+                gpu::ContextDesc {
+                    presentation: true,
+                    validation: cfg!(debug_assertions),
+                    timing: true,
+                    capture: false,
+                    overlay: false,
+                    device_id: 0,
+                },
+                Some(window),
+            )
             .unwrap()
         });
 


### PR DESCRIPTION
This change allows the graphics context to take an optional window handle during initialization. Because the graphics queue family is not being selected correctly, causing issues with surface creation.

The current implementation hardcodes the queue family index to 0, which isn't always correct, especially on systems with multiple GPUs (like a laptop with an integrated and a discrete GPU).

This by properly querying for a queue family that supports graphics operations, should resolve the issue on NVIDIA-based systems.

Fixes: #120