### PR TITLE
Add ComputeCommandEncoder::barrier() on all backends

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -290,6 +290,11 @@ impl crate::traits::CommandEncoder for super::CommandEncoder {
 }
 
 impl super::PassEncoder<'_, super::ComputePipeline> {
+    /// Insert a compute-to-compute memory barrier within the current pass.
+    pub fn barrier(&mut self) {
+        self.commands.push(super::Command::Barrier);
+    }
+
     pub fn with<'b>(
         &'b mut self,
         pipeline: &'b super::ComputePipeline,
@@ -1100,7 +1105,13 @@ impl super::Command {
                     (None, Some(s)) => gl.clear_buffer_i32_slice(glow::STENCIL, 0, &[s as i32]),
                     (None, None) => (),
                 },
-                Self::Barrier => unimplemented!(),
+                Self::Barrier => {
+                    gl.memory_barrier(
+                        glow::SHADER_STORAGE_BARRIER_BIT
+                            | glow::BUFFER_UPDATE_BARRIER_BIT
+                            | glow::UNIFORM_BARRIER_BIT,
+                    );
+                }
                 Self::SetViewport(ref vp) => {
                     gl.viewport(vp.x as i32, vp.y as i32, vp.w as i32, vp.h as i32);
                     gl.depth_range_f32(vp.depth.start, vp.depth.end);

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -641,6 +641,18 @@ impl Drop for super::AccelerationStructureCommandEncoder<'_> {
 }
 
 impl super::ComputeCommandEncoder<'_> {
+    /// Insert a compute-to-compute memory barrier within the current pass.
+    ///
+    /// Ensures that storage buffer writes from preceding dispatches are
+    /// visible to subsequent dispatches without ending the compute encoder.
+    pub fn barrier(&mut self) {
+        // MTLBarrierScope.buffers = 1 << 0
+        // memoryBarrier(scope:) requires macOS 10.14+ / iOS 12.0+
+        unsafe {
+            let _: () = objc2::msg_send![&*self.raw, memoryBarrierWithScope: 1u64];
+        }
+    }
+
     pub fn with<'p>(
         &'p mut self,
         pipeline: &'p super::ComputePipeline,

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -848,6 +848,33 @@ impl Drop for super::AccelerationStructureCommandEncoder<'_> {
 }
 
 impl<'a> super::ComputeCommandEncoder<'a> {
+    /// Insert a compute-to-compute memory barrier within the current pass.
+    ///
+    /// Ensures that storage buffer writes from preceding dispatches are
+    /// visible to subsequent dispatches, without ending the compute pass.
+    /// Uses `COMPUTE_SHADER` stage scope since this is inherently a
+    /// compute-only synchronization point.
+    pub fn barrier(&mut self) {
+        let barrier = vk::MemoryBarrier {
+            src_access_mask: vk::AccessFlags::SHADER_WRITE,
+            dst_access_mask: vk::AccessFlags::SHADER_READ
+                | vk::AccessFlags::SHADER_WRITE
+                | vk::AccessFlags::UNIFORM_READ,
+            ..Default::default()
+        };
+        unsafe {
+            self.device.core.cmd_pipeline_barrier(
+                self.cmd_buf.raw,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(),
+                &[barrier],
+                &[],
+                &[],
+            );
+        }
+    }
+
     pub fn with<'b, 'p>(
         &'b mut self,
         pipeline: &'p super::ComputePipeline,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog for *Blade* project
 ## blade-graphics-0.8.2 (TBD)
 
 - metal: enable fast math, skip debug groups in production
+- add `ComputeCommandEncoder::barrier()` for inline compute-to-compute synchronization within a pass
 
 ## blade-graphics-0.8.1 (28 Mar 2026)
 


### PR DESCRIPTION
Portable compute-to-compute memory barrier within a compute pass, without ending and re-starting the pass.

- Vulkan: vkCmdPipelineBarrier with COMPUTE_SHADER stage and SHADER_WRITE → SHADER_READ | SHADER_WRITE | UNIFORM_READ.
- Metal: memoryBarrierWithScope:.buffers (macOS 10.14+).
- GLES: glMemoryBarrier with SHADER_STORAGE | BUFFER_UPDATE | UNIFORM barrier bits.