### PR TITLE
Fixes a panic in Metal backend when creating render pipelines with fragment shaders.

### DIFF
--- a/blade-graphics/src/metal/pipeline.rs
+++ b/blade-graphics/src/metal/pipeline.rs
@@ -321,7 +321,7 @@ impl super::Context {
             });
 
         let ep = &module.entry_points[ep_index];
-        // MSL compilation with per_entry_point_map produces info with only one entry point at index 0
+        // MSL compilation with PipelineOptions::entry_point specified produces info with only one entry point at index 0
         let name = info.entry_point_names[0].as_ref().unwrap();
         let wg_size = metal::MTLSize {
             width: ep.workgroup_size[0] as _,


### PR DESCRIPTION
## Note

I am not much of a graphics dev, found this issue playing with my [rendering engine](https://github.com/Far-Beyond-Pulsar/Helio) project PLEASE DOUBLE CHECK ME ON THIS

## Summary
Fixes a panic in Metal backend when creating render pipelines with fragment shaders.

## Issue
The Metal pipeline creation panics with:

```
index out of bounds: the len is 1 but the index is 1
at blade-graphics/src/metal/pipeline.rs:324
```

This occurs when creating any render pipeline with a fragment shader on macOS.

## Root Cause
When compiling shaders with `per_entry_point_map` in naga, the output `info` struct contains only the single requested entry point at index 0, regardless of its position in the original module.

The code was using `ep_index` (from the original module, where fragment shader is typically at index 1) to access `info.entry_point_names`, which only has 1 element at index 0.

- Vertex shader: `ep_index=0` → `info.entry_point_names[0]` ✓
- Fragment shader: `ep_index=1` → `info.entry_point_names[1]` ✗ panic

## Solution
Use index 0 to access `info.entry_point_names` since naga's per-entry-point compilation always produces a single entry point at index 0. We still correctly use `ep_index` for accessing the original module's entry points.

## Testing
Any render pipeline creation with a fragment shader now works correctly on macOS/Metal. Previously, all such pipelines would panic at initialization.
