### PR TITLE
gles: assign texture units to sampler uniforms on GLSL ES 3.00

### DIFF
--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -337,6 +337,18 @@ impl super::PassEncoder<'_, super::RenderPipeline> {
     ) -> super::PipelineEncoder<'b> {
         self.commands
             .push(super::Command::SetProgram(pipeline.inner.program));
+        self.commands.push(match pipeline.depth_stencil {
+            Some(ref ds) => super::Command::SetDepthState {
+                enabled: true,
+                func: super::map_compare_func(ds.depth_compare),
+                write: ds.depth_write_enabled,
+            },
+            None => super::Command::SetDepthState {
+                enabled: false,
+                func: glow::ALWAYS,
+                write: false,
+            },
+        });
 
         match &pipeline.inner.color_targets[..] {
             &[(blend_state, write_masks)] => self
@@ -1099,14 +1111,23 @@ impl super::Command {
                         );
                     }
                 },
-                Self::ClearDepthStencil { depth, stencil } => match (depth, stencil) {
-                    (Some(d), Some(s)) => {
-                        gl.clear_buffer_depth_stencil(glow::DEPTH_STENCIL, 0, d, s as i32)
+                Self::ClearDepthStencil { depth, stencil } => {
+                    // The depth write mask gates the clear as much as it gates a draw,
+                    // and it's left wherever the last bound pipeline put it. Every
+                    // pipeline bind emits `SetDepthState`, so opening it up here can't
+                    // leak into the draws that follow.
+                    if depth.is_some() {
+                        gl.depth_mask(true);
                     }
-                    (Some(d), None) => gl.clear_buffer_f32_slice(glow::DEPTH, 0, &[d]),
-                    (None, Some(s)) => gl.clear_buffer_i32_slice(glow::STENCIL, 0, &[s as i32]),
-                    (None, None) => (),
-                },
+                    match (depth, stencil) {
+                        (Some(d), Some(s)) => {
+                            gl.clear_buffer_depth_stencil(glow::DEPTH_STENCIL, 0, d, s as i32)
+                        }
+                        (Some(d), None) => gl.clear_buffer_f32_slice(glow::DEPTH, 0, &[d]),
+                        (None, Some(s)) => gl.clear_buffer_i32_slice(glow::STENCIL, 0, &[s as i32]),
+                        (None, None) => (),
+                    }
+                }
                 Self::Barrier => {
                     gl.memory_barrier(
                         glow::SHADER_STORAGE_BARRIER_BIT
@@ -1135,6 +1156,19 @@ impl super::Command {
                 //SetDepth(DepthState),
                 //SetDepthBias(wgt::DepthBiasState),
                 //ConfigureDepthStencil(crate::FormatAspects),
+                Self::SetDepthState {
+                    enabled,
+                    func,
+                    write,
+                } => {
+                    if enabled {
+                        gl.enable(glow::DEPTH_TEST);
+                        gl.depth_func(func);
+                    } else {
+                        gl.disable(glow::DEPTH_TEST);
+                    }
+                    gl.depth_mask(write);
+                }
                 Self::SetProgram(raw_program) => {
                     gl.use_program(Some(raw_program));
                 }

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -144,6 +144,7 @@ impl crate::traits::ComputePipelineBase for ComputePipeline {
 pub struct RenderPipeline {
     inner: PipelineInner,
     topology: crate::PrimitiveTopology,
+    depth_stencil: Option<crate::DepthStencilState>,
 }
 
 #[derive(Debug)]
@@ -321,6 +322,15 @@ enum Command {
     //SetDepthBias(wgt::DepthBiasState),
     //ConfigureDepthStencil(crate::FormatAspects),
     SetProgram(glow::Program),
+    // Depth state travels with the pipeline bind: the pipeline descriptor's
+    // DepthStencilState was previously ignored by this backend entirely,
+    // which left GL_DEPTH_TEST off and made draw order decide visibility.
+    // Stencil and bias are still not implemented.
+    SetDepthState {
+        enabled: bool,
+        func: u32,
+        write: bool,
+    },
     UnsetProgram,
     //SetPrimitive(PrimitiveState),
     SetBlendConstant([f32; 4]),

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -1,5 +1,6 @@
 use glow::HasContext as _;
 use naga::back::glsl;
+use std::collections::HashMap;
 
 fn separate<T: PartialEq>(mut iter: impl Iterator<Item = T>) -> bool {
     if let Some(first) = iter.next() {
@@ -208,6 +209,14 @@ impl super::Context {
             if !force_explicit_bindings {
                 let force_uniform_block_assignment = true;
                 let mut variables_to_bind = Vec::new();
+                // GLSL ES 3.00 (WebGL2) cannot carry explicit sampler
+                // bindings, and freshly linked programs leave every sampler
+                // uniform at texture unit 0 — so multiple textures in one
+                // pipeline would all collide there. Assign sequential units
+                // here instead, sharing the unit between the texture and
+                // sampler halves of each combined GLSL sampler.
+                let mut assigned_units = HashMap::<&str, u32>::new();
+                let mut next_texture_unit = 0u32;
                 for (sf, baked_shader) in shaders.iter().zip(baked_shaders.iter()) {
                     let reflection = &baked_shader.1;
                     for (glsl_name, mapping) in reflection.texture_mapping.iter() {
@@ -243,9 +252,17 @@ impl super::Context {
                                 if let Some(ref location) =
                                     gl.get_uniform_location(program, glsl_name)
                                 {
-                                    let mut slots = [0i32];
-                                    gl.get_uniform_i32(program, location, &mut slots);
-                                    targets.push(slots[0] as u32);
+                                    let unit = match assigned_units.get(glsl_name.as_str()) {
+                                        Some(&unit) => unit,
+                                        None => {
+                                            let unit = next_texture_unit;
+                                            next_texture_unit += 1;
+                                            gl.uniform_1_i32(Some(location), unit as i32);
+                                            assigned_units.insert(glsl_name, unit);
+                                            unit
+                                        }
+                                    };
+                                    targets.push(unit);
                                 }
                             }
                             crate::ShaderBinding::Buffer => {

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -412,6 +412,7 @@ impl crate::traits::ShaderDevice for super::Context {
         super::RenderPipeline {
             inner,
             topology: desc.primitive.topology,
+            depth_stencil: desc.depth_stencil.clone(),
         }
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@ Changelog for *Blade* project
 - tests: validate the renderer shaders, snapshot the PBR material grid in both of the render paths
 - vk: support `VK_EXT_external_memory_host` — enable the extension, query memory-type compatibility via `vkGetMemoryHostPointerPropertiesEXT`, and round allocation size to `minImportedHostPointerAlignment` so `Memory::External(HostAllocation)` imports succeed on drivers that expose the extension
 - gles: assign texture units to sampler uniforms where GLSL ES 3.00 can't carry explicit bindings, so multi-texture pipelines don't collide on unit 0 in WebGL2
+- gles: apply `RenderPipelineDesc::depth_stencil`, which the backend previously ignored, leaving draw order to decide visibility
 
 ## blade-egui-0.8.2, blade-util-0.4.1 (25 Apr 2026)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,7 @@ Changelog for *Blade* project
 - fix `fill-gbuf.wgsl` missing the `wgpu_binding_array` enable directive
 - tests: validate the renderer shaders, snapshot the PBR material grid in both of the render paths
 - vk: support `VK_EXT_external_memory_host` — enable the extension, query memory-type compatibility via `vkGetMemoryHostPointerPropertiesEXT`, and round allocation size to `minImportedHostPointerAlignment` so `Memory::External(HostAllocation)` imports succeed on drivers that expose the extension
+- gles: assign texture units to sampler uniforms where GLSL ES 3.00 can't carry explicit bindings, so multi-texture pipelines don't collide on unit 0 in WebGL2
 
 ## blade-egui-0.8.2, blade-util-0.4.1 (25 Apr 2026)
 

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -1539,6 +1539,20 @@ fn gltf_material_test() {
 }
 
 // --- Render pipeline state tests ---
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+struct QuadParams {
+    color: [f32; 4],
+    depth: f32,
+    pad: [f32; 3],
+}
+
+#[derive(blade_macros::ShaderData)]
+struct QuadData {
+    quad_params: QuadParams,
+}
+
 #[derive(blade_macros::ShaderData)]
 struct SplitData {
     left_texture: gpu::TextureView,
@@ -1600,6 +1614,132 @@ fn make_solid_texture(
         transfer.copy_buffer_to_texture(stage.at(0), 4, texture.into(), size);
     }
     (texture, view, stage)
+}
+
+/// Draw a near quad and then a far one, and check the near one survives.
+///
+/// Draw order alone would put the far quad on top, so a backend that drops
+/// `RenderPipelineDesc::depth_stencil` renders this inside out.
+#[test]
+#[ignore = "requires a working GPU context"]
+fn depth_state_gpu_test() {
+    let context = unsafe { gpu::Context::init(gpu::ContextDesc::default()).unwrap() };
+    let format = gpu::TextureFormat::Rgba8Unorm;
+    let target = snapshot::OffscreenTarget::new(&context, STATE_TEST_SIZE, format);
+
+    let depth_texture = context.create_texture(gpu::TextureDesc {
+        name: "depth-state/depth",
+        format: gpu::TextureFormat::Depth32Float,
+        size: STATE_TEST_SIZE,
+        dimension: gpu::TextureDimension::D2,
+        array_layer_count: 1,
+        mip_level_count: 1,
+        usage: gpu::TextureUsage::TARGET,
+        sample_count: 1,
+        external: None,
+    });
+    let depth_view = context.create_texture_view(
+        depth_texture,
+        gpu::TextureViewDesc {
+            name: "depth-state/depth",
+            format: gpu::TextureFormat::Depth32Float,
+            dimension: gpu::ViewDimension::D2,
+            subresources: &Default::default(),
+        },
+    );
+
+    let shader = context.create_shader(gpu::ShaderDesc {
+        source: include_str!("shaders/pipeline_state.wgsl"),
+        naga_module: None,
+    });
+    let quad_layout = <QuadData as gpu::ShaderData>::layout();
+    let mut pipeline = context.create_render_pipeline(gpu::RenderPipelineDesc {
+        name: "depth-state",
+        data_layouts: &[&quad_layout],
+        vertex: shader.at("quad_vs"),
+        vertex_fetches: &[],
+        primitive: gpu::PrimitiveState {
+            topology: gpu::PrimitiveTopology::TriangleList,
+            ..Default::default()
+        },
+        depth_stencil: Some(gpu::DepthStencilState {
+            format: gpu::TextureFormat::Depth32Float,
+            depth_write_enabled: true,
+            depth_compare: gpu::CompareFunction::Less,
+            stencil: gpu::StencilState::default(),
+            bias: gpu::DepthBiasState::default(),
+        }),
+        fragment: Some(shader.at("quad_fs")),
+        color_targets: &[format.into()],
+        multisample_state: gpu::MultisampleState::default(),
+    });
+
+    let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
+        name: "depth-state",
+        buffer_count: 1,
+        manual_barriers: false,
+    });
+    command_encoder.start();
+    command_encoder.init_texture(target.texture);
+    command_encoder.init_texture(depth_texture);
+
+    if let mut pass = command_encoder.render(
+        "depth-state",
+        gpu::RenderTargetSet {
+            colors: &[gpu::RenderTarget {
+                view: target.view,
+                init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
+                finish_op: gpu::FinishOp::Store,
+            }],
+            depth_stencil: Some(gpu::RenderTarget {
+                view: depth_view,
+                init_op: gpu::InitOp::Clear(gpu::TextureColor::White),
+                finish_op: gpu::FinishOp::Discard,
+            }),
+        },
+    ) && let mut pc = pass.with(&pipeline)
+    {
+        // near, and green
+        pc.bind(
+            0,
+            &QuadData {
+                quad_params: QuadParams {
+                    color: [0.0, 1.0, 0.0, 1.0],
+                    depth: 0.25,
+                    pad: [0.0; 3],
+                },
+            },
+        );
+        pc.draw(0, 3, 0, 1);
+        // far, and red: covers the same pixels, and has to lose all of them
+        pc.bind(
+            0,
+            &QuadData {
+                quad_params: QuadParams {
+                    color: [1.0, 0.0, 0.0, 1.0],
+                    depth: 0.75,
+                    pad: [0.0; 3],
+                },
+            },
+        );
+        pc.draw(0, 3, 0, 1);
+    }
+
+    let pixels = target.read_pixels(&context, &mut command_encoder);
+    for (i, texel) in pixels.chunks(4).enumerate() {
+        assert!(
+            texel[1] > 200 && texel[0] < 50,
+            "texel {} is {:?}, so the far quad won the depth test",
+            i,
+            texel
+        );
+    }
+
+    context.destroy_render_pipeline(&mut pipeline);
+    context.destroy_texture_view(depth_view);
+    context.destroy_texture(depth_texture);
+    context.destroy_command_encoder(&mut command_encoder);
+    target.destroy(&context);
 }
 
 /// Bind two textures to one pipeline and check they land in different slots.

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -1537,3 +1537,181 @@ fn gltf_material_test() {
     context.destroy_command_encoder(&mut command_encoder);
     harness.destroy();
 }
+
+// --- Render pipeline state tests ---
+#[derive(blade_macros::ShaderData)]
+struct SplitData {
+    left_texture: gpu::TextureView,
+    right_texture: gpu::TextureView,
+    samp: gpu::Sampler,
+}
+
+const STATE_TEST_SIZE: gpu::Extent = gpu::Extent {
+    width: 16,
+    height: 16,
+    depth: 1,
+};
+
+/// Upload a 1x1 texture of the given color, for a binding that only has to be
+/// told apart from another one.
+fn make_solid_texture(
+    name: &'static str,
+    color: [u8; 4],
+    encoder: &mut gpu::CommandEncoder,
+    context: &gpu::Context,
+) -> (gpu::Texture, gpu::TextureView, gpu::Buffer) {
+    let format = gpu::TextureFormat::Rgba8Unorm;
+    let size = gpu::Extent {
+        width: 1,
+        height: 1,
+        depth: 1,
+    };
+    let texture = context.create_texture(gpu::TextureDesc {
+        name,
+        format,
+        size,
+        dimension: gpu::TextureDimension::D2,
+        array_layer_count: 1,
+        mip_level_count: 1,
+        usage: gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE,
+        sample_count: 1,
+        external: None,
+    });
+    let view = context.create_texture_view(
+        texture,
+        gpu::TextureViewDesc {
+            name,
+            format,
+            dimension: gpu::ViewDimension::D2,
+            subresources: &Default::default(),
+        },
+    );
+    let stage = context.create_buffer(gpu::BufferDesc {
+        name,
+        size: 4,
+        memory: gpu::Memory::Upload,
+    });
+    unsafe {
+        std::ptr::copy_nonoverlapping(color.as_ptr(), stage.data(), 4);
+    }
+
+    encoder.init_texture(texture);
+    if let mut transfer = encoder.transfer(name) {
+        transfer.copy_buffer_to_texture(stage.at(0), 4, texture.into(), size);
+    }
+    (texture, view, stage)
+}
+
+/// Bind two textures to one pipeline and check they land in different slots.
+///
+/// A backend that leaves them sharing a slot shows whichever was bound last on
+/// both halves of the screen, which no single-texture pipeline would reveal.
+///
+/// Which of the GLES binding paths this takes is the driver's call: the slots
+/// come from the shader's explicit bindings where `GL_EXT_buffer_storage` is
+/// available, and are assigned by hand where it isn't. A desktop driver has the
+/// extension, so covering the hand-assigned path — the one WebGL2 always takes
+/// — means running this on a context that lacks it.
+#[test]
+#[ignore = "requires a working GPU context"]
+fn multi_texture_gpu_test() {
+    let context = unsafe { gpu::Context::init(gpu::ContextDesc::default()).unwrap() };
+    let format = gpu::TextureFormat::Rgba8Unorm;
+    let target = snapshot::OffscreenTarget::new(&context, STATE_TEST_SIZE, format);
+
+    let shader = context.create_shader(gpu::ShaderDesc {
+        source: include_str!("shaders/pipeline_state.wgsl"),
+        naga_module: None,
+    });
+    let split_layout = <SplitData as gpu::ShaderData>::layout();
+    let mut pipeline = context.create_render_pipeline(gpu::RenderPipelineDesc {
+        name: "multi-texture",
+        data_layouts: &[&split_layout],
+        vertex: shader.at("split_vs"),
+        vertex_fetches: &[],
+        primitive: gpu::PrimitiveState {
+            topology: gpu::PrimitiveTopology::TriangleList,
+            ..Default::default()
+        },
+        depth_stencil: None,
+        fragment: Some(shader.at("split_fs")),
+        color_targets: &[format.into()],
+        multisample_state: gpu::MultisampleState::default(),
+    });
+    let sampler = context.create_sampler(gpu::SamplerDesc {
+        name: "multi-texture",
+        ..Default::default()
+    });
+
+    let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {
+        name: "multi-texture",
+        buffer_count: 1,
+        manual_barriers: false,
+    });
+    command_encoder.start();
+    command_encoder.init_texture(target.texture);
+
+    let (left_texture, left_view, left_stage) = make_solid_texture(
+        "multi-texture/left",
+        [0, 255, 0, 255],
+        &mut command_encoder,
+        &context,
+    );
+    let (right_texture, right_view, right_stage) = make_solid_texture(
+        "multi-texture/right",
+        [0, 0, 255, 255],
+        &mut command_encoder,
+        &context,
+    );
+
+    if let mut pass = command_encoder.render(
+        "multi-texture",
+        gpu::RenderTargetSet {
+            colors: &[gpu::RenderTarget {
+                view: target.view,
+                init_op: gpu::InitOp::Clear(gpu::TextureColor::OpaqueBlack),
+                finish_op: gpu::FinishOp::Store,
+            }],
+            depth_stencil: None,
+        },
+    ) && let mut pc = pass.with(&pipeline)
+    {
+        pc.bind(
+            0,
+            &SplitData {
+                left_texture: left_view,
+                right_texture: right_view,
+                samp: sampler,
+            },
+        );
+        pc.draw(0, 3, 0, 1);
+    }
+
+    let pixels = target.read_pixels(&context, &mut command_encoder);
+    let width = STATE_TEST_SIZE.width as usize;
+    for (i, texel) in pixels.chunks(4).enumerate() {
+        let (channel, name) = if i % width < width / 2 {
+            (1, "green")
+        } else {
+            (2, "blue")
+        };
+        assert!(
+            texel[channel] > 200,
+            "texel {} is {:?}, expected {}: the two textures share a slot",
+            i,
+            texel,
+            name
+        );
+    }
+
+    context.destroy_sampler(sampler);
+    context.destroy_render_pipeline(&mut pipeline);
+    context.destroy_buffer(left_stage);
+    context.destroy_buffer(right_stage);
+    context.destroy_texture_view(left_view);
+    context.destroy_texture(left_texture);
+    context.destroy_texture_view(right_view);
+    context.destroy_texture(right_texture);
+    context.destroy_command_encoder(&mut command_encoder);
+    target.destroy(&context);
+}

--- a/tests/shaders/pipeline_state.wgsl
+++ b/tests/shaders/pipeline_state.wgsl
@@ -1,0 +1,31 @@
+// Fixed-function and binding state that a render pipeline carries, checked
+// with the least shading a backend can get away with, so that a failure points
+// at the state rather than at the pixels.
+
+var left_texture: texture_2d<f32>;
+var right_texture: texture_2d<f32>;
+var samp: sampler;
+
+struct SplitOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn split_vs(@builtin(vertex_index) vi: u32) -> SplitOutput {
+    let uv = vec2<f32>(2.0 * f32(vi & 1u), 2.0 * f32(vi >> 1u));
+    var so: SplitOutput;
+    so.position = vec4<f32>(2.0 * uv - 1.0, 0.0, 1.0);
+    so.uv = uv;
+    return so;
+}
+
+// One texture on each half of the screen. Both are sampled unconditionally:
+// two textures that ended up sharing a slot still produce a plausible looking
+// image, just the same one twice, so the halves have to be compared.
+@fragment
+fn split_fs(so: SplitOutput) -> @location(0) vec4<f32> {
+    let left = textureSampleLevel(left_texture, samp, vec2<f32>(0.5), 0.0);
+    let right = textureSampleLevel(right_texture, samp, vec2<f32>(0.5), 0.0);
+    return select(left, right, so.uv.x >= 0.5);
+}

--- a/tests/shaders/pipeline_state.wgsl
+++ b/tests/shaders/pipeline_state.wgsl
@@ -2,6 +2,25 @@
 // with the least shading a backend can get away with, so that a failure points
 // at the state rather than at the pixels.
 
+struct QuadParams {
+    color: vec4<f32>,
+    depth: f32,
+}
+var<uniform> quad_params: QuadParams;
+
+// A full-screen triangle at a depth the host picks, in a color the host picks.
+@vertex
+fn quad_vs(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
+    let x = 4.0 * f32(vi & 1u) - 1.0;
+    let y = 4.0 * f32(vi >> 1u) - 1.0;
+    return vec4<f32>(x, y, quad_params.depth, 1.0);
+}
+
+@fragment
+fn quad_fs() -> @location(0) vec4<f32> {
+    return quad_params.color;
+}
+
 var left_texture: texture_2d<f32>;
 var right_texture: texture_2d<f32>;
 var samp: sampler;


### PR DESCRIPTION
Where the driver has no `GL_EXT_buffer_storage`, the backend drops to GLSL ES
3.00, which cannot carry an explicit binding on a sampler uniform. The slots
were read back after linking instead - but a freshly linked program leaves
every sampler uniform at texture unit 0, and nothing ever assigned them
anything else. So every texture in a pipeline collided on unit 0, and the last
bind won for all of them.

They are now assigned sequentially with `glUniform1i`, with the texture and the
sampler halves of a combined GLSL sampler sharing a unit, which is what the
mapping already assumed.

A single texture is all it takes to hide this, since the collision is with
another texture and the value it lands on is the right one anyway. Everything
that runs this path today is WebGL2, where it showed up while bringing
vandals-and-heroes up on the web: a GL trace had every texture on TEXTURE0.

`multi_texture_gpu_test` puts a different color in each half of the screen from
a different texture, since two textures sharing a slot still render an image,
just the same one twice. Which path a context takes is the driver's call, and a
desktop driver has the extension, so covering the assignment above means a
context without it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W9jSvpnbXEXmoHFuUVFdUN