### PR TITLE
vk: Dynamic per-binding IUB/UBO selection based on device limits

### DIFF
--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -52,38 +52,40 @@ impl super::PipelineContext<'_> {
 
 impl<T: bytemuck::Pod> crate::ShaderBindable for T {
     fn bind_to(&self, ctx: &mut super::PipelineContext, index: u32) {
-        let descriptor_buf_info = if let Some(ref mut scratch) = ctx.scratch {
-            // UBO fallback: copy data to scratch buffer
-            let data = bytemuck::bytes_of(self);
-            let aligned_offset =
-                (scratch.offset + scratch.alignment - 1) & !(scratch.alignment - 1);
-            let end = aligned_offset + data.len() as u64;
-            assert!(
-                end <= scratch.capacity,
-                "Scratch buffer overflow: needed {end}, capacity {}",
-                scratch.capacity
-            );
-            unsafe {
-                ptr::copy_nonoverlapping(
-                    data.as_ptr(),
-                    scratch.mapped.add(aligned_offset as usize),
-                    data.len(),
-                );
-            }
-            scratch.offset = end;
-            Some(vk::DescriptorBufferInfo {
-                buffer: scratch.raw,
-                offset: aligned_offset,
-                range: data.len() as u64,
-            })
-        } else {
-            None
-        };
-        if let Some(info) = descriptor_buf_info {
-            ctx.write(index, info);
-        } else {
+        if ctx.inline_uniform_mask & (1 << index) != 0 {
             // Inline uniform block mode: write raw data directly
             ctx.write(index, *self);
+        } else {
+            // UBO mode: copy data to scratch buffer, then write descriptor
+            let info = {
+                let scratch = ctx
+                    .scratch
+                    .as_mut()
+                    .expect("scratch buffer required for UBO binding");
+                let data = bytemuck::bytes_of(self);
+                let aligned_offset =
+                    (scratch.offset + scratch.alignment - 1) & !(scratch.alignment - 1);
+                let end = aligned_offset + data.len() as u64;
+                assert!(
+                    end <= scratch.capacity,
+                    "Scratch buffer overflow: needed {end}, capacity {}",
+                    scratch.capacity
+                );
+                unsafe {
+                    ptr::copy_nonoverlapping(
+                        data.as_ptr(),
+                        scratch.mapped.add(aligned_offset as usize),
+                        data.len(),
+                    );
+                }
+                scratch.offset = end;
+                vk::DescriptorBufferInfo {
+                    buffer: scratch.raw,
+                    offset: aligned_offset,
+                    range: data.len() as u64,
+                }
+            };
+            ctx.write(index, info);
         }
     }
 }
@@ -1003,6 +1005,7 @@ impl crate::traits::PipelineEncoder for super::PipelineEncoder<'_, '_> {
                 update_data: self.update_data.as_mut_slice(),
                 template_offsets: &dsl.template_offsets,
                 scratch: self.cmd_buf.scratch.as_mut(),
+                inline_uniform_mask: dsl.inline_uniform_mask,
             });
         }
 

--- a/blade-graphics/src/vulkan/descriptor.rs
+++ b/blade-graphics/src/vulkan/descriptor.rs
@@ -31,17 +31,18 @@ impl super::Device {
                 descriptor_count: max_sets,
             },
         ];
-        if self.inline_uniform_blocks {
+        if self.max_inline_uniform_block_size > 0 {
             descriptor_sizes.push(vk::DescriptorPoolSize {
                 ty: vk::DescriptorType::INLINE_UNIFORM_BLOCK_EXT,
-                descriptor_count: max_sets * crate::limits::PLAIN_DATA_SIZE,
-            });
-        } else {
-            descriptor_sizes.push(vk::DescriptorPoolSize {
-                ty: vk::DescriptorType::UNIFORM_BUFFER,
-                descriptor_count: max_sets,
+                descriptor_count: max_sets * self.max_inline_uniform_block_size,
             });
         }
+        // Always include UBO type: needed as fallback when bindings exceed
+        // the inline uniform block size limit, or when IUBs aren't supported.
+        descriptor_sizes.push(vk::DescriptorPoolSize {
+            ty: vk::DescriptorType::UNIFORM_BUFFER,
+            descriptor_count: max_sets,
+        });
         if self.ray_tracing.is_some() {
             descriptor_sizes.push(vk::DescriptorPoolSize {
                 ty: vk::DescriptorType::ACCELERATION_STRUCTURE_KHR,
@@ -58,7 +59,7 @@ impl super::Device {
             .max_sets(max_sets)
             .flags(self.workarounds.extra_descriptor_pool_create_flags)
             .pool_sizes(&descriptor_sizes);
-        if self.inline_uniform_blocks {
+        if self.max_inline_uniform_block_size > 0 {
             descriptor_pool_info = descriptor_pool_info.push_next(&mut inline_uniform_block_info);
         }
 

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -341,25 +341,21 @@ fn inspect_adapter(
         && inline_uniform_block_features.inline_uniform_block != 0;
     // Adreno 740 (Qualcomm) has a driver bug: inline uniform blocks combined
     // with inter-stage varyings cause "Failed to link shaders" at pipeline creation.
-    let max_inline_uniform_block_size = if has_inline_ub
-        && properties.vendor_id != db::qualcomm::VENDOR
-    {
-        inline_uniform_block_properties.max_inline_uniform_block_size
-    } else {
-        0
-    };
-    if max_inline_uniform_block_size == 0 {
-        log::info!(
-            "Inline uniform blocks disabled (supported={}, vendor=0x{:X}). Using UBO fallback.",
-            has_inline_ub,
-            properties.vendor_id,
-        );
-    } else {
-        log::info!(
-            "Inline uniform blocks enabled (max size per binding: {} bytes)",
-            max_inline_uniform_block_size,
-        );
-    }
+    let max_inline_uniform_block_size =
+        if has_inline_ub && properties.vendor_id != db::qualcomm::VENDOR {
+            log::info!(
+                "Inline uniform blocks enabled (max size per binding: {} bytes)",
+                inline_uniform_block_properties.max_inline_uniform_block_size,
+            );
+            inline_uniform_block_properties.max_inline_uniform_block_size
+        } else {
+            log::info!(
+                "Inline uniform blocks disabled (supported={}, vendor=0x{:X}). Using UBO fallback.",
+                has_inline_ub,
+                properties.vendor_id,
+            );
+            0
+        };
 
     if timeline_semaphore_features.timeline_semaphore == 0 {
         return Err("timeline semaphore feature is not supported".to_string());

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -97,7 +97,7 @@ struct AdapterCapabilities {
     binding_array: bool,
     ray_tracing: Option<RayTracingCapabilities>,
     buffer_device_address: bool,
-    inline_uniform_blocks: bool,
+    max_inline_uniform_block_size: u32,
     buffer_marker: bool,
     shader_info: bool,
     full_screen_exclusive: bool,
@@ -337,18 +337,27 @@ fn inspect_adapter(
     let shader_float16 = float16_int8_features.shader_float16 != 0;
 
     let has_inline_ub = supported_extensions.contains(&vk::EXT_INLINE_UNIFORM_BLOCK_NAME)
-        && inline_uniform_block_properties.max_inline_uniform_block_size
-            >= crate::limits::PLAIN_DATA_SIZE
         && inline_uniform_block_properties.max_descriptor_set_inline_uniform_blocks > 0
         && inline_uniform_block_features.inline_uniform_block != 0;
     // Adreno 740 (Qualcomm) has a driver bug: inline uniform blocks combined
     // with inter-stage varyings cause "Failed to link shaders" at pipeline creation.
-    let inline_uniform_blocks = has_inline_ub && properties.vendor_id != db::qualcomm::VENDOR;
-    if !inline_uniform_blocks {
+    let max_inline_uniform_block_size = if has_inline_ub
+        && properties.vendor_id != db::qualcomm::VENDOR
+    {
+        inline_uniform_block_properties.max_inline_uniform_block_size
+    } else {
+        0
+    };
+    if max_inline_uniform_block_size == 0 {
         log::info!(
             "Inline uniform blocks disabled (supported={}, vendor=0x{:X}). Using UBO fallback.",
             has_inline_ub,
             properties.vendor_id,
+        );
+    } else {
+        log::info!(
+            "Inline uniform blocks enabled (max size per binding: {} bytes)",
+            max_inline_uniform_block_size,
         );
     }
 
@@ -533,7 +542,7 @@ fn inspect_adapter(
         binding_array,
         ray_tracing,
         buffer_device_address,
-        inline_uniform_blocks,
+        max_inline_uniform_block_size,
         buffer_marker,
         shader_info,
         full_screen_exclusive,
@@ -893,7 +902,7 @@ impl super::Context {
             let family_infos = [family_info];
 
             let mut device_extensions = REQUIRED_DEVICE_EXTENSIONS.to_vec();
-            if capabilities.inline_uniform_blocks {
+            if capabilities.max_inline_uniform_block_size > 0 {
                 device_extensions.push(vk::EXT_INLINE_UNIFORM_BLOCK_NAME);
             }
             if desc.presentation {
@@ -975,7 +984,7 @@ impl super::Context {
                 .enabled_extension_names(&str_pointers)
                 .push_next(&mut khr_timeline_semaphore)
                 .push_next(&mut khr_dynamic_rendering);
-            if capabilities.inline_uniform_blocks {
+            if capabilities.max_inline_uniform_block_size > 0 {
                 device_create_info = device_create_info.push_next(&mut ext_inline_uniform_block);
             }
 
@@ -1121,7 +1130,7 @@ impl super::Context {
                 None
             },
             buffer_device_address: capabilities.buffer_device_address,
-            inline_uniform_blocks: capabilities.inline_uniform_blocks,
+            max_inline_uniform_block_size: capabilities.max_inline_uniform_block_size,
             buffer_marker: if capabilities.buffer_marker && desc.validation {
                 Some(amd::buffer_marker::Device::new(
                     &instance.core,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -61,7 +61,7 @@ struct Device {
     dynamic_rendering: khr::dynamic_rendering::Device,
     ray_tracing: Option<RayTracingDevice>,
     buffer_device_address: bool,
-    inline_uniform_blocks: bool,
+    max_inline_uniform_block_size: u32,
     buffer_marker: Option<ash::amd::buffer_marker::Device>,
     shader_info: Option<ash::amd::shader_info::Device>,
     full_screen_exclusive: Option<ash::ext::full_screen_exclusive::Device>,
@@ -361,6 +361,9 @@ struct DescriptorSetLayout {
     update_template: vk::DescriptorUpdateTemplate,
     template_size: u32,
     template_offsets: Box<[u32]>,
+    /// Bitmask: bit N is set if binding N uses inline uniform blocks.
+    /// Clear bits use uniform buffer objects via the scratch buffer.
+    inline_uniform_mask: u64,
 }
 
 impl DescriptorSetLayout {
@@ -389,6 +392,8 @@ pub struct PipelineContext<'a> {
     update_data: &'a mut [u8],
     template_offsets: &'a [u32],
     scratch: Option<&'a mut ScratchBuffer>,
+    /// Bitmask: bit N is set if binding N uses inline uniform blocks.
+    inline_uniform_mask: u64,
 }
 
 #[derive(Debug)]
@@ -520,24 +525,23 @@ impl crate::traits::CommandDevice for Context {
                 } else {
                     vk::QueryPool::null()
                 };
-                let scratch = if !self.device.inline_uniform_blocks {
-                    const SCRATCH_SIZE: u64 = 1 << 20; // 1 MiB
-                    let buf = self.create_buffer(crate::BufferDesc {
-                        name: "_scratch",
-                        size: SCRATCH_SIZE,
-                        memory: crate::Memory::Shared,
-                    });
-                    Some(ScratchBuffer {
-                        raw: buf.raw,
-                        memory_handle: buf.memory_handle,
-                        mapped: buf.mapped_data,
-                        capacity: SCRATCH_SIZE,
-                        offset: 0,
-                        alignment: self.min_uniform_buffer_offset_alignment,
-                    })
-                } else {
-                    None
-                };
+                // Always create a scratch buffer for UBO bindings.
+                // Even when inline uniform blocks are supported, individual
+                // bindings that exceed the device limit fall back to UBOs.
+                const SCRATCH_SIZE: u64 = 1 << 20; // 1 MiB
+                let scratch_buf = self.create_buffer(crate::BufferDesc {
+                    name: "_scratch",
+                    size: SCRATCH_SIZE,
+                    memory: crate::Memory::Shared,
+                });
+                let scratch = Some(ScratchBuffer {
+                    raw: scratch_buf.raw,
+                    memory_handle: scratch_buf.memory_handle,
+                    mapped: scratch_buf.mapped_data,
+                    capacity: SCRATCH_SIZE,
+                    offset: 0,
+                    alignment: self.min_uniform_buffer_offset_alignment,
+                });
                 CommandBuffer {
                     raw,
                     descriptor_pool,

--- a/blade-graphics/src/vulkan/pipeline.rs
+++ b/blade-graphics/src/vulkan/pipeline.rs
@@ -186,6 +186,7 @@ impl super::Context {
         let mut template_entries = Vec::with_capacity(layout.bindings.len());
         let mut template_offsets = Vec::with_capacity(layout.bindings.len());
         let mut binding_flags = Vec::with_capacity(layout.bindings.len());
+        let mut inline_uniform_mask = 0u64;
         let mut update_offset = 0;
         for (binding_index, (&(_, binding), &access)) in layout
             .bindings
@@ -245,7 +246,7 @@ impl super::Context {
                     vk::DescriptorBindingFlags::PARTIALLY_BOUND,
                 ),
                 crate::ShaderBinding::Plain { size } => {
-                    if self.device.inline_uniform_blocks {
+                    if size <= self.device.max_inline_uniform_block_size {
                         (
                             vk::DescriptorType::INLINE_UNIFORM_BLOCK_EXT,
                             1,
@@ -270,25 +271,7 @@ impl super::Context {
                     binding_index,
                     descriptor_count
                 );
-                assert!(
-                    descriptor_count <= crate::limits::PLAIN_DATA_SIZE,
-                    "Inline uniform block binding {} size {} exceeds blade limit {}",
-                    binding_index,
-                    descriptor_count,
-                    crate::limits::PLAIN_DATA_SIZE
-                );
-            }
-            // UBO fallback: ensure Plain size fits in the scratch buffer
-            if descriptor_type == vk::DescriptorType::UNIFORM_BUFFER
-                && let crate::ShaderBinding::Plain { size } = binding
-            {
-                assert!(
-                    size <= crate::limits::PLAIN_DATA_SIZE,
-                    "UBO binding {} size {} exceeds blade limit {}",
-                    binding_index,
-                    size,
-                    crate::limits::PLAIN_DATA_SIZE
-                );
+                inline_uniform_mask |= 1 << binding_index;
             }
 
             vk_bindings.push(vk::DescriptorSetLayoutBinding {
@@ -339,6 +322,7 @@ impl super::Context {
             update_template,
             template_size: update_offset as u32,
             template_offsets: template_offsets.into_boxed_slice(),
+            inline_uniform_mask,
         }
     }
 

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -308,9 +308,9 @@ impl crate::traits::ResourceDevice for super::Context {
             sharing_mode: vk::SharingMode::EXCLUSIVE,
             ..Default::default()
         };
-        if !self.device.inline_uniform_blocks {
-            vk_info.usage |= Buf::UNIFORM_BUFFER;
-        }
+        // Always include UNIFORM_BUFFER usage: even when inline uniform blocks
+        // are supported, bindings that exceed the device limit fall back to UBOs.
+        vk_info.usage |= Buf::UNIFORM_BUFFER;
         if let Some(external_next) = external_next.as_mut() {
             vk_info = vk_info.push_next(external_next);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,10 @@ Changelog for *Blade* project
 
 ## blade-graphics-0.8.2 (TBD)
 
-- metal: enable fast math, skip debug groups in production
 - add `ComputeCommandEncoder::barrier()` for inline compute-to-compute synchronization within a pass
 - enable `naga::valid::Capabilities::SUBGROUP` for shader validation
+- vulkan: fall back to UBO for larger uniform blocks on all systems
+- metal: enable fast math, skip debug groups in production
 
 ## blade-graphics-0.8.1 (28 Mar 2026)
 

--- a/examples/move/main.rs
+++ b/examples/move/main.rs
@@ -229,9 +229,9 @@ impl Game {
 
         let raw_input = self.egui_state.take_egui_input(&self.window);
         let egui_context = self.egui_state.egui_ctx().clone();
-        let egui_output = egui_context.run(raw_input, |egui_ctx| {
+        let egui_output = egui_context.run_ui(raw_input, |egui_ctx| {
             let frame = {
-                let mut frame = egui::Frame::side_top_panel(&egui_ctx.style());
+                let mut frame = egui::Frame::side_top_panel(&egui_ctx.global_style());
                 let mut fill = frame.fill.to_array();
                 for f in fill.iter_mut() {
                     *f = (*f as u32 * 7 / 8) as u8;
@@ -240,9 +240,9 @@ impl Game {
                     egui::Color32::from_rgba_premultiplied(fill[0], fill[1], fill[2], fill[3]);
                 frame
             };
-            egui::SidePanel::right("engine")
+            egui::Panel::right("engine")
                 .frame(frame)
-                .show(egui_ctx, |ui| self.populate_hud(ui));
+                .show_inside(egui_ctx, |ui| self.populate_hud(ui));
         });
 
         self.egui_state

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -473,8 +473,8 @@ impl winit::application::ApplicationHandler for App {
 
             winit::event::WindowEvent::RedrawRequested => {
                 let raw_input = egui_winit.take_egui_input(window);
-                let egui_output = egui_winit.egui_ctx().run(raw_input, |egui_ctx| {
-                    egui::SidePanel::left("info").show(egui_ctx, |ui| {
+                let egui_output = egui_winit.egui_ctx().run_ui(raw_input, |egui_ctx| {
+                    egui::Panel::left("info").show_inside(egui_ctx, |ui| {
                         ui.add_space(5.0);
                         example.add_gui(ui);
 

--- a/examples/scene/main.rs
+++ b/examples/scene/main.rs
@@ -957,9 +957,9 @@ impl winit::application::ApplicationHandler for App {
             }
             winit::event::WindowEvent::RedrawRequested => {
                 let raw_input = egui_winit.take_egui_input(window);
-                let egui_output = egui_winit.egui_ctx().run(raw_input, |egui_ctx| {
+                let egui_output = egui_winit.egui_ctx().run_ui(raw_input, |egui_ctx| {
                     let frame = {
-                        let mut frame = egui::Frame::side_top_panel(&egui_ctx.style());
+                        let mut frame = egui::Frame::side_top_panel(&egui_ctx.global_style());
                         let mut fill = frame.fill.to_array();
                         for f in fill.iter_mut() {
                             *f = (*f as u32 * 7 / 8) as u8;
@@ -969,14 +969,14 @@ impl winit::application::ApplicationHandler for App {
                         );
                         frame
                     };
-                    egui::SidePanel::right("view")
+                    egui::Panel::right("view")
                         .frame(frame)
-                        .show(egui_ctx, |ui| {
+                        .show_inside(egui_ctx, |ui| {
                             example.populate_view(ui);
                         });
-                    egui::SidePanel::left("content")
+                    egui::Panel::left("content")
                         .frame(frame)
-                        .show(egui_ctx, |ui| {
+                        .show_inside(egui_ctx, |ui| {
                             example.populate_content(ui);
                             ui.separator();
                             if ui.button("Quit").clicked() {
@@ -986,7 +986,8 @@ impl winit::application::ApplicationHandler for App {
                 });
 
                 //HACK: https://github.com/urholaukkarinen/egui-gizmo/issues/29
-                if example.have_objects_changed && egui_winit.egui_ctx().wants_pointer_input() {
+                if example.have_objects_changed && egui_winit.egui_ctx().egui_wants_pointer_input()
+                {
                     self.drag_start = None;
                 }
 

--- a/examples/vehicle/main.rs
+++ b/examples/vehicle/main.rs
@@ -579,9 +579,9 @@ impl Game {
 
         let raw_input = self.egui_state.take_egui_input(&self.window);
         let egui_context = self.egui_state.egui_ctx().clone();
-        let egui_output = egui_context.run(raw_input, |egui_ctx| {
+        let egui_output = egui_context.run_ui(raw_input, |egui_ctx| {
             let frame = {
-                let mut frame = egui::Frame::side_top_panel(&egui_ctx.style());
+                let mut frame = egui::Frame::side_top_panel(&egui_ctx.global_style());
                 let mut fill = frame.fill.to_array();
                 for f in fill.iter_mut() {
                     *f = (*f as u32 * 7 / 8) as u8;
@@ -590,9 +590,9 @@ impl Game {
                     egui::Color32::from_rgba_premultiplied(fill[0], fill[1], fill[2], fill[3]);
                 frame
             };
-            egui::SidePanel::right("engine")
+            egui::Panel::right("engine")
                 .frame(frame)
-                .show(egui_ctx, |ui| self.populate_hud(ui));
+                .show_inside(egui_ctx, |ui| self.populate_hud(ui));
         });
 
         self.egui_state


### PR DESCRIPTION
Instead of a global bool deciding all Plain bindings use inline uniform blocks or all use UBOs, store the device's maxInlineUniformBlockSize and decide per-binding: bindings that fit use IUBs, larger ones fall back to UBOs. This fixes validation errors when binding sizes exceed the device's inline uniform block limits (e.g. light arrays > 256 bytes).

Resolves #334.

https://claude.ai/code/session_01W9jSvpnbXEXmoHFuUVFdUN