### PR TITLE
Allow buffers used for uniform data

### DIFF
--- a/blade-graphics/src/shader.rs
+++ b/blade-graphics/src/shader.rs
@@ -177,7 +177,9 @@ impl super::Shader {
                         }
                         _ => {
                             let type_layout = &layouter[var.ty];
-                            let proto = if var_access.is_empty() {
+                            let proto = if var_access.is_empty()
+                                && proto_binding != crate::ShaderBinding::Buffer
+                            {
                                 crate::ShaderBinding::Plain {
                                     size: type_layout.size,
                                 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for *Blade* project
 
 - graphics
   - pipeline constants API
+  - allow buffer bindings for uniform data
   - supported MSAA samples are now returned in context `Capabilities`
 
 ## blade-graphics-0.6, blade-util-0.2, blade-egui-0.6, blade-render-0.4, blade-0.3 (21 Dec 2024)

--- a/examples/mini/shader.wgsl
+++ b/examples/mini/shader.wgsl
@@ -2,6 +2,7 @@ var input: texture_2d<f32>;
 var output: texture_storage_2d<rgba8unorm, write>;
 
 var<uniform> modulator: vec4<f32>;
+var<uniform> demodulator: vec4<f32>;
 
 @compute
 @workgroup_size(8, 8)


### PR DESCRIPTION
Sometimes it's useful for the client to have the uniform data managed externally. And they wouldn't want to use a storage buffer because it has different caching/broadcasting policies.