### PR TITLE
GLES: Use surfaceless platform only if presentation is false

### DIFF
--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -223,7 +223,10 @@ impl super::Context {
                         &display_attributes,
                     )
                     .unwrap()
-            } else if client_extensions.contains("EGL_MESA_platform_surfaceless") {
+            } else if client_extensions.contains("EGL_MESA_platform_surfaceless")
+                && !desc.presentation
+            {
+                // ONLY use surfaceless for headless contexts
                 log::info!("Using surfaceless platform");
                 egl1_5
                     .get_platform_display(


### PR DESCRIPTION
## Work Around EGL BadNativeWindow Panic on Linux

### Problem
**EGL backend panics with `BadNativeWindow` when creating window surfaces** on Linux systems. The root cause is that surfaceless displays (selected via `EGL_MESA_platform_surfaceless`) are fundamentally incompatible with window surface creation.

### Workaround
Prevent the selection of surfaceless displays for windowed contexts, forcing the fallback to default EGL display instead.

### Changes Made
**One-line change in `src/gles/egl.rs`**:
```rust
// BEFORE: Unconditionally using surfaceless (leads to BadNativeWindow)
} else if client_extensions.contains("EGL_MESA_platform_surfaceless") {

// AFTER: Avoid surfaceless for windowed contexts, use fallback instead
} else if client_extensions.contains("EGL_MESA_platform_surfaceless") && !desc.presentation {
```

### What This Does
- **For windowed apps** (`presentation: true`): Skips surfaceless, uses default EGL display (fallback)
- **For headless apps** (`presentation: false`): Still uses surfaceless for optimization
- **Doesn't fix** the underlying platform detection issue
- **Doesn't implement** proper X11/Wayland platform support

### Platform Context
- **ANGLE**: Primarily targets Windows/macOS (DirectX/Metal translation), not well-suited for native Linux
- **Surfaceless**: Designed for headless/offscreen rendering, incompatible with window surfaces  
- **Native Linux**: Should use proper X11/Wayland platforms, but current code lacks this detection

### Impact
- ✅ **Prevents panic**: Windowed apps no longer crash with `BadNativeWindow`
- ⚠️ **Suboptimal**: Uses generic EGL display instead of proper platform-specific one
- ✅ **Temporary solution**: Unblocks users while proper fix is developed
- ✅ **No regression**: Headless rendering still benefits from surfaceless

### Note
This is a **temporary workaround**, not a proper fix. The comprehensive solution requires restoring platform-specific display creation for X11/Wayland, which will be addressed in a follow-up PR.
