### PR TITLE
vulkan: Explicitly enable dualSrcBlend feature to fix rendering artifacts

### DIFF
--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -540,6 +540,16 @@ impl super::Context {
                     .push_next(&mut khr_ray_query);
             }
 
+            let mut core_features = vk::PhysicalDeviceFeatures::default();
+            if capabilities.dual_source_blending {
+                core_features.dual_src_blend = vk::TRUE;
+            }
+
+            let mut device_features2 =
+                vk::PhysicalDeviceFeatures2::default().features(core_features);
+
+            device_create_info = device_create_info.push_next(&mut device_features2);
+
             instance
                 .core
                 .create_device(physical_device, &device_create_info, None)


### PR DESCRIPTION
# Summary

This PR fixes a Vulkan validation error and severe visual artifacts (green mosaic on AMD/RADV) caused by using dual-source blending without explicitly enabling the feature on the logical device.

# The Fix

I updated blade-graphics/src/vulkan/init.rs to explicitly enable the dual_src_blend feature in vk::PhysicalDeviceFeatures if the physical device supports it.

# Linked Issue

Addresses part of zed-industries/zed#47650
