### PR TITLE
vk: Use driver API version for instance creation

### DIFF
--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -681,7 +681,7 @@ impl super::VulkanInstance {
             let app_info = vk::ApplicationInfo::default()
                 .engine_name(c"blade")
                 .engine_version(1)
-                .api_version(vk::HEADER_VERSION_COMPLETE);
+                .api_version(driver_api_version);
             let str_pointers = layers
                 .iter()
                 .chain(enabled_instance_extensions.iter())

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -681,7 +681,7 @@ impl super::VulkanInstance {
             let app_info = vk::ApplicationInfo::default()
                 .engine_name(c"blade")
                 .engine_version(1)
-                .api_version(driver_api_version);
+                .api_version(driver_api_version.min(vk::HEADER_VERSION_COMPLETE));
             let str_pointers = layers
                 .iter()
                 .chain(enabled_instance_extensions.iter())


### PR DESCRIPTION
Use the version reported by `vkEnumerateInstanceVersion` instead of `vk::HEADER_VERSION_COMPLETE` when creating the Vulkan instance.

On systems where the driver only supports Vulkan 1.1 or 1.2 (e.g. lavapipe on RHEL 8), requesting the ash header version (1.3.x) causes `ERROR_INCOMPATIBLE_DRIVER`. The [spec](https://registry.khronos.org/vulkan/specs/latest/man/html/VkApplicationInfo.html) says conformant 1.1+ implementations must not return this error, but older Mesa builds do.

`driver_api_version` is already queried via `try_enumerate_instance_version()` and used for extension promotion checks in the same function. This matches what wgpu-hal does for instance creation.

Fixes #341