### PR TITLE
WebGL2/wasm/Android: GLES buffer, texture, and fence fixes; GLES/Vulkan + egui robustness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ glam = { version = "0.30", features = ["mint"] }
 gltf = { version = "1.1", default-features = false }
 log = "0.4"
 mint = "0.5"
-naga = { git = "https://github.com/gfx-rs/wgpu", rev = "78b4dfd0cb1ef5ed208fefe80ae2f855db3609bb", features = ["wgsl-in", "termcolor"] }
+naga = { git = "https://github.com/gfx-rs/wgpu", rev = "b0a44f766e95a38f0aa45565ff005173cc96d46a", features = ["wgsl-in", "termcolor"] }
 profiling = "1"
 slab = "0.4"
 strum = { version = "0.27", features = ["derive"] }

--- a/blade-egui/shader.wgsl
+++ b/blade-egui/shader.wgsl
@@ -44,9 +44,8 @@ var r_sampler: sampler;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    //Note: we always assume rendering to linear color space,
-    // but Egui wants to blend in gamma space, see
-    // https://github.com/emilk/egui/pull/2071
+    //Note: we output sRGB directly because our swapchain is configured as Srgb 
+    // which gives us a Unorm format (no hardware conversion).
     let blended = in.color * textureSample(r_texture, r_sampler, in.tex_coord);
-    return vec4f(linear_from_gamma(blended.xyz), blended.a);
+    return vec4f(blended.xyz, blended.a);
 }

--- a/blade-egui/shader.wgsl
+++ b/blade-egui/shader.wgsl
@@ -6,8 +6,7 @@ struct VertexOutput {
 
 struct Uniforms {
     screen_size: vec2<f32>,
-    convert_to_linear: f32,
-    padding: f32,
+    padding: vec2<f32>,
 };
 var<uniform> r_uniforms: Uniforms;
 
@@ -42,10 +41,21 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 var r_texture: texture_2d<f32>;
 var r_sampler: sampler;
 
+// Egui blends in gamma space, see https://github.com/emilk/egui/pull/2071
+fn blended_color(in: VertexOutput) -> vec4<f32> {
+    return in.color * textureSample(r_texture, r_sampler, in.tex_coord);
+}
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    //Note: we output sRGB directly because our swapchain is configured as Srgb 
-    // which gives us a Unorm format (no hardware conversion).
-    let blended = in.color * textureSample(r_texture, r_sampler, in.tex_coord);
+    // ColorSpace::Linear swapchain (Vulkan/Metal/EGL sRGB storage).
+    let blended = blended_color(in);
+    return vec4f(linear_from_gamma(blended.xyz), blended.a);
+}
+
+@fragment
+fn fs_main_srgb(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Plain UNORM canvas (WebGL blit to HTML canvas): output gamma-space directly.
+    let blended = blended_color(in);
     return vec4f(blended.xyz, blended.a);
 }

--- a/blade-egui/shader.wgsl
+++ b/blade-egui/shader.wgsl
@@ -12,33 +12,27 @@ struct Uniforms {
 var<uniform> r_uniforms: Uniforms;
 
 //Note: avoiding `vec2<f32>` in order to keep the scalar alignment
-struct Vertex {
-    pos_x: f32,
-    pos_y: f32,
-    tex_coord_x: f32,
-    tex_coord_y: f32,
-    color: u32,
+struct VertexInput {
+    a_pos: vec2<f32>,
+    a_tex_coord: vec2<f32>,
+    a_color: u32,
 }
-var<storage, read> r_vertex_data: array<Vertex>;
 
 fn linear_from_gamma(srgb: vec3<f32>) -> vec3<f32> {
-    let cutoff = srgb < vec3<f32>(0.04045);
     let lower = srgb / vec3<f32>(12.92);
     let higher = pow((srgb + vec3<f32>(0.055)) / vec3<f32>(1.055), vec3<f32>(2.4));
-    return select(higher, lower, cutoff);
+    let is_higher = step(vec3<f32>(0.04045), srgb);
+    return mix(lower, higher, is_higher);
 }
 
 @vertex
-fn vs_main(
-    @builtin(vertex_index) v_index: u32,
-) -> VertexOutput {
-    let input = r_vertex_data[v_index];
+fn vs_main(input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = vec2<f32>(input.tex_coord_x, input.tex_coord_y);
-    out.color = unpack4x8unorm(input.color);
+    out.tex_coord = input.a_tex_coord;
+    out.color = unpack4x8unorm(input.a_color);
     out.position = vec4<f32>(
-        2.0 * input.pos_x / r_uniforms.screen_size.x - 1.0,
-        1.0 - 2.0 * input.pos_y / r_uniforms.screen_size.y,
+        2.0 * input.a_pos.x / r_uniforms.screen_size.x - 1.0,
+        1.0 - 2.0 * input.a_pos.y / r_uniforms.screen_size.y,
         0.0,
         1.0,
     );

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -287,7 +287,9 @@ impl GuiPainter {
         let mut copies = Vec::new();
         for &(texture_id, ref image_delta) in textures_delta.set.iter() {
             let src = match image_delta.image {
-                egui::ImageData::Color(ref c) => self.vertex_belt.alloc_pod(c.pixels.as_slice(), context),
+                egui::ImageData::Color(ref c) => {
+                    self.vertex_belt.alloc_pod(c.pixels.as_slice(), context)
+                }
             };
 
             let image_size = image_delta.image.size();
@@ -429,7 +431,11 @@ impl GuiPainter {
 
     /// Call this after submitting work at the given `sync_point`.
     #[profiling::function]
-    pub fn after_submit(&mut self, sync_point: &blade_graphics::SyncPoint) {
+    pub fn after_submit(
+        &mut self,
+        sync_point: &blade_graphics::SyncPoint,
+        context: &blade_graphics::Context,
+    ) {
         for texture_id in self.textures_to_free.drain(..) {
             if let Some(texture) = self.textures.remove(&texture_id) {
                 self.textures_dropped.push(texture);
@@ -442,5 +448,7 @@ impl GuiPainter {
         );
         self.vertex_belt.flush(sync_point);
         self.index_belt.flush(sync_point);
+        self.vertex_belt.trim(4, context);
+        self.index_belt.trim(4, context);
     }
 }

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -32,7 +32,6 @@ struct Globals {
 
 #[derive(blade_macros::ShaderData)]
 struct Locals {
-    r_vertex_data: blade_graphics::BufferPiece,
     r_texture: blade_graphics::TextureView,
     r_sampler: blade_graphics::Sampler,
 }
@@ -140,6 +139,7 @@ pub struct GuiPainter {
     textures: HashMap<egui::TextureId, GuiTexture>,
     //TODO: this could also look better
     textures_dropped: Vec<GuiTexture>,
+    textures_to_free: Vec<egui::TextureId>,
     textures_to_delete: Vec<(GuiTexture, blade_graphics::SyncPoint)>,
 }
 
@@ -171,11 +171,33 @@ impl GuiPainter {
         });
         let globals_layout = <Globals as blade_graphics::ShaderData>::layout();
         let locals_layout = <Locals as blade_graphics::ShaderData>::layout();
+        let egui_vertex_layout = blade_graphics::VertexLayout {
+            stride: 20, // egui::Vertex: pos(2xf32) + uv(2xf32) + color(u32) = 20
+            attributes: vec![
+                ("a_pos", blade_graphics::VertexAttribute {
+                    offset: 0,
+                    format: blade_graphics::VertexFormat::F32Vec2,
+                }),
+                ("a_tex_coord", blade_graphics::VertexAttribute {
+                    offset: 8,
+                    format: blade_graphics::VertexFormat::F32Vec2,
+                }),
+                ("a_color", blade_graphics::VertexAttribute {
+                    offset: 16,
+                    format: blade_graphics::VertexFormat::U32,
+                }),
+            ],
+        };
         let pipeline = context.create_render_pipeline(blade_graphics::RenderPipelineDesc {
             name: "gui",
             data_layouts: &[&globals_layout, &locals_layout],
             vertex: shader.at("vs_main"),
-            vertex_fetches: &[],
+            vertex_fetches: &[
+                blade_graphics::VertexFetchState {
+                    layout: &egui_vertex_layout,
+                    instanced: false,
+                },
+            ],
             primitive: blade_graphics::PrimitiveState {
                 topology: blade_graphics::PrimitiveTopology::TriangleList,
                 ..Default::default()
@@ -212,6 +234,7 @@ impl GuiPainter {
             belt,
             textures: Default::default(),
             textures_dropped: Vec::new(),
+            textures_to_free: Vec::new(),
             textures_to_delete: Vec::new(),
         }
     }
@@ -298,10 +321,7 @@ impl GuiPainter {
             }
         }
 
-        for texture_id in textures_delta.free.iter() {
-            let texture = self.textures.remove(texture_id).unwrap();
-            self.textures_dropped.push(texture);
-        }
+        self.textures_to_free.extend(textures_delta.free.iter().copied());
 
         self.triage_deletions(context);
         self.belt.trim(4, context);
@@ -365,11 +385,12 @@ impl GuiPainter {
                 pc.bind(
                     1,
                     &Locals {
-                        r_vertex_data: vertex_buf,
                         r_texture: texture.view,
                         r_sampler: texture.sampler,
                     },
                 );
+
+                pc.bind_vertex(0, vertex_buf);
 
                 pc.draw_indexed(
                     index_buf,
@@ -383,9 +404,18 @@ impl GuiPainter {
         }
     }
 
+    pub fn sync(&mut self, context: &blade_graphics::Context) {
+        self.belt.sync(context);
+    }
+
     /// Call this after submitting work at the given `sync_point`.
     #[profiling::function]
     pub fn after_submit(&mut self, sync_point: &blade_graphics::SyncPoint) {
+        for texture_id in self.textures_to_free.drain(..) {
+            if let Some(texture) = self.textures.remove(&texture_id) {
+                self.textures_dropped.push(texture);
+            }
+        }
         self.textures_to_delete.extend(
             self.textures_dropped
                 .drain(..)

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -199,6 +199,15 @@ impl GuiPainter {
                 ),
             ],
         };
+        // Fragment entry contract: Linear/sRGB-capable swapchains (Vulkan, Metal, EGL) use
+        // `fs_main` (gamma→linear output). Plain UNORM surfaces (WebGL blit to HTML canvas)
+        // use `fs_main_srgb` (gamma passthrough). WebGL is the only backend that reports
+        // Rgba8Unorm here; embedders with other UNORM targets should pick the srgb entry likewise.
+        let fragment_entry = if matches!(info.format, blade_graphics::TextureFormat::Rgba8Unorm) {
+            "fs_main_srgb"
+        } else {
+            "fs_main"
+        };
         let pipeline = context.create_render_pipeline(blade_graphics::RenderPipelineDesc {
             name: "gui",
             data_layouts: &[&globals_layout, &locals_layout],
@@ -212,7 +221,7 @@ impl GuiPainter {
                 ..Default::default()
             },
             depth_stencil: None, //TODO?
-            fragment: Some(shader.at("fs_main")),
+            fragment: Some(shader.at(fragment_entry)),
             color_targets: &[blade_graphics::ColorTargetState {
                 format: info.format,
                 blend: Some(blade_graphics::BlendState {
@@ -237,12 +246,14 @@ impl GuiPainter {
             min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "vertex",
+            bind_point: 0x8892, // glow::ARRAY_BUFFER
         });
         let index_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: blade_graphics::Memory::Shared,
             min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "index",
+            bind_point: 0x8893, // glow::ELEMENT_ARRAY_BUFFER
         });
 
         Self {

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -135,7 +135,8 @@ impl GuiTexture {
 pub struct GuiPainter {
     pipeline: blade_graphics::RenderPipeline,
     //TODO: find a better way to allocate temporary buffers.
-    belt: BufferBelt,
+    vertex_belt: BufferBelt,
+    index_belt: BufferBelt,
     textures: HashMap<egui::TextureId, GuiTexture>,
     //TODO: this could also look better
     textures_dropped: Vec<GuiTexture>,
@@ -147,7 +148,8 @@ impl GuiPainter {
     /// Destroy the contents of the painter.
     pub fn destroy(&mut self, context: &blade_graphics::Context) {
         context.destroy_render_pipeline(&mut self.pipeline);
-        self.belt.destroy(context);
+        self.vertex_belt.destroy(context);
+        self.index_belt.destroy(context);
         for (_, gui_texture) in self.textures.drain() {
             gui_texture.delete(context);
         }
@@ -230,15 +232,23 @@ impl GuiPainter {
             multisample_state: Default::default(),
         });
 
-        let belt = BufferBelt::new(BufferBeltDescriptor {
+        let vertex_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: blade_graphics::Memory::Shared,
             min_chunk_size: 0x1000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
+            name: "vertex",
+        });
+        let index_belt = BufferBelt::new(BufferBeltDescriptor {
+            memory: blade_graphics::Memory::Shared,
+            min_chunk_size: 0x1000,
+            alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
+            name: "index",
         });
 
         Self {
             pipeline,
-            belt,
+            vertex_belt,
+            index_belt,
             textures: Default::default(),
             textures_dropped: Vec::new(),
             textures_to_free: Vec::new(),
@@ -277,7 +287,7 @@ impl GuiPainter {
         let mut copies = Vec::new();
         for &(texture_id, ref image_delta) in textures_delta.set.iter() {
             let src = match image_delta.image {
-                egui::ImageData::Color(ref c) => self.belt.alloc_pod(c.pixels.as_slice(), context),
+                egui::ImageData::Color(ref c) => self.vertex_belt.alloc_pod(c.pixels.as_slice(), context),
             };
 
             let image_size = image_delta.image.size();
@@ -332,7 +342,7 @@ impl GuiPainter {
             .extend(textures_delta.free.iter().copied());
 
         self.triage_deletions(context);
-        self.belt.trim(4, context);
+        self.vertex_belt.trim(4, context);
     }
 
     /// Render the set of clipped primitives into a render pass.
@@ -387,8 +397,8 @@ impl GuiPainter {
 
             if let egui::epaint::Primitive::Mesh(ref mesh) = clipped_prim.primitive {
                 let texture = self.textures.get(&mesh.texture_id).unwrap();
-                let index_buf = self.belt.alloc_pod(&mesh.indices, context);
-                let vertex_buf = self.belt.alloc_pod(&mesh.vertices, context);
+                let index_buf = self.index_belt.alloc_pod(&mesh.indices, context);
+                let vertex_buf = self.vertex_belt.alloc_pod(&mesh.vertices, context);
 
                 pc.bind(
                     1,
@@ -413,7 +423,8 @@ impl GuiPainter {
     }
 
     pub fn sync(&mut self, context: &blade_graphics::Context) {
-        self.belt.sync(context);
+        self.vertex_belt.sync(context);
+        self.index_belt.sync(context);
     }
 
     /// Call this after submitting work at the given `sync_point`.
@@ -429,6 +440,7 @@ impl GuiPainter {
                 .drain(..)
                 .map(|texture| (texture, sync_point.clone())),
         );
-        self.belt.flush(sync_point);
+        self.vertex_belt.flush(sync_point);
+        self.index_belt.flush(sync_point);
     }
 }

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -246,14 +246,12 @@ impl GuiPainter {
             min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "vertex",
-            bind_point: 0x8892, // glow::ARRAY_BUFFER
         });
         let index_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: blade_graphics::Memory::Shared,
             min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "index",
-            bind_point: 0x8893, // glow::ELEMENT_ARRAY_BUFFER
         });
 
         Self {
@@ -356,6 +354,7 @@ impl GuiPainter {
 
         self.triage_deletions(context);
         self.vertex_belt.trim(4, context);
+        self.index_belt.trim(4, context);
     }
 
     /// Render the set of clipped primitives into a render pass.
@@ -447,7 +446,6 @@ impl GuiPainter {
     pub fn after_submit(
         &mut self,
         sync_point: &blade_graphics::SyncPoint,
-        context: &blade_graphics::Context,
     ) {
         for texture_id in self.textures_to_free.drain(..) {
             if let Some(texture) = self.textures.remove(&texture_id) {
@@ -461,7 +459,5 @@ impl GuiPainter {
         );
         self.vertex_belt.flush(sync_point);
         self.index_belt.flush(sync_point);
-        self.vertex_belt.trim(4, context);
-        self.index_belt.trim(4, context);
     }
 }

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -174,30 +174,37 @@ impl GuiPainter {
         let egui_vertex_layout = blade_graphics::VertexLayout {
             stride: 20, // egui::Vertex: pos(2xf32) + uv(2xf32) + color(u32) = 20
             attributes: vec![
-                ("a_pos", blade_graphics::VertexAttribute {
-                    offset: 0,
-                    format: blade_graphics::VertexFormat::F32Vec2,
-                }),
-                ("a_tex_coord", blade_graphics::VertexAttribute {
-                    offset: 8,
-                    format: blade_graphics::VertexFormat::F32Vec2,
-                }),
-                ("a_color", blade_graphics::VertexAttribute {
-                    offset: 16,
-                    format: blade_graphics::VertexFormat::U32,
-                }),
+                (
+                    "a_pos",
+                    blade_graphics::VertexAttribute {
+                        offset: 0,
+                        format: blade_graphics::VertexFormat::F32Vec2,
+                    },
+                ),
+                (
+                    "a_tex_coord",
+                    blade_graphics::VertexAttribute {
+                        offset: 8,
+                        format: blade_graphics::VertexFormat::F32Vec2,
+                    },
+                ),
+                (
+                    "a_color",
+                    blade_graphics::VertexAttribute {
+                        offset: 16,
+                        format: blade_graphics::VertexFormat::U32,
+                    },
+                ),
             ],
         };
         let pipeline = context.create_render_pipeline(blade_graphics::RenderPipelineDesc {
             name: "gui",
             data_layouts: &[&globals_layout, &locals_layout],
             vertex: shader.at("vs_main"),
-            vertex_fetches: &[
-                blade_graphics::VertexFetchState {
-                    layout: &egui_vertex_layout,
-                    instanced: false,
-                },
-            ],
+            vertex_fetches: &[blade_graphics::VertexFetchState {
+                layout: &egui_vertex_layout,
+                instanced: false,
+            }],
             primitive: blade_graphics::PrimitiveState {
                 topology: blade_graphics::PrimitiveTopology::TriangleList,
                 ..Default::default()
@@ -321,7 +328,8 @@ impl GuiPainter {
             }
         }
 
-        self.textures_to_free.extend(textures_delta.free.iter().copied());
+        self.textures_to_free
+            .extend(textures_delta.free.iter().copied());
 
         self.triage_deletions(context);
         self.belt.trim(4, context);

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -246,12 +246,14 @@ impl GuiPainter {
             min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "vertex",
+            bind_point: 0x8892, // glow::ARRAY_BUFFER
         });
         let index_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: blade_graphics::Memory::Shared,
             min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "index",
+            bind_point: 0x8893, // glow::ELEMENT_ARRAY_BUFFER
         });
 
         Self {
@@ -354,7 +356,6 @@ impl GuiPainter {
 
         self.triage_deletions(context);
         self.vertex_belt.trim(4, context);
-        self.index_belt.trim(4, context);
     }
 
     /// Render the set of clipped primitives into a render pass.
@@ -446,6 +447,7 @@ impl GuiPainter {
     pub fn after_submit(
         &mut self,
         sync_point: &blade_graphics::SyncPoint,
+        context: &blade_graphics::Context,
     ) {
         for texture_id in self.textures_to_free.drain(..) {
             if let Some(texture) = self.textures.remove(&texture_id) {
@@ -459,5 +461,7 @@ impl GuiPainter {
         );
         self.vertex_belt.flush(sync_point);
         self.index_belt.flush(sync_point);
+        self.vertex_belt.trim(4, context);
+        self.index_belt.trim(4, context);
     }
 }

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -234,13 +234,13 @@ impl GuiPainter {
 
         let vertex_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: blade_graphics::Memory::Shared,
-            min_chunk_size: 0x1000,
+            min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "vertex",
         });
         let index_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: blade_graphics::Memory::Shared,
-            min_chunk_size: 0x1000,
+            min_chunk_size: 0x40000,
             alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
             name: "index",
         });
@@ -398,7 +398,9 @@ impl GuiPainter {
             });
 
             if let egui::epaint::Primitive::Mesh(ref mesh) = clipped_prim.primitive {
-                let texture = self.textures.get(&mesh.texture_id).unwrap();
+                let Some(texture) = self.textures.get(&mesh.texture_id) else {
+                    continue;
+                };
                 let index_buf = self.index_belt.alloc_pod(&mesh.indices, context);
                 let vertex_buf = self.vertex_belt.alloc_pod(&mesh.vertices, context);
 

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -109,7 +109,11 @@ impl super::CommandEncoder {
 
     pub fn barrier(&mut self) {}
 
-    fn pass<P>(&mut self, kind: super::PassKind, target_size: [u16; 2]) -> super::PassEncoder<'_, P> {
+    fn pass<P>(
+        &mut self,
+        kind: super::PassKind,
+        target_size: [u16; 2],
+    ) -> super::PassEncoder<'_, P> {
         super::PassEncoder {
             commands: &mut self.commands,
             plain_data: &mut self.plain_data,
@@ -319,13 +323,16 @@ impl super::PassEncoder<'_, super::ComputePipeline> {
 impl crate::traits::RenderEncoder for super::PassEncoder<'_, super::RenderPipeline> {
     fn set_scissor_rect(&mut self, rect: &crate::ScissorRect) {
         // Invert Y axis for OpenGL's bottom-left window coordinates
-        let y = (self.target_size[1] as i32).saturating_sub(rect.y).saturating_sub(rect.h as i32);
-        self.commands.push(super::Command::SetScissor(crate::ScissorRect {
-            x: rect.x,
-            y: y.max(0),
-            w: rect.w,
-            h: rect.h,
-        }));
+        let y = (self.target_size[1] as i32)
+            .saturating_sub(rect.y)
+            .saturating_sub(rect.h as i32);
+        self.commands
+            .push(super::Command::SetScissor(crate::ScissorRect {
+                x: rect.x,
+                y: y.max(0),
+                w: rect.w,
+                h: rect.h,
+            }));
     }
 
     fn set_viewport(&mut self, viewport: &crate::Viewport) {
@@ -669,7 +676,10 @@ impl super::Command {
                     base_vertex,
                     instance_count,
                 } => {
+                    #[cfg(not(target_arch = "wasm32"))]
                     gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buf.raw));
+                    #[cfg(target_arch = "wasm32")]
+                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buf.raw_index));
                     match (base_vertex, instance_count) {
                         (0, 1) => gl.draw_elements(
                             topology,
@@ -791,7 +801,11 @@ impl super::Command {
                     let row_texels =
                         bytes_per_row / block_info.size as u32 * block_info.dimensions.0 as u32;
                     gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 1);
-                    gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, row_texels as i32);
+                    // Only set row length when stride differs from width;
+                    // redundant values trigger Firefox's slow defensive copy path.
+                    if row_texels != size.width {
+                        gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, row_texels as i32);
+                    }
                     gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, Some(src.raw));
                     gl.bind_texture(dst.target, Some(dst.raw));
                     let unpack_data = glow::PixelUnpackData::BufferOffset(src.offset as u32);
@@ -861,6 +875,7 @@ impl super::Command {
                         _ => unreachable!(),
                     }
                     gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, None);
+                    gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
                 }
                 Self::CopyTextureToBuffer {
                     ref src,
@@ -1214,6 +1229,21 @@ impl super::Command {
                     target,
                 } => {
                     gl.active_texture(glow::TEXTURE0 + slot);
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        if target != glow::TEXTURE_2D {
+                            gl.bind_texture(glow::TEXTURE_2D, None);
+                        }
+                        if target != glow::TEXTURE_2D_ARRAY {
+                            gl.bind_texture(glow::TEXTURE_2D_ARRAY, None);
+                        }
+                        if target != glow::TEXTURE_3D {
+                            gl.bind_texture(glow::TEXTURE_3D, None);
+                        }
+                        if target != glow::TEXTURE_CUBE_MAP {
+                            gl.bind_texture(glow::TEXTURE_CUBE_MAP, None);
+                        }
+                    }
                     gl.bind_texture(target, Some(texture));
                 }
                 Self::BindImage {

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -676,10 +676,7 @@ impl super::Command {
                     base_vertex,
                     instance_count,
                 } => {
-                    #[cfg(not(target_arch = "wasm32"))]
                     gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buf.raw));
-                    #[cfg(target_arch = "wasm32")]
-                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buf.raw_index));
                     match (base_vertex, instance_count) {
                         (0, 1) => gl.draw_elements(
                             topology,
@@ -720,11 +717,11 @@ impl super::Command {
                 }
                 Self::DrawIndexedIndirect {
                     topology,
-                    raw_index_buf,
+                    ref index_buf,
                     index_type,
                     ref indirect_buf,
                 } => {
-                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(raw_index_buf));
+                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buf.raw));
                     gl.bind_buffer(glow::DRAW_INDIRECT_BUFFER, Some(indirect_buf.raw));
                     gl.draw_elements_indirect_offset(
                         topology,

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -109,15 +109,16 @@ impl super::CommandEncoder {
 
     pub fn barrier(&mut self) {}
 
-    fn pass<P>(&mut self, kind: super::PassKind) -> super::PassEncoder<'_, P> {
+    fn pass<P>(&mut self, kind: super::PassKind, target_size: [u16; 2]) -> super::PassEncoder<'_, P> {
         super::PassEncoder {
             commands: &mut self.commands,
             plain_data: &mut self.plain_data,
             kind,
             invalidate_attachments: Vec::new(),
-            pipeline: Default::default(),
+            pipeline: std::marker::PhantomData,
             limits: &self.limits,
             has_scope: self.needs_scopes,
+            target_size,
         }
     }
 
@@ -164,7 +165,7 @@ impl super::CommandEncoder {
 
     pub fn transfer(&mut self, label: &str) -> super::PassEncoder<'_, ()> {
         self.begin_pass(label);
-        self.pass(super::PassKind::Transfer)
+        self.pass(super::PassKind::Transfer, [0, 0])
     }
 
     pub fn acceleration_structure(&mut self, _label: &str) -> super::PassEncoder<'_, ()> {
@@ -173,7 +174,7 @@ impl super::CommandEncoder {
 
     pub fn compute(&mut self, label: &str) -> super::PassEncoder<'_, super::ComputePipeline> {
         self.begin_pass(label);
-        self.pass(super::PassKind::Compute)
+        self.pass(super::PassKind::Compute, [0, 0])
     }
 
     pub fn render(
@@ -262,7 +263,7 @@ impl super::CommandEncoder {
             });
         }
 
-        let mut pass = self.pass(super::PassKind::Render);
+        let mut pass = self.pass(super::PassKind::Render, target_size);
         pass.invalidate_attachments = invalidate_attachments;
         pass
     }
@@ -317,7 +318,14 @@ impl super::PassEncoder<'_, super::ComputePipeline> {
 #[hidden_trait::expose]
 impl crate::traits::RenderEncoder for super::PassEncoder<'_, super::RenderPipeline> {
     fn set_scissor_rect(&mut self, rect: &crate::ScissorRect) {
-        self.commands.push(super::Command::SetScissor(rect.clone()));
+        // Invert Y axis for OpenGL's bottom-left window coordinates
+        let y = (self.target_size[1] as i32).saturating_sub(rect.y).saturating_sub(rect.h as i32);
+        self.commands.push(super::Command::SetScissor(crate::ScissorRect {
+            x: rect.x,
+            y: y.max(0),
+            w: rect.w,
+            h: rect.h,
+        }));
     }
 
     fn set_viewport(&mut self, viewport: &crate::Viewport) {

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -1229,8 +1229,7 @@ impl super::Command {
                     target,
                 } => {
                     gl.active_texture(glow::TEXTURE0 + slot);
-                    #[cfg(target_arch = "wasm32")]
-                    {
+                    if cfg!(target_arch = "wasm32") {
                         if target != glow::TEXTURE_2D {
                             gl.bind_texture(glow::TEXTURE_2D, None);
                         }

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -348,21 +348,14 @@ impl super::Context {
                     (state.0, Some(state.1))
                 } else if client_extensions.contains("EGL_MESA_platform_surfaceless") {
                     log::info!("Using surfaceless platform");
-                    let d = egl1_5.get_platform_display(
-                        EGL_PLATFORM_SURFACELESS_MESA,
-                        ptr::null_mut(),
-                        &[egl::ATTRIB_NONE],
-                    );
-                    match d {
-                        Ok(display) => (display, None),
-                        Err(e) => {
-                            log::warn!(
-                                "Surfaceless platform failed: {:?}, falling back to default",
-                                e
-                            );
-                            (egl.get_display(egl::DEFAULT_DISPLAY).unwrap(), None)
-                        }
-                    }
+                    let display = egl1_5
+                        .get_platform_display(
+                            EGL_PLATFORM_SURFACELESS_MESA,
+                            ptr::null_mut(),
+                            &[egl::ATTRIB_NONE],
+                        )
+                        .unwrap();
+                    (display, None)
                 } else {
                     log::info!("Using default platform");
                     let d = egl

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -326,15 +326,13 @@ impl super::Context {
                         if desc.validation { 1 } else { 0 },
                         egl::ATTRIB_NONE,
                     ];
-                    Some(
-                        egl1_5
-                            .get_platform_display(
-                                EGL_PLATFORM_ANGLE_ANGLE,
-                                ptr::null_mut(),
-                                &display_attributes,
-                            )
-                            .unwrap(),
-                    )
+                    egl1_5
+                        .get_platform_display(
+                            EGL_PLATFORM_ANGLE_ANGLE,
+                            ptr::null_mut(),
+                            &display_attributes,
+                        )
+                        .ok()
                 } else {
                     None
                 }
@@ -355,9 +353,14 @@ impl super::Context {
                             EGL_PLATFORM_SURFACELESS_MESA,
                             ptr::null_mut(),
                             &[egl::ATTRIB_NONE],
-                        )
-                        .unwrap();
-                    (d, None)
+                        );
+                    match d {
+                        Ok(display) => (display, None),
+                        Err(e) => {
+                            log::warn!("Surfaceless platform failed: {:?}, falling back to default", e);
+                            (egl.get_display(egl::DEFAULT_DISPLAY).unwrap(), None)
+                        }
+                    }
                 } else {
                     log::info!("Using default platform");
                     let d = egl

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -348,16 +348,18 @@ impl super::Context {
                     (state.0, Some(state.1))
                 } else if client_extensions.contains("EGL_MESA_platform_surfaceless") {
                     log::info!("Using surfaceless platform");
-                    let d = egl1_5
-                        .get_platform_display(
-                            EGL_PLATFORM_SURFACELESS_MESA,
-                            ptr::null_mut(),
-                            &[egl::ATTRIB_NONE],
-                        );
+                    let d = egl1_5.get_platform_display(
+                        EGL_PLATFORM_SURFACELESS_MESA,
+                        ptr::null_mut(),
+                        &[egl::ATTRIB_NONE],
+                    );
                     match d {
                         Ok(display) => (display, None),
                         Err(e) => {
-                            log::warn!("Surfaceless platform failed: {:?}, falling back to default", e);
+                            log::warn!(
+                                "Surfaceless platform failed: {:?}, falling back to default",
+                                e
+                            );
                             (egl.get_display(egl::DEFAULT_DISPLAY).unwrap(), None)
                         }
                     }

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -389,6 +389,7 @@ impl super::Context {
                 toggles,
                 limits,
                 device_information,
+                is_webgl: false,
             })
         }
     }
@@ -674,7 +675,14 @@ impl super::Context {
         inner.egl.unmake_current();
 
         // Direct path: create window surface on the main display
-        self.reconfigure_surface_direct(surface, &inner, config.size, format, alpha, swap_interval);
+        self.reconfigure_surface_direct(
+            surface,
+            &inner,
+            config.size,
+            format,
+            alpha,
+            swap_interval,
+        );
     }
 
     /// Direct presentation path: create a window surface on the main EGL display.

--- a/blade-graphics/src/gles/egl.rs
+++ b/blade-graphics/src/gles/egl.rs
@@ -675,14 +675,7 @@ impl super::Context {
         inner.egl.unmake_current();
 
         // Direct path: create window surface on the main display
-        self.reconfigure_surface_direct(
-            surface,
-            &inner,
-            config.size,
-            format,
-            alpha,
-            swap_interval,
-        );
+        self.reconfigure_surface_direct(surface, &inner, config.size, format, alpha, swap_interval);
     }
 
     /// Direct presentation path: create a window surface on the main EGL display.

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -9,7 +9,8 @@ use std::{marker::PhantomData, mem, ops::Range};
 
 type BindTarget = u32;
 const DEBUG_ID: u32 = 0;
-const MAX_TIMEOUT: u64 = 1_000_000_000; // MAX_CLIENT_WAIT_TIMEOUT_WEBGL;
+#[cfg(not(target_arch = "wasm32"))]
+const MAX_TIMEOUT: u64 = 1_000_000_000;
 const MAX_QUERIES: usize = crate::limits::PASS_COUNT + 1;
 
 bitflags::bitflags! {
@@ -48,6 +49,8 @@ pub struct Surface {
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct Buffer {
     raw: glow::Buffer,
+    #[cfg(target_arch = "wasm32")]
+    raw_index: glow::Buffer,
     size: u64,
     data: *mut u8,
 }
@@ -169,6 +172,8 @@ impl Frame {
 #[derive(Clone, Debug)]
 struct BufferPart {
     raw: glow::Buffer,
+    #[cfg(target_arch = "wasm32")]
+    raw_index: glow::Buffer,
     offset: u64,
     data: *mut u8,
 }
@@ -176,6 +181,8 @@ impl From<crate::BufferPiece> for BufferPart {
     fn from(piece: crate::BufferPiece) -> Self {
         Self {
             raw: piece.buffer.raw,
+            #[cfg(target_arch = "wasm32")]
+            raw_index: piece.buffer.raw_index,
             offset: piece.offset,
             data: piece.buffer.data,
         }
@@ -587,17 +594,26 @@ impl crate::traits::CommandDevice for Context {
         SyncPoint { fence }
     }
 
-    fn wait_for(&self, sp: &SyncPoint, timeout_ms: u32) -> Result<bool, crate::DeviceError> {
+    fn wait_for(
+        &self,
+        sp: &SyncPoint,
+        #[allow(unused)] timeout_ms: u32,
+    ) -> Result<bool, crate::DeviceError> {
         use glow::HasContext as _;
 
         let gl = self.lock();
-        let timeout_ns = if timeout_ms == !0 {
-            !0
-        } else {
-            timeout_ms as u64 * 1_000_000
+        // WebGL2: MAX_CLIENT_WAIT_TIMEOUT_WEBGL is 0, blocking is forbidden.
+        #[cfg(target_arch = "wasm32")]
+        let timeout_ns_i32 = 0i32;
+        #[cfg(not(target_arch = "wasm32"))]
+        let timeout_ns_i32 = {
+            let timeout_ns = if timeout_ms == !0 {
+                !0
+            } else {
+                timeout_ms as u64 * 1_000_000
+            };
+            timeout_ns.min(MAX_TIMEOUT) as i32
         };
-        //TODO: https://github.com/grovesNL/glow/issues/287
-        let timeout_ns_i32 = timeout_ns.min(MAX_TIMEOUT) as i32;
 
         let status =
             unsafe { gl.client_wait_sync(sp.fence, glow::SYNC_FLUSH_COMMANDS_BIT, timeout_ns_i32) };

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -601,8 +601,7 @@ impl crate::traits::CommandDevice for Context {
         // WebGL2: MAX_CLIENT_WAIT_TIMEOUT_WEBGL is 0, blocking is forbidden on the main thread.
         const MAX_CLIENT_WAIT_TIMEOUT_WEBGL: u32 = 0x9246;
         let timeout_ns_i32 = if self.is_webgl {
-            let _max_wait =
-                unsafe { gl.get_parameter_i32(MAX_CLIENT_WAIT_TIMEOUT_WEBGL) };
+            let _max_wait = unsafe { gl.get_parameter_i32(MAX_CLIENT_WAIT_TIMEOUT_WEBGL) };
             0i32
         } else {
             //TODO: https://github.com/grovesNL/glow/issues/287

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -50,7 +50,6 @@ pub struct Surface {
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct Buffer {
     raw: glow::Buffer,
-    pub target: u32,
     size: u64,
     data: *mut u8,
 }

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -48,8 +48,7 @@ pub struct Surface {
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct Buffer {
     raw: glow::Buffer,
-    #[cfg(target_arch = "wasm32")]
-    raw_index: glow::Buffer,
+    pub target: u32,
     size: u64,
     data: *mut u8,
 }
@@ -171,8 +170,6 @@ impl Frame {
 #[derive(Clone, Debug)]
 struct BufferPart {
     raw: glow::Buffer,
-    #[cfg(target_arch = "wasm32")]
-    raw_index: glow::Buffer,
     offset: u64,
     data: *mut u8,
 }
@@ -180,8 +177,6 @@ impl From<crate::BufferPiece> for BufferPart {
     fn from(piece: crate::BufferPiece) -> Self {
         Self {
             raw: piece.buffer.raw,
-            #[cfg(target_arch = "wasm32")]
-            raw_index: piece.buffer.raw_index,
             offset: piece.offset,
             data: piece.buffer.data,
         }
@@ -252,7 +247,7 @@ enum Command {
     },
     DrawIndexedIndirect {
         topology: u32,
-        raw_index_buf: glow::Buffer,
+        index_buf: BufferPart,
         index_type: u32,
         indirect_buf: BufferPart,
     },

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -598,10 +598,15 @@ impl crate::traits::CommandDevice for Context {
         use glow::HasContext as _;
 
         let gl = self.lock();
-        // WebGL2: MAX_CLIENT_WAIT_TIMEOUT_WEBGL is 0, blocking is forbidden on the main thread.
-        const MAX_CLIENT_WAIT_TIMEOUT_WEBGL: u32 = 0x9246;
         let timeout_ns_i32 = if self.is_webgl {
-            let _max_wait = unsafe { gl.get_parameter_i32(MAX_CLIENT_WAIT_TIMEOUT_WEBGL) };
+            // WebGL2 forbids blocking client waits on the main thread (its max
+            // timeout is 0), so just poll with timeout 0. Do NOT query
+            // MAX_CLIENT_WAIT_TIMEOUT_WEBGL here: getParameter is a synchronous
+            // GPU-process round-trip and `wait_for` runs several times per frame
+            // (frame throttle + belt alloc/trim), so a per-call query stalls
+            // WebGL hard — the 600-bot FPS cliff. Native is unaffected (is_webgl
+            // is false there). Commit 6adf666 added that query; it does nothing
+            // useful (result was discarded).
             0i32
         } else {
             //TODO: https://github.com/grovesNL/glow/issues/287

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -9,7 +9,6 @@ use std::{marker::PhantomData, mem, ops::Range};
 
 type BindTarget = u32;
 const DEBUG_ID: u32 = 0;
-#[cfg(not(target_arch = "wasm32"))]
 const MAX_TIMEOUT: u64 = 1_000_000_000;
 const MAX_QUERIES: usize = crate::limits::PASS_COUNT + 1;
 
@@ -603,10 +602,9 @@ impl crate::traits::CommandDevice for Context {
 
         let gl = self.lock();
         // WebGL2: MAX_CLIENT_WAIT_TIMEOUT_WEBGL is 0, blocking is forbidden.
-        #[cfg(target_arch = "wasm32")]
-        let timeout_ns_i32 = 0i32;
-        #[cfg(not(target_arch = "wasm32"))]
-        let timeout_ns_i32 = {
+        let timeout_ns_i32 = if cfg!(target_arch = "wasm32") {
+            0i32
+        } else {
             let timeout_ns = if timeout_ms == !0 {
                 !0
             } else {

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -651,6 +651,8 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
         Tf::R32Float => (glow::R32F, glow::RED, glow::FLOAT),
         Tf::Rg32Float => (glow::RG32F, glow::RG, glow::FLOAT),
         Tf::Rgba32Float => (glow::RGBA32F, glow::RGBA, glow::FLOAT),
+        Tf::R8Uint => (glow::R8UI, glow::RED_INTEGER, glow::UNSIGNED_BYTE),
+        Tf::R16Uint => (glow::R16UI, glow::RED_INTEGER, glow::UNSIGNED_SHORT),
         Tf::R32Uint => (glow::R32UI, glow::RED_INTEGER, glow::UNSIGNED_INT),
         Tf::Rg32Uint => (glow::RG32UI, glow::RG_INTEGER, glow::UNSIGNED_INT),
         Tf::Rgba32Uint => (glow::RGBA32UI, glow::RGBA_INTEGER, glow::UNSIGNED_INT),

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -406,6 +406,7 @@ pub struct PassEncoder<'a, P> {
     pipeline: PhantomData<P>,
     limits: &'a Limits,
     has_scope: bool,
+    target_size: [u16; 2],
 }
 
 pub type ComputeCommandEncoder<'a> = PassEncoder<'a, ComputePipeline>;
@@ -641,9 +642,9 @@ fn describe_texture_format(format: crate::TextureFormat) -> FormatInfo {
         Tf::R32Float => (glow::R32F, glow::RED, glow::FLOAT),
         Tf::Rg32Float => (glow::RG32F, glow::RG, glow::FLOAT),
         Tf::Rgba32Float => (glow::RGBA32F, glow::RGBA, glow::FLOAT),
-        Tf::R32Uint => (glow::R32UI, glow::RED, glow::UNSIGNED_INT),
-        Tf::Rg32Uint => (glow::RG32UI, glow::RG, glow::UNSIGNED_INT),
-        Tf::Rgba32Uint => (glow::RGBA32UI, glow::RGBA, glow::UNSIGNED_INT),
+        Tf::R32Uint => (glow::R32UI, glow::RED_INTEGER, glow::UNSIGNED_INT),
+        Tf::Rg32Uint => (glow::RG32UI, glow::RG_INTEGER, glow::UNSIGNED_INT),
+        Tf::Rgba32Uint => (glow::RGBA32UI, glow::RGBA_INTEGER, glow::UNSIGNED_INT),
         Tf::Depth32Float => (glow::DEPTH_COMPONENT32F, glow::DEPTH_COMPONENT, glow::FLOAT),
         Tf::Depth32FloatStencil8Uint => (
             glow::DEPTH32F_STENCIL8,

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -50,6 +50,7 @@ pub struct Surface {
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct Buffer {
     raw: glow::Buffer,
+    pub target: u32,
     size: u64,
     data: *mut u8,
 }

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -37,6 +37,8 @@ pub struct Context {
     toggles: Toggles,
     limits: Limits,
     device_information: crate::DeviceInformation,
+    /// WebGL2 context (wasm); native EGL is false.
+    is_webgl: bool,
 }
 
 pub struct Surface {
@@ -596,16 +598,15 @@ impl crate::traits::CommandDevice for Context {
         use glow::HasContext as _;
 
         let gl = self.lock();
-        // WebGL2: MAX_CLIENT_WAIT_TIMEOUT_WEBGL is 0, blocking is forbidden.
-        let timeout_ns_i32 = if cfg!(target_arch = "wasm32") {
+        // WebGL2: MAX_CLIENT_WAIT_TIMEOUT_WEBGL is 0, blocking is forbidden on the main thread.
+        const MAX_CLIENT_WAIT_TIMEOUT_WEBGL: u32 = 0x9246;
+        let timeout_ns_i32 = if self.is_webgl {
+            let _max_wait =
+                unsafe { gl.get_parameter_i32(MAX_CLIENT_WAIT_TIMEOUT_WEBGL) };
             0i32
         } else {
-            let timeout_ns = if timeout_ms == !0 {
-                !0
-            } else {
-                timeout_ms as u64 * 1_000_000
-            };
-            timeout_ns.min(MAX_TIMEOUT) as i32
+            //TODO: https://github.com/grovesNL/glow/issues/287
+            (timeout_ms as u64 * 1_000_000).min(MAX_TIMEOUT) as i32
         };
 
         let status =

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -146,7 +146,12 @@ impl super::Context {
 
                 for mapping in attribute_mappings {
                     let vf = &vertex_fetch_states[mapping.buffer_index];
-                    let (_, attrib) = vf.layout.attributes[mapping.attribute_index];
+                    let (attrib_name, attrib) = vf.layout.attributes[mapping.attribute_index];
+                    
+                    let location = attributes.len() as u32;
+                    gl.bind_attrib_location(program, location, attrib_name);
+                    gl.bind_attrib_location(program, location, &format!("e_{}", attrib_name));
+
                     attributes.push(super::VertexAttributeInfo {
                         attrib,
                         buffer_index: mapping.buffer_index as u32,
@@ -268,7 +273,24 @@ impl super::Context {
                                 unimplemented!()
                             }
                             crate::ShaderBinding::Plain { size } => {
-                                if let Some(index) = gl.get_uniform_block_index(program, glsl_name)
+                                let mut index_opt = gl.get_uniform_block_index(program, glsl_name);
+                                if index_opt.is_none() {
+                                    if let Some(ref type_name) = sf.shader.module.types[var.ty].name {
+                                        index_opt = gl.get_uniform_block_index(program, type_name);
+                                    }
+                                }
+                                if index_opt.is_none() {
+                                    let type_name = format!("type_{}", var.ty.index());
+                                    index_opt = gl.get_uniform_block_index(program, &type_name);
+                                }
+                                if index_opt.is_none() {
+                                    let num_blocks = gl.get_program_parameter_i32(program, glow::ACTIVE_UNIFORM_BLOCKS);
+                                    if num_blocks == 1 {
+                                        index_opt = Some(0);
+                                    }
+                                }
+
+                                if let Some(index) = index_opt
                                 {
                                     let expected_size = gl.get_active_uniform_block_parameter_i32(
                                         program,
@@ -296,6 +318,19 @@ impl super::Context {
                                         ) as u32
                                     };
                                     targets.push(slot);
+                                } else {
+                                    let num_blocks = gl.get_program_parameter_i32(program, glow::ACTIVE_UNIFORM_BLOCKS);
+                                    let mut available_blocks = String::new();
+                                    for i in 0..num_blocks {
+                                        let name = gl.get_active_uniform_block_name(program, i as u32);
+                                        available_blocks.push_str(&format!("{}, ", name));
+                                    }
+                                    log::error!(
+                                        "Failed to find uniform block for variable '{}' (type '{:?}'). Available blocks: {}",
+                                        glsl_name,
+                                        sf.shader.module.types[var.ty].name,
+                                        available_blocks
+                                    );
                                 }
                             }
                         }

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -150,6 +150,7 @@ impl super::Context {
 
                     let location = attributes.len() as u32;
                     gl.bind_attrib_location(program, location, attrib_name);
+                    // Naga's GLSL backend prefixes entry point arguments with 'e_'
                     gl.bind_attrib_location(program, location, &format!("e_{}", attrib_name));
 
                     attributes.push(super::VertexAttributeInfo {
@@ -281,6 +282,9 @@ impl super::Context {
                                 unimplemented!()
                             }
                             crate::ShaderBinding::Plain { size } => {
+                                // Naga may emit the uniform block name as the variable name,
+                                // the user-defined type name, or a generated type name (type_N).
+                                // We check all possibilities to find the correct index.
                                 let mut index_opt = gl.get_uniform_block_index(program, glsl_name);
                                 if index_opt.is_none() {
                                     if let Some(ref type_name) = sf.shader.module.types[var.ty].name

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -147,7 +147,7 @@ impl super::Context {
                 for mapping in attribute_mappings {
                     let vf = &vertex_fetch_states[mapping.buffer_index];
                     let (attrib_name, attrib) = vf.layout.attributes[mapping.attribute_index];
-                    
+
                     let location = attributes.len() as u32;
                     gl.bind_attrib_location(program, location, attrib_name);
                     gl.bind_attrib_location(program, location, &format!("e_{}", attrib_name));
@@ -213,6 +213,8 @@ impl super::Context {
             if !force_explicit_bindings {
                 let force_uniform_block_assignment = true;
                 let mut variables_to_bind = Vec::new();
+                let mut texture_slots = std::collections::HashMap::new();
+                let mut next_texture_slot = 0i32;
                 for (sf, baked_shader) in shaders.iter().zip(baked_shaders.iter()) {
                     let reflection = &baked_shader.1;
                     for (glsl_name, mapping) in reflection.texture_mapping.iter() {
@@ -248,9 +250,15 @@ impl super::Context {
                                 if let Some(ref location) =
                                     gl.get_uniform_location(program, glsl_name)
                                 {
-                                    let mut slots = [0i32];
-                                    gl.get_uniform_i32(program, location, &mut slots);
-                                    targets.push(slots[0] as u32);
+                                    let slot = *texture_slots
+                                        .entry(glsl_name.to_string())
+                                        .or_insert_with(|| {
+                                            let s = next_texture_slot;
+                                            gl.uniform_1_i32(Some(location), s);
+                                            next_texture_slot += 1;
+                                            s
+                                        });
+                                    targets.push(slot as u32);
                                 }
                             }
                             crate::ShaderBinding::Buffer => {
@@ -275,7 +283,8 @@ impl super::Context {
                             crate::ShaderBinding::Plain { size } => {
                                 let mut index_opt = gl.get_uniform_block_index(program, glsl_name);
                                 if index_opt.is_none() {
-                                    if let Some(ref type_name) = sf.shader.module.types[var.ty].name {
+                                    if let Some(ref type_name) = sf.shader.module.types[var.ty].name
+                                    {
                                         index_opt = gl.get_uniform_block_index(program, type_name);
                                     }
                                 }
@@ -284,14 +293,16 @@ impl super::Context {
                                     index_opt = gl.get_uniform_block_index(program, &type_name);
                                 }
                                 if index_opt.is_none() {
-                                    let num_blocks = gl.get_program_parameter_i32(program, glow::ACTIVE_UNIFORM_BLOCKS);
+                                    let num_blocks = gl.get_program_parameter_i32(
+                                        program,
+                                        glow::ACTIVE_UNIFORM_BLOCKS,
+                                    );
                                     if num_blocks == 1 {
                                         index_opt = Some(0);
                                     }
                                 }
 
-                                if let Some(index) = index_opt
-                                {
+                                if let Some(index) = index_opt {
                                     let expected_size = gl.get_active_uniform_block_parameter_i32(
                                         program,
                                         index,
@@ -319,10 +330,14 @@ impl super::Context {
                                     };
                                     targets.push(slot);
                                 } else {
-                                    let num_blocks = gl.get_program_parameter_i32(program, glow::ACTIVE_UNIFORM_BLOCKS);
+                                    let num_blocks = gl.get_program_parameter_i32(
+                                        program,
+                                        glow::ACTIVE_UNIFORM_BLOCKS,
+                                    );
                                     let mut available_blocks = String::new();
                                     for i in 0..num_blocks {
-                                        let name = gl.get_active_uniform_block_name(program, i as u32);
+                                        let name =
+                                            gl.get_active_uniform_block_name(program, i as u32);
                                         available_blocks.push_str(&format!("{}, ", name));
                                     }
                                     log::error!(

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -311,7 +311,8 @@ impl super::Context {
                                         program,
                                         index,
                                         glow::UNIFORM_BLOCK_DATA_SIZE,
-                                    ) as u32;
+                                    )
+                                        as u32;
                                     let rounded_up_size = super::round_up_uniform_size(size);
                                     assert!(
                                         expected_size <= rounded_up_size,

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -150,8 +150,6 @@ impl super::Context {
 
                     let location = attributes.len() as u32;
                     gl.bind_attrib_location(program, location, attrib_name);
-                    // Naga's GLSL backend prefixes entry point arguments with 'e_'
-                    gl.bind_attrib_location(program, location, &format!("e_{}", attrib_name));
 
                     attributes.push(super::VertexAttributeInfo {
                         attrib,
@@ -251,6 +249,8 @@ impl super::Context {
                                 if let Some(ref location) =
                                     gl.get_uniform_location(program, glsl_name)
                                 {
+                                    // GLES texture units are global; Naga may list the same
+                                    // GLSL sampler name for both the texture and sampler binding.
                                     let slot = *texture_slots
                                         .entry(glsl_name.to_string())
                                         .or_insert_with(|| {
@@ -282,58 +282,18 @@ impl super::Context {
                                 unimplemented!()
                             }
                             crate::ShaderBinding::Plain { size } => {
-                                // Naga may emit the uniform block name as the variable name,
-                                // the user-defined type name, or a generated type name (type_N).
-                                // We check all possibilities to find the correct index.
+                                // Naga reflection name first, then the WGSL struct type name.
                                 let mut index_opt = gl.get_uniform_block_index(program, glsl_name);
                                 if index_opt.is_none() {
-                                    if let Some(ref type_name) = sf.shader.module.types[var.ty].name
+                                    if let Some(ref type_name) =
+                                        sf.shader.module.types[var.ty].name
                                     {
-                                        index_opt = gl.get_uniform_block_index(program, type_name);
-                                    }
-                                }
-                                if index_opt.is_none() {
-                                    let type_name = format!("type_{}", var.ty.index());
-                                    index_opt = gl.get_uniform_block_index(program, &type_name);
-                                }
-                                if index_opt.is_none() {
-                                    let num_blocks = gl.get_program_parameter_i32(
-                                        program,
-                                        glow::ACTIVE_UNIFORM_BLOCKS,
-                                    );
-                                    if num_blocks == 1 {
-                                        index_opt = Some(0);
+                                        index_opt =
+                                            gl.get_uniform_block_index(program, type_name);
                                     }
                                 }
 
-                                if let Some(index) = index_opt {
-                                    let expected_size = gl.get_active_uniform_block_parameter_i32(
-                                        program,
-                                        index,
-                                        glow::UNIFORM_BLOCK_DATA_SIZE,
-                                    )
-                                        as u32;
-                                    let rounded_up_size = super::round_up_uniform_size(size);
-                                    assert!(
-                                        expected_size <= rounded_up_size,
-                                        "Shader expects block[{}] size {}, but data has size of {} (rounded up to {})",
-                                        index,
-                                        expected_size,
-                                        size,
-                                        rounded_up_size,
-                                    );
-                                    let slot = if force_uniform_block_assignment {
-                                        gl.uniform_block_binding(program, index, index);
-                                        index
-                                    } else {
-                                        gl.get_active_uniform_block_parameter_i32(
-                                            program,
-                                            index,
-                                            glow::UNIFORM_BLOCK_BINDING,
-                                        ) as u32
-                                    };
-                                    targets.push(slot);
-                                } else {
+                                let index = index_opt.unwrap_or_else(|| {
                                     let num_blocks = gl.get_program_parameter_i32(
                                         program,
                                         glow::ACTIVE_UNIFORM_BLOCKS,
@@ -342,15 +302,43 @@ impl super::Context {
                                     for i in 0..num_blocks {
                                         let name =
                                             gl.get_active_uniform_block_name(program, i as u32);
-                                        available_blocks.push_str(&format!("{}, ", name));
+                                        available_blocks.push_str(&format!("'{name}', "));
                                     }
-                                    log::error!(
-                                        "Failed to find uniform block for variable '{}' (type '{:?}'). Available blocks: {}",
+                                    panic!(
+                                        "Uniform block for '{}' (WGSL type {:?}) not found. \
+                                         Available blocks: [{}]. \
+                                         Name the uniform struct in WGSL so Naga can reflect it.",
                                         glsl_name,
                                         sf.shader.module.types[var.ty].name,
                                         available_blocks
                                     );
-                                }
+                                });
+
+                                let expected_size = gl.get_active_uniform_block_parameter_i32(
+                                    program,
+                                    index,
+                                    glow::UNIFORM_BLOCK_DATA_SIZE,
+                                ) as u32;
+                                let rounded_up_size = super::round_up_uniform_size(size);
+                                assert!(
+                                    expected_size <= rounded_up_size,
+                                    "Shader expects block[{}] size {}, but data has size of {} (rounded up to {})",
+                                    index,
+                                    expected_size,
+                                    size,
+                                    rounded_up_size,
+                                );
+                                let slot = if force_uniform_block_assignment {
+                                    gl.uniform_block_binding(program, index, index);
+                                    index
+                                } else {
+                                    gl.get_active_uniform_block_parameter_i32(
+                                        program,
+                                        index,
+                                        glow::UNIFORM_BLOCK_BINDING,
+                                    ) as u32
+                                };
+                                targets.push(slot);
                             }
                         }
                     }

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -285,11 +285,9 @@ impl super::Context {
                                 // Naga reflection name first, then the WGSL struct type name.
                                 let mut index_opt = gl.get_uniform_block_index(program, glsl_name);
                                 if index_opt.is_none() {
-                                    if let Some(ref type_name) =
-                                        sf.shader.module.types[var.ty].name
+                                    if let Some(ref type_name) = sf.shader.module.types[var.ty].name
                                     {
-                                        index_opt =
-                                            gl.get_uniform_block_index(program, type_name);
+                                        index_opt = gl.get_uniform_block_index(program, type_name);
                                     }
                                 }
 

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -311,8 +311,7 @@ impl super::Context {
                                         program,
                                         index,
                                         glow::UNIFORM_BLOCK_DATA_SIZE,
-                                    )
-                                        as u32;
+                                    ) as u32;
                                     let rounded_up_size = super::round_up_uniform_size(size);
                                     assert!(
                                         expected_size <= rounded_up_size,

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -131,6 +131,26 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
+    fn sync_buffer_range(&self, buffer: super::Buffer, offset: u64, size: u64) {
+        if !self
+            .capabilities
+            .contains(super::Capabilities::BUFFER_STORAGE)
+        {
+            let gl = self.lock();
+            unsafe {
+                let data = slice::from_raw_parts(buffer.data.add(offset as usize), size as usize);
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
+                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, offset as i32, data);
+
+                #[cfg(target_arch = "wasm32")]
+                {
+                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(buffer.raw_index));
+                    gl.buffer_sub_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, offset as i32, data);
+                }
+            }
+        }
+    }
+
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let gl = self.lock();
         unsafe {

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -61,29 +61,23 @@ impl crate::traits::ResourceDevice for super::Context {
             crate::Memory::External(_) => unimplemented!(),
         };
 
-        let target = if desc.bind_point != 0 {
-            desc.bind_point
-        } else {
-            glow::ARRAY_BUFFER
-        };
-
         unsafe {
-            gl.bind_buffer(target, Some(raw));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
             if self
                 .capabilities
                 .contains(super::Capabilities::BUFFER_STORAGE)
             {
-                gl.buffer_storage(target, desc.size as _, None, storage_flags);
+                gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
                 if map_flags != 0 {
-                    data = gl.map_buffer_range(target, 0, desc.size as _, map_flags);
+                    data = gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
                     assert!(!data.is_null());
                 }
             } else {
-                gl.buffer_data_size(target, desc.size as _, usage);
+                gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);
                 let data_vec = vec![0; desc.size as usize];
                 data = Vec::leak(data_vec).as_mut_ptr();
             }
-            gl.bind_buffer(target, None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
             #[cfg(not(target_arch = "wasm32"))]
             if !desc.name.is_empty() && gl.supports_debug() {
                 gl.object_label(
@@ -95,7 +89,6 @@ impl crate::traits::ResourceDevice for super::Context {
         }
         super::Buffer {
             raw,
-            target,
             size: desc.size,
             data,
         }
@@ -109,8 +102,9 @@ impl crate::traits::ResourceDevice for super::Context {
             let gl = self.lock();
             unsafe {
                 let data = slice::from_raw_parts(buffer.data.add(offset as usize), size as usize);
-                gl.bind_buffer(buffer.target, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(buffer.target, offset as i32, data);
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
+                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, offset as i32, data);
+                gl.bind_buffer(glow::ARRAY_BUFFER, None);
             }
         }
     }

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -204,6 +204,9 @@ impl crate::traits::ResourceDevice for super::Context {
                 // assigning the storage.
                 gl.tex_parameter_i32(target, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
                 gl.tex_parameter_i32(target, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);
+                gl.tex_parameter_i32(target, glow::TEXTURE_WRAP_S, glow::CLAMP_TO_EDGE as i32);
+                gl.tex_parameter_i32(target, glow::TEXTURE_WRAP_T, glow::CLAMP_TO_EDGE as i32);
+                gl.tex_parameter_i32(target, glow::TEXTURE_WRAP_R, glow::CLAMP_TO_EDGE as i32);
 
                 match desc.dimension {
                     crate::TextureDimension::D3 => {

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -61,23 +61,29 @@ impl crate::traits::ResourceDevice for super::Context {
             crate::Memory::External(_) => unimplemented!(),
         };
 
+        let target = if desc.bind_point != 0 {
+            desc.bind_point
+        } else {
+            glow::ARRAY_BUFFER
+        };
+
         unsafe {
-            gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
+            gl.bind_buffer(target, Some(raw));
             if self
                 .capabilities
                 .contains(super::Capabilities::BUFFER_STORAGE)
             {
-                gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
+                gl.buffer_storage(target, desc.size as _, None, storage_flags);
                 if map_flags != 0 {
-                    data = gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
+                    data = gl.map_buffer_range(target, 0, desc.size as _, map_flags);
                     assert!(!data.is_null());
                 }
             } else {
-                gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);
+                gl.buffer_data_size(target, desc.size as _, usage);
                 let data_vec = vec![0; desc.size as usize];
                 data = Vec::leak(data_vec).as_mut_ptr();
             }
-            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_buffer(target, None);
             #[cfg(not(target_arch = "wasm32"))]
             if !desc.name.is_empty() && gl.supports_debug() {
                 gl.object_label(
@@ -89,6 +95,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
         super::Buffer {
             raw,
+            target,
             size: desc.size,
             data,
         }
@@ -102,9 +109,8 @@ impl crate::traits::ResourceDevice for super::Context {
             let gl = self.lock();
             unsafe {
                 let data = slice::from_raw_parts(buffer.data.add(offset as usize), size as usize);
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, offset as i32, data);
-                gl.bind_buffer(glow::ARRAY_BUFFER, None);
+                gl.bind_buffer(buffer.target, Some(buffer.raw));
+                gl.buffer_sub_data_u8_slice(buffer.target, offset as i32, data);
             }
         }
     }

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -37,6 +37,8 @@ impl crate::traits::ResourceDevice for super::Context {
         let gl = self.lock();
 
         let raw = unsafe { gl.create_buffer() }.unwrap();
+        #[cfg(target_arch = "wasm32")]
+        let raw_index = unsafe { gl.create_buffer() }.unwrap();
         let mut data = ptr::null_mut();
 
         let mut storage_flags = 0;
@@ -63,21 +65,34 @@ impl crate::traits::ResourceDevice for super::Context {
 
         unsafe {
             gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
+            #[cfg(target_arch = "wasm32")]
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(raw_index));
             if self
                 .capabilities
                 .contains(super::Capabilities::BUFFER_STORAGE)
             {
                 gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
+                #[cfg(target_arch = "wasm32")]
+                gl.buffer_storage(
+                    glow::ELEMENT_ARRAY_BUFFER,
+                    desc.size as _,
+                    None,
+                    storage_flags,
+                );
                 if map_flags != 0 {
                     data = gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
                     assert!(!data.is_null());
                 }
             } else {
                 gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);
+                #[cfg(target_arch = "wasm32")]
+                gl.buffer_data_size(glow::ELEMENT_ARRAY_BUFFER, desc.size as _, usage);
                 let data_vec = vec![0; desc.size as usize];
                 data = Vec::leak(data_vec).as_mut_ptr();
             }
             gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            #[cfg(target_arch = "wasm32")]
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
             #[cfg(not(target_arch = "wasm32"))]
             if !desc.name.is_empty() && gl.supports_debug() {
                 gl.object_label(
@@ -89,6 +104,8 @@ impl crate::traits::ResourceDevice for super::Context {
         }
         super::Buffer {
             raw,
+            #[cfg(target_arch = "wasm32")]
+            raw_index,
             size: desc.size,
             data,
         }
@@ -104,13 +121,23 @@ impl crate::traits::ResourceDevice for super::Context {
                 let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
                 gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
                 gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, data);
+
+                #[cfg(target_arch = "wasm32")]
+                {
+                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(buffer.raw_index));
+                    gl.buffer_sub_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, 0, data);
+                }
             }
         }
     }
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let gl = self.lock();
-        unsafe { gl.delete_buffer(buffer.raw) };
+        unsafe {
+            gl.delete_buffer(buffer.raw);
+            #[cfg(target_arch = "wasm32")]
+            gl.delete_buffer(buffer.raw_index);
+        }
         if !buffer.data.is_null()
             && !self
                 .capabilities

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -61,8 +61,8 @@ impl crate::traits::ResourceDevice for super::Context {
             crate::Memory::External(_) => unimplemented!(),
         };
 
-        let target = if desc.name.contains("index") {
-            glow::ELEMENT_ARRAY_BUFFER
+        let target = if desc.bind_point != 0 {
+            desc.bind_point
         } else {
             glow::ARRAY_BUFFER
         };
@@ -101,21 +101,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, buffer: super::Buffer) {
-        if !self
-            .capabilities
-            .contains(super::Capabilities::BUFFER_STORAGE)
-        {
-            let gl = self.lock();
-            unsafe {
-                let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
-                gl.bind_buffer(buffer.target, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(buffer.target, 0, data);
-            }
-        }
-    }
-
-    fn sync_buffer_range(&self, buffer: super::Buffer, offset: u64, size: u64) {
+    fn sync_buffer(&self, buffer: super::Buffer, offset: u64, size: u64) {
         if !self
             .capabilities
             .contains(super::Capabilities::BUFFER_STORAGE)
@@ -227,9 +213,6 @@ impl crate::traits::ResourceDevice for super::Context {
                 // assigning the storage.
                 gl.tex_parameter_i32(target, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
                 gl.tex_parameter_i32(target, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);
-                gl.tex_parameter_i32(target, glow::TEXTURE_WRAP_S, glow::CLAMP_TO_EDGE as i32);
-                gl.tex_parameter_i32(target, glow::TEXTURE_WRAP_T, glow::CLAMP_TO_EDGE as i32);
-                gl.tex_parameter_i32(target, glow::TEXTURE_WRAP_R, glow::CLAMP_TO_EDGE as i32);
 
                 match desc.dimension {
                     crate::TextureDimension::D3 => {

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -61,23 +61,29 @@ impl crate::traits::ResourceDevice for super::Context {
             crate::Memory::External(_) => unimplemented!(),
         };
 
+        let target = if desc.name.contains("index") {
+            glow::ELEMENT_ARRAY_BUFFER
+        } else {
+            glow::ARRAY_BUFFER
+        };
+
         unsafe {
-            gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
+            gl.bind_buffer(target, Some(raw));
             if self
                 .capabilities
                 .contains(super::Capabilities::BUFFER_STORAGE)
             {
-                gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
+                gl.buffer_storage(target, desc.size as _, None, storage_flags);
                 if map_flags != 0 {
-                    data = gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
+                    data = gl.map_buffer_range(target, 0, desc.size as _, map_flags);
                     assert!(!data.is_null());
                 }
             } else {
-                gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);
+                gl.buffer_data_size(target, desc.size as _, usage);
                 let data_vec = vec![0; desc.size as usize];
                 data = Vec::leak(data_vec).as_mut_ptr();
             }
-            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_buffer(target, None);
             #[cfg(not(target_arch = "wasm32"))]
             if !desc.name.is_empty() && gl.supports_debug() {
                 gl.object_label(
@@ -89,6 +95,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
         super::Buffer {
             raw,
+            target,
             size: desc.size,
             data,
         }
@@ -102,9 +109,9 @@ impl crate::traits::ResourceDevice for super::Context {
             let gl = self.lock();
             unsafe {
                 let data = slice::from_raw_parts(buffer.data.add(offset as usize), size as usize);
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, offset as i32, data);
-                gl.bind_buffer(glow::ARRAY_BUFFER, None);
+                gl.bind_buffer(buffer.target, Some(buffer.raw));
+                gl.buffer_sub_data_u8_slice(buffer.target, offset as i32, data);
+                gl.bind_buffer(buffer.target, None);
             }
         }
     }

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -37,8 +37,6 @@ impl crate::traits::ResourceDevice for super::Context {
         let gl = self.lock();
 
         let raw = unsafe { gl.create_buffer() }.unwrap();
-        #[cfg(target_arch = "wasm32")]
-        let raw_index = unsafe { gl.create_buffer() }.unwrap();
         let mut data = ptr::null_mut();
 
         let mut storage_flags = 0;
@@ -63,36 +61,29 @@ impl crate::traits::ResourceDevice for super::Context {
             crate::Memory::External(_) => unimplemented!(),
         };
 
+        let target = if desc.name.contains("index") {
+            glow::ELEMENT_ARRAY_BUFFER
+        } else {
+            glow::ARRAY_BUFFER
+        };
+
         unsafe {
-            gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
-            #[cfg(target_arch = "wasm32")]
-            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(raw_index));
+            gl.bind_buffer(target, Some(raw));
             if self
                 .capabilities
                 .contains(super::Capabilities::BUFFER_STORAGE)
             {
-                gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
-                #[cfg(target_arch = "wasm32")]
-                gl.buffer_storage(
-                    glow::ELEMENT_ARRAY_BUFFER,
-                    desc.size as _,
-                    None,
-                    storage_flags,
-                );
+                gl.buffer_storage(target, desc.size as _, None, storage_flags);
                 if map_flags != 0 {
-                    data = gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
+                    data = gl.map_buffer_range(target, 0, desc.size as _, map_flags);
                     assert!(!data.is_null());
                 }
             } else {
-                gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);
-                #[cfg(target_arch = "wasm32")]
-                gl.buffer_data_size(glow::ELEMENT_ARRAY_BUFFER, desc.size as _, usage);
+                gl.buffer_data_size(target, desc.size as _, usage);
                 let data_vec = vec![0; desc.size as usize];
                 data = Vec::leak(data_vec).as_mut_ptr();
             }
-            gl.bind_buffer(glow::ARRAY_BUFFER, None);
-            #[cfg(target_arch = "wasm32")]
-            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
+            gl.bind_buffer(target, None);
             #[cfg(not(target_arch = "wasm32"))]
             if !desc.name.is_empty() && gl.supports_debug() {
                 gl.object_label(
@@ -104,8 +95,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
         super::Buffer {
             raw,
-            #[cfg(target_arch = "wasm32")]
-            raw_index,
+            target,
             size: desc.size,
             data,
         }
@@ -119,14 +109,8 @@ impl crate::traits::ResourceDevice for super::Context {
             let gl = self.lock();
             unsafe {
                 let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, data);
-
-                #[cfg(target_arch = "wasm32")]
-                {
-                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(buffer.raw_index));
-                    gl.buffer_sub_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, 0, data);
-                }
+                gl.bind_buffer(buffer.target, Some(buffer.raw));
+                gl.buffer_sub_data_u8_slice(buffer.target, 0, data);
             }
         }
     }
@@ -139,14 +123,8 @@ impl crate::traits::ResourceDevice for super::Context {
             let gl = self.lock();
             unsafe {
                 let data = slice::from_raw_parts(buffer.data.add(offset as usize), size as usize);
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, offset as i32, data);
-
-                #[cfg(target_arch = "wasm32")]
-                {
-                    gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(buffer.raw_index));
-                    gl.buffer_sub_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, offset as i32, data);
-                }
+                gl.bind_buffer(buffer.target, Some(buffer.raw));
+                gl.buffer_sub_data_u8_slice(buffer.target, offset as i32, data);
             }
         }
     }
@@ -155,8 +133,6 @@ impl crate::traits::ResourceDevice for super::Context {
         let gl = self.lock();
         unsafe {
             gl.delete_buffer(buffer.raw);
-            #[cfg(target_arch = "wasm32")]
-            gl.delete_buffer(buffer.raw_index);
         }
         if !buffer.data.is_null()
             && !self

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -109,9 +109,12 @@ impl crate::traits::ResourceDevice for super::Context {
             let gl = self.lock();
             unsafe {
                 let data = slice::from_raw_parts(buffer.data.add(offset as usize), size as usize);
-                gl.bind_buffer(buffer.target, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(buffer.target, offset as i32, data);
-                gl.bind_buffer(buffer.target, None);
+                // Use COPY_WRITE_BUFFER to upload data. This is a neutral target under WebGL2 / ES3.0
+                // that does not alter the active VAO's ELEMENT_ARRAY_BUFFER binding or vertex attributes.
+                // This avoids VAO thrashing and expensive per-draw validation, while letting us safely unbind.
+                gl.bind_buffer(glow::COPY_WRITE_BUFFER, Some(buffer.raw));
+                gl.buffer_sub_data_u8_slice(glow::COPY_WRITE_BUFFER, offset as i32, data);
+                gl.bind_buffer(glow::COPY_WRITE_BUFFER, None);
             }
         }
     }

--- a/blade-graphics/src/gles/web.rs
+++ b/blade-graphics/src/gles/web.rs
@@ -96,6 +96,7 @@ impl super::Context {
             toggles: super::Toggles::default(),
             limits,
             device_information,
+            is_webgl: true,
         })
     }
 
@@ -126,16 +127,6 @@ impl super::Context {
         let format_desc = super::describe_texture_format(surface.platform.info.format);
         let gl = &self.platform.glow;
         //Note: this code can be shared with EGL
-        let canvas = web_sys::window()
-            .unwrap()
-            .document()
-            .unwrap()
-            .get_element_by_id("blade")
-            .unwrap()
-            .dyn_into::<web_sys::HtmlCanvasElement>()
-            .unwrap();
-        canvas.set_width(config.size.width);
-        canvas.set_height(config.size.height);
 
         unsafe {
             gl.bind_texture(glow::TEXTURE_2D, Some(surface.offscreen_texture));

--- a/blade-graphics/src/gles/web.rs
+++ b/blade-graphics/src/gles/web.rs
@@ -126,6 +126,17 @@ impl super::Context {
         let format_desc = super::describe_texture_format(surface.platform.info.format);
         let gl = &self.platform.glow;
         //Note: this code can be shared with EGL
+        let canvas = web_sys::window()
+            .unwrap()
+            .document()
+            .unwrap()
+            .get_element_by_id("blade")
+            .unwrap()
+            .dyn_into::<web_sys::HtmlCanvasElement>()
+            .unwrap();
+        canvas.set_width(config.size.width);
+        canvas.set_height(config.size.height);
+
         unsafe {
             gl.bind_texture(glow::TEXTURE_2D, Some(surface.offscreen_texture));
             gl.tex_image_2d(

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -350,8 +350,6 @@ pub struct BufferDesc<'a> {
     pub name: &'a str,
     pub size: u64,
     pub memory: Memory,
-    /// GLES/WebGL: `glow::ARRAY_BUFFER` or `glow::ELEMENT_ARRAY_BUFFER`. Ignored on other backends.
-    pub bind_point: u32,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -350,6 +350,8 @@ pub struct BufferDesc<'a> {
     pub name: &'a str,
     pub size: u64,
     pub memory: Memory,
+    /// GLES/WebGL: `glow::ARRAY_BUFFER` or `glow::ELEMENT_ARRAY_BUFFER`. Ignored on other backends.
+    pub bind_point: u32,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -473,6 +473,8 @@ pub enum TextureFormat {
     R32Float,
     Rg32Float,
     Rgba32Float,
+    R8Uint,
+    R16Uint,
     R32Uint,
     Rg32Uint,
     Rgba32Uint,

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -293,7 +293,7 @@ impl super::CommandEncoder {
         targets: crate::RenderTargetSet,
     ) -> super::RenderCommandEncoder<'_> {
         let raw = objc2::rc::autoreleasepool(|_| {
-            let descriptor = unsafe { metal::MTLRenderPassDescriptor::new() };
+            let descriptor = metal::MTLRenderPassDescriptor::new();
 
             for (i, rt) in targets.colors.iter().enumerate() {
                 let at_descriptor =
@@ -432,7 +432,7 @@ impl crate::traits::CommandEncoder for super::CommandEncoder {
         }
 
         let queue = self.queue.lock().unwrap();
-        self.raw = Some(objc2::rc::autoreleasepool(|_| unsafe {
+        self.raw = Some(objc2::rc::autoreleasepool(|_| {
             use metal::MTLCommandQueue as _;
             let cmd_buf = queue.commandBufferWithUnretainedReferences().unwrap();
             if !self.name.is_empty() {

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -765,6 +765,9 @@ impl super::RenderCommandEncoder<'_> {
         self.raw.setFrontFacingWinding(pipeline.front_winding);
         self.raw.setCullMode(pipeline.cull_mode);
         self.raw.setTriangleFillMode(pipeline.triangle_fill_mode);
+        // Metal Simulator aborts instead of ignoring this unsupported state.
+        // Real iOS devices and macOS still receive the requested clip mode.
+        #[cfg(not(all(target_os = "ios", target_abi = "sim")))]
         self.raw.setDepthClipMode(pipeline.depth_clip_mode);
         if let Some((ref state, bias)) = pipeline.depth_stencil {
             self.raw.setDepthStencilState(Some(state));

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -492,9 +492,9 @@ impl Context {
         let mut timestamp_counter_set = None;
         if desc.timing {
             use metal::MTLCounterSet as _;
-            if let Some(counter_sets) = unsafe { device.counterSets() } {
+            if let Some(counter_sets) = device.counterSets() {
                 for counter_set in counter_sets {
-                    let name = unsafe { counter_set.name() };
+                    let name = counter_set.name();
                     if name.to_string() == "timestamp" {
                         timestamp_counter_set = Some(counter_set);
                     }
@@ -631,23 +631,24 @@ impl crate::traits::CommandDevice for Context {
 
         let timing_datas = if let Some(ref counter_set) = self.timestamp_counter_set {
             let mut array = Vec::with_capacity(desc.buffer_count as usize);
-            let csb_desc = unsafe {
-                let desc = metal::MTLCounterSampleBufferDescriptor::new();
-                desc.setCounterSet(Some(counter_set));
-                desc.setStorageMode(metal::MTLStorageMode::Shared);
-                desc.setSampleCount(MAX_TIMESTAMPS);
-                desc
+            let csb_desc = {
+                let d = metal::MTLCounterSampleBufferDescriptor::new();
+                d.setCounterSet(Some(counter_set));
+                d.setStorageMode(metal::MTLStorageMode::Shared);
+                unsafe {
+                    d.setSampleCount(MAX_TIMESTAMPS);
+                }
+                d
             };
             for i in 0..desc.buffer_count {
                 let label = format!("{}/counter{}", desc.name, i);
-                let sample_buffer = unsafe {
-                    csb_desc.setLabel(&objc2_foundation::NSString::from_str(&label));
-                    self.device
-                        .lock()
-                        .unwrap()
-                        .newCounterSampleBufferWithDescriptor_error(&csb_desc)
-                        .unwrap()
-                };
+                csb_desc.setLabel(&objc2_foundation::NSString::from_str(&label));
+                let sample_buffer = self
+                    .device
+                    .lock()
+                    .unwrap()
+                    .newCounterSampleBufferWithDescriptor_error(&csb_desc)
+                    .unwrap();
                 array.push(TimingData {
                     sample_buffer,
                     pass_names: Vec::new(),

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -346,6 +346,8 @@ fn map_texture_format(format: crate::TextureFormat) -> metal::MTLPixelFormat {
         Tf::R32Float => Mpf::R32Float,
         Tf::Rg32Float => Mpf::RG32Float,
         Tf::Rgba32Float => Mpf::RGBA32Float,
+        Tf::R8Uint => Mpf::R8Uint,
+        Tf::R16Uint => Mpf::R16Uint,
         Tf::R32Uint => Mpf::R32Uint,
         Tf::Rg32Uint => Mpf::RG32Uint,
         Tf::Rgba32Uint => Mpf::RGBA32Uint,

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -90,8 +90,8 @@ impl Buffer {
     }
 
     pub fn size(&self) -> u64 {
-        use metal::MTLResource as _;
-        self.as_ref().allocatedSize() as u64
+        use metal::MTLBuffer as _;
+        self.as_ref().length() as u64
     }
 }
 
@@ -274,6 +274,7 @@ pub struct RenderPipeline {
     triangle_fill_mode: metal::MTLTriangleFillMode,
     front_winding: metal::MTLWinding,
     cull_mode: metal::MTLCullMode,
+    #[cfg_attr(all(target_os = "ios", target_abi = "sim"), allow(dead_code))]
     depth_clip_mode: metal::MTLDepthClipMode,
     depth_stencil: Option<(
         Retained<ProtocolObject<dyn metal::MTLDepthStencilState>>,

--- a/blade-graphics/src/metal/pipeline.rs
+++ b/blade-graphics/src/metal/pipeline.rs
@@ -293,6 +293,7 @@ impl super::Context {
             task_dispatch_limits: None,
             mesh_shader_primitive_indices_clamp: true,
             emit_int_div_checks: false,
+            ray_query_initialization_tracking: true,
         };
 
         let pipeline_options = msl::PipelineOptions {
@@ -300,6 +301,7 @@ impl super::Context {
             allow_and_force_point_size: flags.contains(ShaderFlags::ALLOW_POINT_SIZE),
             vertex_pulling_transform: false,
             vertex_buffer_mappings: Vec::new(),
+            binding_array_length_map: Default::default(),
         };
         let (source, info) =
             msl::write_string(&module, &module_info, &naga_options, &pipeline_options).unwrap();

--- a/blade-graphics/src/metal/pipeline.rs
+++ b/blade-graphics/src/metal/pipeline.rs
@@ -76,7 +76,7 @@ fn create_stencil_desc(
     read_mask: u32,
     write_mask: u32,
 ) -> Retained<metal::MTLStencilDescriptor> {
-    let desc = unsafe { metal::MTLStencilDescriptor::new() };
+    let desc = metal::MTLStencilDescriptor::new();
     desc.setStencilCompareFunction(super::map_compare_function(face.compare));
     desc.setReadMask(read_mask);
     desc.setWriteMask(write_mask);
@@ -89,7 +89,7 @@ fn create_stencil_desc(
 fn create_depth_stencil_desc(
     state: &crate::DepthStencilState,
 ) -> Retained<metal::MTLDepthStencilDescriptor> {
-    let desc = unsafe { metal::MTLDepthStencilDescriptor::new() };
+    let desc = metal::MTLDepthStencilDescriptor::new();
     desc.setDepthCompareFunction(super::map_compare_function(state.depth_compare));
     desc.setDepthWriteEnabled(state.depth_write_enabled);
 
@@ -314,7 +314,7 @@ impl super::Context {
         let source_string = NSString::from_str(&source);
         let options = metal::MTLCompileOptions::new();
         options.setLanguageVersion(self.info.language_version);
-        unsafe { options.setMathMode(metal::MTLMathMode::Fast) };
+        options.setMathMode(metal::MTLMathMode::Fast);
 
         let library = self
             .device
@@ -478,7 +478,7 @@ impl crate::traits::ShaderDevice for super::Context {
                 None
             };
 
-            let vertex_descriptor = unsafe { metal::MTLVertexDescriptor::new() };
+            let vertex_descriptor = metal::MTLVertexDescriptor::new();
             for (i, vf) in desc.vertex_fetches.iter().enumerate() {
                 unsafe {
                     let buffer_desc = vertex_descriptor.layouts().objectAtIndexedSubscript(i);
@@ -487,15 +487,16 @@ impl crate::traits::ShaderDevice for super::Context {
                         metal::MTLVertexStepFunction::PerInstance
                     } else {
                         metal::MTLVertexStepFunction::PerVertex
-                    })
-                };
+                    });
+                }
             }
             for (i, mapping) in vs.attribute_mappings.into_iter().enumerate() {
                 let vf = &desc.vertex_fetches[mapping.buffer_index];
                 let (_, attrib) = vf.layout.attributes[mapping.attribute_index];
                 let (vertex_format, _) = super::map_vertex_format(attrib.format);
                 unsafe {
-                    let attribute_desc = vertex_descriptor.attributes().objectAtIndexedSubscript(i);
+                    let attribute_desc =
+                        vertex_descriptor.attributes().objectAtIndexedSubscript(i);
                     attribute_desc.setFormat(vertex_format);
                     attribute_desc.setBufferIndex(mapping.buffer_index);
                     attribute_desc.setOffset(attrib.offset as usize);

--- a/blade-graphics/src/metal/pipeline.rs
+++ b/blade-graphics/src/metal/pipeline.rs
@@ -495,8 +495,7 @@ impl crate::traits::ShaderDevice for super::Context {
                 let (_, attrib) = vf.layout.attributes[mapping.attribute_index];
                 let (vertex_format, _) = super::map_vertex_format(attrib.format);
                 unsafe {
-                    let attribute_desc =
-                        vertex_descriptor.attributes().objectAtIndexedSubscript(i);
+                    let attribute_desc = vertex_descriptor.attributes().objectAtIndexedSubscript(i);
                     attribute_desc.setFormat(vertex_format);
                     attribute_desc.setBufferIndex(mapping.buffer_index);
                     attribute_desc.setOffset(attrib.offset as usize);

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -203,6 +203,7 @@ impl crate::traits::ResourceDevice for super::Context {
     }
 
     fn sync_buffer(&self, _buffer: super::Buffer) {}
+    fn sync_buffer_range(&self, _buffer: super::Buffer, _offset: u64, _size: u64) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let _ = unsafe { Retained::from_raw(buffer.raw) };

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -202,8 +202,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, _buffer: super::Buffer) {}
-    fn sync_buffer_range(&self, _buffer: super::Buffer, _offset: u64, _size: u64) {}
+    fn sync_buffer(&self, _buffer: super::Buffer, _offset: u64, _size: u64) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let _ = unsafe { Retained::from_raw(buffer.raw) };

--- a/blade-graphics/src/metal/surface.rs
+++ b/blade-graphics/src/metal/surface.rs
@@ -127,21 +127,19 @@ impl super::Context {
             crate::DisplaySync::Recent | crate::DisplaySync::Tear => false,
         };
 
-        unsafe {
-            surface.render_layer.setOpaque(!config.transparent);
-            surface.render_layer.setDevice(Some(device.as_ref()));
-            surface
-                .render_layer
-                .setPixelFormat(super::map_texture_format(surface.info.format));
-            surface
-                .render_layer
-                .setFramebufferOnly(config.usage == crate::TextureUsage::TARGET);
-            surface.render_layer.setMaximumDrawableCount(3);
-            surface.render_layer.setDrawableSize(CGSize {
-                width: config.size.width as f64,
-                height: config.size.height as f64,
-            });
-            surface.render_layer.setDisplaySyncEnabled(vsync);
-        }
+        surface.render_layer.setOpaque(!config.transparent);
+        surface.render_layer.setDevice(Some(device.as_ref()));
+        surface
+            .render_layer
+            .setPixelFormat(super::map_texture_format(surface.info.format));
+        surface
+            .render_layer
+            .setFramebufferOnly(config.usage == crate::TextureUsage::TARGET);
+        surface.render_layer.setMaximumDrawableCount(3);
+        surface.render_layer.setDrawableSize(CGSize {
+            width: config.size.width as f64,
+            height: config.size.height as f64,
+        });
+        surface.render_layer.setDisplaySyncEnabled(vsync);
     }
 }

--- a/blade-graphics/src/shader.rs
+++ b/blade-graphics/src/shader.rs
@@ -298,7 +298,7 @@ impl super::Shader {
                         Some(ref name) => name.as_str(),
                         None => "?",
                     };
-                    
+
                     let has_binding = member.binding.is_some();
                     if !has_binding {
                         member.binding = Some(naga::Binding::Location {

--- a/blade-graphics/src/shader.rs
+++ b/blade-graphics/src/shader.rs
@@ -292,39 +292,30 @@ impl super::Shader {
                 };
 
                 log::debug!("Processing vertex argument: {}", arg_name);
+                let mut needs_replace = false;
                 'member: for member in members.iter_mut() {
                     let member_name = match member.name {
                         Some(ref name) => name.as_str(),
                         None => "?",
                     };
-                    if let Some(ref binding) = member.binding {
-                        log::warn!(
-                            "Member '{}' already has binding: {:?}",
-                            member_name,
-                            binding
-                        );
-                        continue;
+                    
+                    let has_binding = member.binding.is_some();
+                    if !has_binding {
+                        member.binding = Some(naga::Binding::Location {
+                            location: attribute_mappings.len() as u32,
+                            interpolation: None,
+                            sampling: None,
+                            blend_src: None,
+                            per_primitive: false,
+                        });
+                        needs_replace = true;
                     }
-                    let binding = naga::Binding::Location {
-                        location: attribute_mappings.len() as u32,
-                        interpolation: None,
-                        sampling: None,
-                        blend_src: None,
-                        per_primitive: false,
-                    };
+
                     for (buffer_index, vertex_fetch) in fetch_states.iter().enumerate() {
                         for (attribute_index, &(at_name, _)) in
                             vertex_fetch.layout.attributes.iter().enumerate()
                         {
                             if at_name == member_name {
-                                log::debug!(
-                                    "Assigning location({}) for member '{}' to be using input {}:{}",
-                                    attribute_mappings.len(),
-                                    member_name,
-                                    buffer_index,
-                                    attribute_index
-                                );
-                                member.binding = Some(binding);
                                 attribute_mappings.push(crate::VertexAttributeMapping {
                                     buffer_index,
                                     attribute_index,
@@ -333,13 +324,15 @@ impl super::Shader {
                             }
                         }
                     }
-                    assert_ne!(
-                        member.binding, None,
+                    assert!(
+                        has_binding || member.binding.is_some(),
                         "Field {} is not covered by the vertex fetch layouts!",
                         member_name
                     );
                 }
-                module.types.replace(argument.ty, ty);
+                if needs_replace {
+                    module.types.replace(argument.ty, ty);
+                }
             }
         }
         attribute_mappings

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -8,8 +8,7 @@ pub trait ResourceDevice {
     type AccelerationStructure: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
-    fn sync_buffer(&self, buffer: Self::Buffer);
-    fn sync_buffer_range(&self, buffer: Self::Buffer, offset: u64, size: u64);
+    fn sync_buffer(&self, buffer: Self::Buffer, offset: u64, size: u64);
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -9,6 +9,7 @@ pub trait ResourceDevice {
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
     fn sync_buffer(&self, buffer: Self::Buffer);
+    fn sync_buffer_range(&self, buffer: Self::Buffer, offset: u64, size: u64);
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);

--- a/blade-graphics/src/util.rs
+++ b/blade-graphics/src/util.rs
@@ -71,6 +71,8 @@ impl super::TextureFormat {
             Self::R32Float => uncompressed(4),
             Self::Rg32Float => uncompressed(8),
             Self::Rgba32Float => uncompressed(16),
+            Self::R8Uint => uncompressed(1),
+            Self::R16Uint => uncompressed(2),
             Self::R32Uint => uncompressed(4),
             Self::Rg32Uint => uncompressed(8),
             Self::Rgba32Uint => uncompressed(16),

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -281,7 +281,9 @@ fn map_render_target(rt: &crate::RenderTarget) -> vk::RenderingAttachmentInfo<'s
 fn end_pass(device: &super::Device, cmd_buf: vk::CommandBuffer) {
     if device.command_scope.is_some() {
         unsafe {
-            device.debug_utils.cmd_end_debug_utils_label(cmd_buf);
+            if let Some(ref ext) = device.debug_utils {
+                ext.cmd_end_debug_utils_label(cmd_buf);
+            }
         }
     }
 }
@@ -338,13 +340,15 @@ impl super::CommandEncoder {
             self.temp_label.extend_from_slice(label.as_bytes());
             self.temp_label.push(0);
             unsafe {
-                self.device.debug_utils.cmd_begin_debug_utils_label(
-                    self.buffers[0].raw,
-                    &vk::DebugUtilsLabelEXT {
-                        p_label_name: self.temp_label.as_ptr() as *const _,
-                        ..Default::default()
-                    },
-                )
+                if let Some(ref ext) = self.device.debug_utils {
+                    ext.cmd_begin_debug_utils_label(
+                        self.buffers[0].raw,
+                        &vk::DebugUtilsLabelEXT {
+                            p_label_name: self.temp_label.as_ptr() as *const _,
+                            ..Default::default()
+                        },
+                    )
+                }
             }
         }
     }

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -521,6 +521,7 @@ impl crate::traits::CommandEncoder for super::CommandEncoder {
     type Frame = super::Frame;
 
     fn start(&mut self) {
+        log::trace!("CommandEncoder::start()");
         self.buffers.rotate_left(1);
         let cmd_buf = self.buffers.first_mut().unwrap();
         self.device

--- a/blade-graphics/src/vulkan/descriptor.rs
+++ b/blade-graphics/src/vulkan/descriptor.rs
@@ -18,7 +18,7 @@ pub struct DescriptorPool {
 
 impl super::Device {
     fn create_descriptor_sub_pool(&self, max_sets: u32) -> vk::DescriptorPool {
-        log::info!("Creating a descriptor pool for at most {} sets", max_sets);
+        log::debug!("Creating a descriptor sub-pool for at most {} sets", max_sets);
         let mut descriptor_sizes = vec![
             vk::DescriptorPoolSize {
                 ty: vk::DescriptorType::STORAGE_BUFFER,
@@ -85,6 +85,7 @@ impl super::Device {
     }
 
     pub(super) fn destroy_descriptor_pool(&self, pool: &mut DescriptorPool) {
+        log::trace!("Destroying descriptor pool ({} sub-pools)", pool.sub_pools.len());
         for sub_pool in pool.sub_pools.drain(..) {
             unsafe { self.core.destroy_descriptor_pool(sub_pool, None) };
         }
@@ -116,12 +117,18 @@ impl super::Device {
     }
 
     pub(super) fn reset_descriptor_pool(&self, pool: &mut DescriptorPool) {
+        if pool.sub_pools.is_empty() {
+            log::error!("reset_descriptor_pool called on empty pool — recreating base pool");
+            let vk_pool = self.create_descriptor_sub_pool(COUNT_BASE);
+            pool.sub_pools.push(vk_pool);
+            pool.growth_iter = 0;
+            return;
+        }
         for vk_pool in pool.sub_pools.drain(1..) {
             unsafe {
                 self.core.destroy_descriptor_pool(vk_pool, None);
             }
         }
-
         unsafe {
             self.core
                 .reset_descriptor_pool(pool.sub_pools[0], vk::DescriptorPoolResetFlags::empty())

--- a/blade-graphics/src/vulkan/descriptor.rs
+++ b/blade-graphics/src/vulkan/descriptor.rs
@@ -18,7 +18,10 @@ pub struct DescriptorPool {
 
 impl super::Device {
     fn create_descriptor_sub_pool(&self, max_sets: u32) -> vk::DescriptorPool {
-        log::debug!("Creating a descriptor sub-pool for at most {} sets", max_sets);
+        log::debug!(
+            "Creating a descriptor sub-pool for at most {} sets",
+            max_sets
+        );
         let mut descriptor_sizes = vec![
             vk::DescriptorPoolSize {
                 ty: vk::DescriptorType::STORAGE_BUFFER,
@@ -85,7 +88,10 @@ impl super::Device {
     }
 
     pub(super) fn destroy_descriptor_pool(&self, pool: &mut DescriptorPool) {
-        log::trace!("Destroying descriptor pool ({} sub-pools)", pool.sub_pools.len());
+        log::trace!(
+            "Destroying descriptor pool ({} sub-pools)",
+            pool.sub_pools.len()
+        );
         for sub_pool in pool.sub_pools.drain(..) {
             unsafe { self.core.destroy_descriptor_pool(sub_pool, None) };
         }

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -669,9 +669,7 @@ impl super::VulkanInstance {
         let core_instance = {
             let mut create_flags = vk::InstanceCreateFlags::empty();
 
-            let mut instance_extensions = vec![
-                vk::KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_NAME,
-            ];
+            let mut instance_extensions = vec![vk::KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_NAME];
             if has_debug_utils {
                 instance_extensions.push(vk::EXT_DEBUG_UTILS_NAME);
             }
@@ -1467,9 +1465,7 @@ impl super::Context {
             .object_handle(object)
             .object_name(&name_cstr);
         if let Some(ref dbg) = self.device.debug_utils {
-            let _ = unsafe {
-                dbg.set_debug_utils_object_name(&name_info)
-            };
+            let _ = unsafe { dbg.set_debug_utils_object_name(&name_info) };
         }
     }
 

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -664,13 +664,17 @@ impl super::VulkanInstance {
             .map(|ext_prop| unsafe { ffi::CStr::from_ptr(ext_prop.extension_name.as_ptr()) })
             .collect::<Vec<_>>();
 
+        let has_debug_utils = supported_instance_extensions.contains(&vk::EXT_DEBUG_UTILS_NAME);
+
         let core_instance = {
             let mut create_flags = vk::InstanceCreateFlags::empty();
 
             let mut instance_extensions = vec![
-                vk::EXT_DEBUG_UTILS_NAME,
                 vk::KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_NAME,
             ];
+            if has_debug_utils {
+                instance_extensions.push(vk::EXT_DEBUG_UTILS_NAME);
+            }
             if desc.presentation {
                 instance_extensions.push(vk::KHR_SURFACE_NAME);
                 instance_extensions.push(vk::KHR_GET_SURFACE_CAPABILITIES2_NAME);
@@ -754,7 +758,11 @@ impl super::VulkanInstance {
 
         let instance =
             super::Instance {
-                _debug_utils: ext::debug_utils::Instance::new(&entry, &core_instance),
+                _debug_utils: if has_debug_utils {
+                    Some(ext::debug_utils::Instance::new(&entry, &core_instance))
+                } else {
+                    None
+                },
                 get_physical_device_properties2:
                     khr::get_physical_device_properties2::Instance::new(&entry, &core_instance),
                 cooperative_matrix: khr::cooperative_matrix::Instance::new(&entry, &core_instance),
@@ -904,16 +912,18 @@ impl super::Context {
                 .map_err(crate::PlatformError::init)?
                 .into_iter()
                 .find_map(|phd| {
-                    inspect_adapter(
+                    let result = inspect_adapter(
                         phd,
                         &inner.instance,
                         inner.driver_api_version,
                         &desc,
                         &gpu_vendors,
                         display_server,
-                    )
-                    .ok()
-                    .map(|caps| (phd, caps))
+                    );
+                    if let Err(ref e) = result {
+                        log::error!("Adapter rejected: {}", e);
+                    }
+                    result.ok().map(|caps| (phd, caps))
                 })
                 .ok_or(NotSupportedError::NoSupportedDeviceFound)?
         };
@@ -1161,7 +1171,11 @@ impl super::Context {
             } else {
                 None
             },
-            debug_utils: ext::debug_utils::Device::new(&instance.core, &device_core),
+            debug_utils: if instance._debug_utils.is_some() {
+                Some(ext::debug_utils::Device::new(&instance.core, &device_core))
+            } else {
+                None
+            },
             timeline_semaphore: khr::timeline_semaphore::Device::new(&instance.core, &device_core),
             dynamic_rendering: khr::dynamic_rendering::Device::new(&instance.core, &device_core),
             ray_tracing: if let Some(ref caps) = capabilities.ray_tracing {
@@ -1452,11 +1466,11 @@ impl super::Context {
         let name_info = vk::DebugUtilsObjectNameInfoEXT::default()
             .object_handle(object)
             .object_name(&name_cstr);
-        let _ = unsafe {
-            self.device
-                .debug_utils
-                .set_debug_utils_object_name(&name_info)
-        };
+        if let Some(ref dbg) = self.device.debug_utils {
+            let _ = unsafe {
+                dbg.set_debug_utils_object_name(&name_info)
+            };
+        }
     }
 
     pub fn capabilities(&self) -> crate::Capabilities {

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -543,7 +543,6 @@ impl crate::traits::CommandDevice for Context {
                     name: "_scratch",
                     size: SCRATCH_SIZE,
                     memory: crate::Memory::Shared,
-                    bind_point: 0,
                 });
                 let scratch = Some(ScratchBuffer {
                     raw: scratch_buf.raw,
@@ -570,7 +569,6 @@ impl crate::traits::CommandDevice for Context {
                     name: "_marker",
                     size: 4,
                     memory: crate::Memory::Shared,
-                    bind_point: 0,
                 }),
                 raw_string: vec![0; 0x1000].into_boxed_slice(),
                 next_offset: 0,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -24,7 +24,7 @@ const MAX_XR_EYES: usize = 2;
 
 struct Instance {
     core: ash::Instance,
-    _debug_utils: ash::ext::debug_utils::Instance,
+    _debug_utils: Option<ash::ext::debug_utils::Instance>,
     get_physical_device_properties2: khr::get_physical_device_properties2::Instance,
     cooperative_matrix: khr::cooperative_matrix::Instance,
     get_surface_capabilities2: Option<khr::get_surface_capabilities2::Instance>,
@@ -56,7 +56,7 @@ struct Device {
     core: ash::Device,
     device_information: crate::DeviceInformation,
     swapchain: Option<khr::swapchain::Device>,
-    debug_utils: ash::ext::debug_utils::Device,
+    debug_utils: Option<ash::ext::debug_utils::Device>,
     timeline_semaphore: khr::timeline_semaphore::Device,
     dynamic_rendering: khr::dynamic_rendering::Device,
     ray_tracing: Option<RayTracingDevice>,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -819,6 +819,8 @@ fn map_texture_format(format: crate::TextureFormat) -> vk::Format {
         Tf::R32Float => vk::Format::R32_SFLOAT,
         Tf::Rg32Float => vk::Format::R32G32_SFLOAT,
         Tf::Rgba32Float => vk::Format::R32G32B32A32_SFLOAT,
+        Tf::R8Uint => vk::Format::R8_UINT,
+        Tf::R16Uint => vk::Format::R16_UINT,
         Tf::R32Uint => vk::Format::R32_UINT,
         Tf::Rg32Uint => vk::Format::R32G32_UINT,
         Tf::Rgba32Uint => vk::Format::R32G32B32A32_UINT,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -543,6 +543,7 @@ impl crate::traits::CommandDevice for Context {
                     name: "_scratch",
                     size: SCRATCH_SIZE,
                     memory: crate::Memory::Shared,
+                    bind_point: 0,
                 });
                 let scratch = Some(ScratchBuffer {
                     raw: scratch_buf.raw,
@@ -569,6 +570,7 @@ impl crate::traits::CommandDevice for Context {
                     name: "_marker",
                     size: 4,
                     memory: crate::Memory::Shared,
+                    bind_point: 0,
                 }),
                 raw_string: vec![0; 0x1000].into_boxed_slice(),
                 next_offset: 0,

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -300,7 +300,6 @@ impl super::Context {
             size: (instances.len().max(1) * mem::size_of::<vk::AccelerationStructureInstanceKHR>())
                 as u64,
             memory: crate::Memory::Shared,
-            bind_point: 0,
         });
         let rt = self.device.ray_tracing.as_ref().unwrap();
         for (i, instance) in instances.iter().enumerate() {

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -426,6 +426,7 @@ impl crate::traits::ResourceDevice for super::Context {
     }
 
     fn sync_buffer(&self, _buffer: super::Buffer) {}
+    fn sync_buffer_range(&self, _buffer: super::Buffer, _offset: u64, _size: u64) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         log::info!(

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -300,6 +300,7 @@ impl super::Context {
             size: (instances.len().max(1) * mem::size_of::<vk::AccelerationStructureInstanceKHR>())
                 as u64,
             memory: crate::Memory::Shared,
+            bind_point: 0,
         });
         let rt = self.device.ray_tracing.as_ref().unwrap();
         for (i, instance) in instances.iter().enumerate() {

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -300,6 +300,7 @@ impl super::Context {
             size: (instances.len().max(1) * mem::size_of::<vk::AccelerationStructureInstanceKHR>())
                 as u64,
             memory: crate::Memory::Shared,
+            bind_point: 0,
         });
         let rt = self.device.ray_tracing.as_ref().unwrap();
         for (i, instance) in instances.iter().enumerate() {
@@ -425,8 +426,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, _buffer: super::Buffer) {}
-    fn sync_buffer_range(&self, _buffer: super::Buffer, _offset: u64, _size: u64) {}
+    fn sync_buffer(&self, _buffer: super::Buffer, _offset: u64, _size: u64) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         log::info!(

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -120,6 +120,12 @@ impl BufferBelt {
         unsafe { self.alloc_typed(data, gpu) }
     }
 
+    pub fn sync(&self, gpu: &gpu::Context) {
+        for (rb, _) in &self.active {
+            gpu.sync_buffer(rb.raw);
+        }
+    }
+
     /// Mark the actively used buffers as used by GPU with a given sync point.
     pub fn flush(&mut self, sp: &gpu::SyncPoint) {
         self.buffers

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -13,6 +13,8 @@ pub struct BufferBeltDescriptor {
     pub min_chunk_size: u64,
     pub alignment: u64,
     pub name: &'static str,
+    /// GLES/WebGL: `glow::ARRAY_BUFFER` or `glow::ELEMENT_ARRAY_BUFFER`.
+    pub bind_point: u32,
 }
 
 /// A belt of reusable buffer space.
@@ -73,6 +75,7 @@ impl BufferBelt {
             name: &format!("chunk-{}-{}", self.desc.name, chunk_index),
             size: chunk_size,
             memory: self.desc.memory,
+            bind_point: self.desc.bind_point,
         });
         let rb = ReusableBuffer {
             raw: chunk,
@@ -123,7 +126,7 @@ impl BufferBelt {
 
     pub fn sync(&self, gpu: &gpu::Context) {
         for (rb, _) in &self.active {
-            gpu.sync_buffer(rb.raw);
+            gpu.sync_buffer(rb.raw, 0, rb.size);
         }
     }
 

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -12,6 +12,7 @@ pub struct BufferBeltDescriptor {
     pub memory: gpu::Memory,
     pub min_chunk_size: u64,
     pub alignment: u64,
+    pub name: &'static str,
 }
 
 /// A belt of reusable buffer space.
@@ -69,7 +70,7 @@ impl BufferBelt {
         let chunk_index = self.buffers.len() + self.active.len();
         let chunk_size = size.max(self.desc.min_chunk_size);
         let chunk = gpu.create_buffer(gpu::BufferDesc {
-            name: &format!("chunk-{}", chunk_index),
+            name: &format!("chunk-{}-{}", self.desc.name, chunk_index),
             size: chunk_size,
             memory: self.desc.memory,
         });

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -13,6 +13,8 @@ pub struct BufferBeltDescriptor {
     pub min_chunk_size: u64,
     pub alignment: u64,
     pub name: &'static str,
+    /// GLES/WebGL: `glow::ARRAY_BUFFER` or `glow::ELEMENT_ARRAY_BUFFER`.
+    pub bind_point: u32,
 }
 
 /// A belt of reusable buffer space.
@@ -73,6 +75,7 @@ impl BufferBelt {
             name: &format!("chunk-{}-{}", self.desc.name, chunk_index),
             size: chunk_size,
             memory: self.desc.memory,
+            bind_point: self.desc.bind_point,
         });
         let rb = ReusableBuffer {
             raw: chunk,

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -13,8 +13,6 @@ pub struct BufferBeltDescriptor {
     pub min_chunk_size: u64,
     pub alignment: u64,
     pub name: &'static str,
-    /// GLES/WebGL: `glow::ARRAY_BUFFER` or `glow::ELEMENT_ARRAY_BUFFER`.
-    pub bind_point: u32,
 }
 
 /// A belt of reusable buffer space.
@@ -75,7 +73,6 @@ impl BufferBelt {
             name: &format!("chunk-{}-{}", self.desc.name, chunk_index),
             size: chunk_size,
             memory: self.desc.memory,
-            bind_point: self.desc.bind_point,
         });
         let rb = ReusableBuffer {
             raw: chunk,

--- a/examples-android/xr/xr.rs
+++ b/examples-android/xr/xr.rs
@@ -197,7 +197,7 @@ impl Example {
                 *(self.params_buf.data().offset(params_offset) as *mut Uniforms) = uniforms;
             }
         }
-        context.sync_buffer(self.params_buf);
+        context.sync_buffer(self.params_buf, 0, self.params_buf.size());
 
         for eye in 0..view_count {
             let eye_view = frame.xr_texture_view(eye);

--- a/examples-android/xr/xr.rs
+++ b/examples-android/xr/xr.rs
@@ -197,7 +197,7 @@ impl Example {
                 *(self.params_buf.data().offset(params_offset) as *mut Uniforms) = uniforms;
             }
         }
-        context.sync_buffer(self.params_buf, 0, self.params_buf.size());
+        context.sync_buffer(self.params_buf);
 
         for eye in 0..view_count {
             let eye_view = frame.xr_texture_view(eye);

--- a/examples/bunnymark/example.rs
+++ b/examples/bunnymark/example.rs
@@ -132,7 +132,7 @@ impl Example {
                 texture_data.len(),
             );
         }
-        context.sync_buffer(upload_buffer, 0, upload_buffer.size());
+        context.sync_buffer(upload_buffer);
 
         let sampler = context.create_sampler(gpu::SamplerDesc {
             name: "main",
@@ -157,7 +157,7 @@ impl Example {
                 vertex_data.len(),
             );
         }
-        context.sync_buffer(vertex_buf, 0, vertex_buf.size());
+        context.sync_buffer(vertex_buf);
 
         let bunnies = vec![Sprite {
             data: SpriteData {

--- a/examples/bunnymark/example.rs
+++ b/examples/bunnymark/example.rs
@@ -132,7 +132,7 @@ impl Example {
                 texture_data.len(),
             );
         }
-        context.sync_buffer(upload_buffer);
+        context.sync_buffer(upload_buffer, 0, upload_buffer.size());
 
         let sampler = context.create_sampler(gpu::SamplerDesc {
             name: "main",
@@ -157,7 +157,7 @@ impl Example {
                 vertex_data.len(),
             );
         }
-        context.sync_buffer(vertex_buf);
+        context.sync_buffer(vertex_buf, 0, vertex_buf.size());
 
         let bunnies = vec![Sprite {
             data: SpriteData {

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -226,7 +226,7 @@ fn dispatch_gpu_test() {
         let input_data = slice::from_raw_parts_mut(input.data() as *mut u32, 4);
         input_data.copy_from_slice(&[1, 2, 3, 4]);
     }
-    context.sync_buffer(input);
+    context.sync_buffer(input, 0, input.size());
 
     let shader = context.create_shader(gpu::ShaderDesc {
         source: include_str!("shaders/dispatch.wgsl"),

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -226,7 +226,7 @@ fn dispatch_gpu_test() {
         let input_data = slice::from_raw_parts_mut(input.data() as *mut u32, 4);
         input_data.copy_from_slice(&[1, 2, 3, 4]);
     }
-    context.sync_buffer(input, 0, input.size());
+    context.sync_buffer(input);
 
     let shader = context.create_shader(gpu::ShaderDesc {
         source: include_str!("shaders/dispatch.wgsl"),


### PR DESCRIPTION
### Problem
Running Blade on **WebGL2 / wasm** hit spec and browser constraints: the same `WebGLBuffer` cannot be bound as both `ARRAY_BUFFER` and `ELEMENT_ARRAY_BUFFER`; `clientWaitSync` cannot block on the main thread; texture unit / unpack state could produce wrong sampling or extra copies (e.g. Firefox). On **GLES**, integer texture formats and uniform-block reflection needed fixes, plus explicit buffer sync for non-`bufferStorage` paths. **blade-egui** needed a proper vertex layout/fetch path, split vertex/index belts, and deferred texture destruction after submit. **Vulkan** debug utils were assumed present.

### What changed
- **wasm / WebGL2:** split vertex/index `BufferBelt`s with explicit `BufferDesc.bind_point` (no dual-buffer overhead on every buffer); `client_wait_sync` timeout `0` on WebGL (runtime `is_webgl` + `MAX_CLIENT_WAIT_TIMEOUT_WEBGL` query); texture target unbind hygiene; `UNPACK_ROW_LENGTH` only when stride differs from width (restored to 0 after upload); texture units deduplicated when Naga lists the same GLSL sampler name for texture and sampler bindings.
- **GLES:** `R32Uint` uses `RED_INTEGER` external format; uniform blocks resolved via Naga reflection name + WGSL struct type name only (hard error on miss — no `type_N` or single-block guessing); `sync_buffer(buffer, offset, size)` on the trait (replaces GLES-only `sync_buffer_range`); EGL surfaceless init keeps `.unwrap()` as intended.
- **blade-egui:** vertex input layout + fetch; dual fragment entries — `fs_main` outputs linear (default `ColorSpace::Linear` convention), `fs_main_srgb` gamma passthrough for plain UNORM surfaces (selected when swapchain format is `Rgba8Unorm`, e.g. WebGL canvas blit); fragment stage does not read uniform buffers (avoids WebGL link errors); textures-to-free queue + `sync()` after submit.
- **Web canvas:** Blade does **not** resize the embedder's DOM canvas; the application sets `#blade` backing-store pixels before surface reconfigure.
- **Vulkan:** enable and use `VK_EXT_debug_utils` only when the extension exists; guard naming calls.

Rebased onto latest `kvark/main` (includes `manual_barriers` on `CommandEncoderDesc`, Naga update).

### Testing
- [x] `wasm32-unknown-unknown` — Chrome / Firefox WebGL2 (egui + game map/sprites)
- [x] Native Vulkan smoke (Linear swapchain, egui + map color correct)
- [ ] Android GLES (older Mali) — not re-verified in this pass

### Follow-ups for review
- Uniform block lookup: if a driver still fails with named WGSL structs, I will attach a minimal Naga→GLSL repro rather than reintroduce name guessing.