### PR TITLE
vk: clean up activated extensions in headless

### DIFF
--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -23,7 +23,7 @@ struct Instance {
     core: ash::Instance,
     _debug_utils: ash::ext::debug_utils::Instance,
     get_physical_device_properties2: khr::get_physical_device_properties2::Instance,
-    get_surface_capabilities2: khr::get_surface_capabilities2::Instance,
+    get_surface_capabilities2: Option<khr::get_surface_capabilities2::Instance>,
     surface: Option<khr::surface::Instance>,
 }
 

--- a/blade-graphics/src/vulkan/surface.rs
+++ b/blade-graphics/src/vulkan/surface.rs
@@ -104,6 +104,8 @@ impl super::Context {
         let _ = unsafe {
             self.instance
                 .get_surface_capabilities2
+                .as_ref()
+                .unwrap()
                 .get_physical_device_surface_capabilities2(
                     self.physical_device,
                     &surface_info,


### PR DESCRIPTION
Fixes the following VVL:
```
Validation Error: [ VUID-vkCreateInstance-ppEnabledExtensionNames-01388 ] | MessageID = 0xe5e52180
vkCreateInstance(): pCreateInfo->ppEnabledExtensionNames[2] Missing extension required by the instance extension VK_KHR_get_surface_capabilities2: VK_KHR_surface.
The Vulkan spec states: All required extensions for each extension in the VkInstanceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://docs.vulkan.org/spec/latest/chapters/initialization.html#VUID-vkCreateInstance-ppEnabledExtensionNames-01388)


Validation Error: [ VUID-vkCreateInstance-ppEnabledExtensionNames-01388 ] | MessageID = 0xe5e52180
vkCreateInstance(): pCreateInfo->ppEnabledExtensionNames[3] Missing extension required by the instance extension VK_EXT_swapchain_colorspace: VK_KHR_surface.
The Vulkan spec states: All required extensions for each extension in the VkInstanceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://docs.vulkan.org/spec/latest/chapters/initialization.html#VUID-vkCreateInstance-ppEnabledExtensionNames-01388)
```