### PR TITLE
Add manual_barriers flag to CommandEncoderDesc

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -107,6 +107,8 @@ impl super::CommandEncoder {
         }
     }
 
+    pub fn barrier(&mut self) {}
+
     fn pass<P>(&mut self, kind: super::PassKind) -> super::PassEncoder<'_, P> {
         super::PassEncoder {
             commands: &mut self.commands,

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -884,6 +884,10 @@ pub struct CommandEncoderDesc<'a> {
     /// For example, one buffer is being run on GPU while the
     /// other is being actively encoded, which makes 2.
     pub buffer_count: u32,
+    /// When set, automatic memory barriers between passes are
+    /// not inserted. The user is responsible for calling
+    /// `barrier()` on the encoder where synchronization is needed.
+    pub manual_barriers: bool,
 }
 
 pub struct ComputePipelineDesc<'a> {

--- a/blade-graphics/src/metal/command.rs
+++ b/blade-graphics/src/metal/command.rs
@@ -191,6 +191,8 @@ impl super::CommandEncoder {
         }
     }
 
+    pub fn barrier(&mut self) {}
+
     pub(super) fn finish(&mut self) -> super::RawCommandBuffer {
         if self.has_open_debug_group {
             self.raw.as_mut().unwrap().popDebugGroup();

--- a/blade-graphics/src/vulkan/command.rs
+++ b/blade-graphics/src/vulkan/command.rs
@@ -327,7 +327,9 @@ impl super::CommandEncoder {
     }
 
     fn begin_pass(&mut self, label: &str) {
-        self.barrier();
+        if !self.manual_barriers {
+            self.barrier();
+        }
         self.add_marker(label);
         self.add_timestamp(label);
 
@@ -366,7 +368,7 @@ impl super::CommandEncoder {
         cmd_buf.raw
     }
 
-    fn barrier(&mut self) {
+    pub fn barrier(&mut self) {
         let wa = &self.device.workarounds;
         let barrier = vk::MemoryBarrier {
             src_access_mask: vk::AccessFlags::MEMORY_WRITE | wa.extra_sync_src_access,

--- a/blade-graphics/src/vulkan/mod.rs
+++ b/blade-graphics/src/vulkan/mod.rs
@@ -442,6 +442,7 @@ pub struct CommandEncoder {
     crash_handler: Option<CrashHandler>,
     temp_label: Vec<u8>,
     timings: crate::Timings,
+    manual_barriers: bool,
 }
 pub struct TransferCommandEncoder<'a> {
     raw: vk::CommandBuffer,
@@ -577,6 +578,7 @@ impl crate::traits::CommandDevice for Context {
             crash_handler,
             temp_label: Vec::new(),
             timings: Default::default(),
+            manual_barriers: desc.manual_barriers,
         }
     }
 

--- a/blade-render/src/util/frame_pacer.rs
+++ b/blade-render/src/util/frame_pacer.rs
@@ -17,6 +17,7 @@ impl FramePacer {
         let encoder = context.create_command_encoder(blade_graphics::CommandEncoderDesc {
             name: "main",
             buffer_count: 2,
+            manual_barriers: false,
         });
         Self {
             frame_index: 0,

--- a/examples-android/xr/xr.rs
+++ b/examples-android/xr/xr.rs
@@ -116,6 +116,7 @@ impl Example {
         let command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
             name: "xr",
             buffer_count: 1,
+            manual_barriers: false,
         });
         let params_buf = context.create_buffer(gpu::BufferDesc {
             name: "xr-params",

--- a/examples/bunnymark/example.rs
+++ b/examples/bunnymark/example.rs
@@ -174,6 +174,7 @@ impl Example {
         let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
             name: "init",
             buffer_count: 1,
+            manual_barriers: false,
         });
         command_encoder.start();
         command_encoder.init_texture(texture);

--- a/examples/bunnymark/main.rs
+++ b/examples/bunnymark/main.rs
@@ -85,6 +85,7 @@ impl winit::application::ApplicationHandler for App {
         let command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
             name: "main",
             buffer_count: 2,
+            manual_barriers: false,
         });
 
         self.example = Some(example);

--- a/examples/matmul/main.rs
+++ b/examples/matmul/main.rs
@@ -142,6 +142,7 @@ fn main() {
     let mut encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
         name: "matmul",
         buffer_count: 1,
+        manual_barriers: false,
     });
     encoder.start();
     {

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -172,6 +172,7 @@ impl Example {
         let command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
             name: "main",
             buffer_count: 2,
+            manual_barriers: false,
         });
 
         Self {

--- a/examples/ray-query/example.rs
+++ b/examples/ray-query/example.rs
@@ -183,6 +183,7 @@ impl Example {
         let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
             name: "init",
             buffer_count: 1,
+            manual_barriers: false,
         });
         command_encoder.start();
         command_encoder.init_texture(target);

--- a/examples/ray-query/main.rs
+++ b/examples/ray-query/main.rs
@@ -58,6 +58,7 @@ impl winit::application::ApplicationHandler for App {
         let command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
             name: "main",
             buffer_count: 2,
+            manual_barriers: false,
         });
 
         self.example = Some(example);

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -242,6 +242,7 @@ fn dispatch_gpu_test() {
     let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
         name: "dispatch-test",
         buffer_count: 1,
+        manual_barriers: false,
     });
     command_encoder.start();
     if let mut compute = command_encoder.compute("dispatch")
@@ -287,6 +288,7 @@ fn env_map_gpu_test() {
     let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
         name: "env-map-test",
         buffer_count: 1,
+        manual_barriers: false,
     });
     command_encoder.start();
 
@@ -359,6 +361,7 @@ fn snapshot_bunnymark() {
     let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
         name: "snapshot-bunnymark",
         buffer_count: 1,
+        manual_barriers: false,
     });
     command_encoder.start();
     command_encoder.init_texture(target.texture);
@@ -417,6 +420,7 @@ fn snapshot_ray_query() {
     let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
         name: "snapshot-ray-query",
         buffer_count: 1,
+        manual_barriers: false,
     });
     command_encoder.start();
     command_encoder.init_texture(target.texture);
@@ -472,6 +476,7 @@ fn snapshot_particle() {
     let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
         name: "snapshot-particle",
         buffer_count: 1,
+        manual_barriers: false,
     });
     command_encoder.start();
     // Run several update cycles to emit and move particles
@@ -613,6 +618,7 @@ fn snapshot_space_sky() {
     let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
         name: "sky-test",
         buffer_count: 1,
+        manual_barriers: false,
     });
     command_encoder.start();
     command_encoder.init_texture(target.texture);


### PR DESCRIPTION
Closes #343

When set, automatic inter-pass memory barriers are skipped on Vulkan. The user calls encoder.barrier() explicitly where synchronization is needed. This allows independent passes to overlap on hardware that supports it (notably AMD RDNA).

https://claude.ai/code/session_01W9jSvpnbXEXmoHFuUVFdUN