### PR TITLE
gles: take a BufferTarget in sync_buffer for WebGL2 index buffers

### DIFF
--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -1,5 +1,7 @@
 use glow::HasContext as _;
-use std::{ptr, slice};
+#[cfg(not(target_arch = "wasm32"))]
+use std::ptr;
+use std::slice;
 
 impl super::Context {
     pub fn get_bottom_level_acceleration_structure_sizes(
@@ -37,62 +39,80 @@ impl crate::traits::ResourceDevice for super::Context {
         let gl = self.lock();
 
         let raw = unsafe { gl.create_buffer() }.unwrap();
-        let mut data = ptr::null_mut();
 
-        let mut storage_flags = 0;
-        let mut map_flags = 0;
-        let usage = match desc.memory {
-            crate::Memory::Device => glow::STATIC_DRAW,
-            crate::Memory::Shared => {
-                map_flags = glow::MAP_READ_BIT | glow::MAP_WRITE_BIT | glow::MAP_PERSISTENT_BIT;
-                storage_flags = glow::MAP_PERSISTENT_BIT
-                    | glow::MAP_COHERENT_BIT
-                    | glow::MAP_READ_BIT
-                    | glow::MAP_WRITE_BIT;
-                glow::DYNAMIC_DRAW //TEMP
+        // WebGL2 permanently assigns a buffer to either the element-array
+        // class or the general data class on its first bind. Leave the buffer
+        // unbound here; the first `sync_buffer` allocates the storage through
+        // the caller-provided target.
+        #[cfg(target_arch = "wasm32")]
+        let data = {
+            if let crate::Memory::External(_) = desc.memory {
+                unimplemented!()
             }
-            crate::Memory::Download => {
-                map_flags = glow::MAP_READ_BIT | glow::MAP_PERSISTENT_BIT;
-                storage_flags =
-                    glow::MAP_PERSISTENT_BIT | glow::MAP_COHERENT_BIT | glow::MAP_READ_BIT;
-                glow::DYNAMIC_READ
-            }
-            crate::Memory::Upload => {
-                map_flags =
-                    glow::MAP_WRITE_BIT | glow::MAP_PERSISTENT_BIT | glow::MAP_UNSYNCHRONIZED_BIT;
-                storage_flags =
-                    glow::MAP_PERSISTENT_BIT | glow::MAP_COHERENT_BIT | glow::MAP_WRITE_BIT;
-                glow::DYNAMIC_DRAW
-            }
-            crate::Memory::External(_) => unimplemented!(),
+            Vec::leak(vec![0u8; desc.size as usize]).as_mut_ptr()
         };
 
-        unsafe {
-            gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
-            if self
-                .capabilities
-                .contains(super::Capabilities::BUFFER_STORAGE)
-            {
-                gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
-                if map_flags != 0 {
-                    data = gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
-                    assert!(!data.is_null());
+        #[cfg(not(target_arch = "wasm32"))]
+        let data = {
+            let mut data = ptr::null_mut();
+            let mut storage_flags = 0;
+            let mut map_flags = 0;
+            let usage = match desc.memory {
+                crate::Memory::Device => glow::STATIC_DRAW,
+                crate::Memory::Shared => {
+                    map_flags = glow::MAP_READ_BIT | glow::MAP_WRITE_BIT | glow::MAP_PERSISTENT_BIT;
+                    storage_flags = glow::MAP_PERSISTENT_BIT
+                        | glow::MAP_COHERENT_BIT
+                        | glow::MAP_READ_BIT
+                        | glow::MAP_WRITE_BIT;
+                    glow::DYNAMIC_DRAW //TEMP
                 }
-            } else {
-                gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);
-                let data_vec = vec![0; desc.size as usize];
-                data = Vec::leak(data_vec).as_mut_ptr();
+                crate::Memory::Download => {
+                    map_flags = glow::MAP_READ_BIT | glow::MAP_PERSISTENT_BIT;
+                    storage_flags =
+                        glow::MAP_PERSISTENT_BIT | glow::MAP_COHERENT_BIT | glow::MAP_READ_BIT;
+                    glow::DYNAMIC_READ
+                }
+                crate::Memory::Upload => {
+                    map_flags = glow::MAP_WRITE_BIT
+                        | glow::MAP_PERSISTENT_BIT
+                        | glow::MAP_UNSYNCHRONIZED_BIT;
+                    storage_flags =
+                        glow::MAP_PERSISTENT_BIT | glow::MAP_COHERENT_BIT | glow::MAP_WRITE_BIT;
+                    glow::DYNAMIC_DRAW
+                }
+                crate::Memory::External(_) => unimplemented!(),
+            };
+
+            unsafe {
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(raw));
+                if self
+                    .capabilities
+                    .contains(super::Capabilities::BUFFER_STORAGE)
+                {
+                    gl.buffer_storage(glow::ARRAY_BUFFER, desc.size as _, None, storage_flags);
+                    if map_flags != 0 {
+                        data =
+                            gl.map_buffer_range(glow::ARRAY_BUFFER, 0, desc.size as _, map_flags);
+                        assert!(!data.is_null());
+                    }
+                } else {
+                    gl.buffer_data_size(glow::ARRAY_BUFFER, desc.size as _, usage);
+                    let data_vec = vec![0; desc.size as usize];
+                    data = Vec::leak(data_vec).as_mut_ptr();
+                }
+                gl.bind_buffer(glow::ARRAY_BUFFER, None);
+                if !desc.name.is_empty() && gl.supports_debug() {
+                    gl.object_label(
+                        glow::BUFFER,
+                        std::mem::transmute::<glow::NativeBuffer, u32>(raw),
+                        Some(desc.name),
+                    );
+                }
             }
-            gl.bind_buffer(glow::ARRAY_BUFFER, None);
-            #[cfg(not(target_arch = "wasm32"))]
-            if !desc.name.is_empty() && gl.supports_debug() {
-                gl.object_label(
-                    glow::BUFFER,
-                    std::mem::transmute::<glow::NativeBuffer, u32>(raw),
-                    Some(desc.name),
-                );
-            }
-        }
+            data
+        };
+
         super::Buffer {
             raw,
             size: desc.size,
@@ -100,16 +120,25 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, buffer: super::Buffer) {
+    fn sync_buffer(&self, buffer: super::Buffer, target: crate::BufferTarget) {
         if !self
             .capabilities
             .contains(super::Capabilities::BUFFER_STORAGE)
         {
             let gl = self.lock();
+            let raw_target = match target {
+                crate::BufferTarget::Data => glow::ARRAY_BUFFER,
+                crate::BufferTarget::Index => glow::ELEMENT_ARRAY_BUFFER,
+            };
             unsafe {
                 let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer.raw));
-                gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, data);
+                gl.bind_buffer(raw_target, Some(buffer.raw));
+                // On WebGL the storage is allocated here on first sync:
+                // `bufferData` both allocates and uploads (buffer orphaning).
+                #[cfg(target_arch = "wasm32")]
+                gl.buffer_data_u8_slice(raw_target, data, glow::DYNAMIC_DRAW);
+                #[cfg(not(target_arch = "wasm32"))]
+                gl.buffer_sub_data_u8_slice(raw_target, 0, data);
             }
         }
     }

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -355,6 +355,19 @@ pub struct BufferDesc<'a> {
     pub memory: Memory,
 }
 
+/// Binding target hint for [`sync_buffer`](traits::ResourceDevice::sync_buffer).
+///
+/// Only meaningful on the GLES backend under WebGL2, where a buffer is
+/// permanently assigned to either the element-array class or the general
+/// data class by its first bind. Other backends ignore it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BufferTarget {
+    /// Anything other than index data: vertices, uniforms, texels, etc.
+    Data,
+    /// Index data for indexed draws.
+    Index,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct BufferPiece {
     pub buffer: Buffer,

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -203,7 +203,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, _buffer: super::Buffer) {}
+    fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let _ = unsafe { Retained::from_raw(buffer.raw) };

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -8,7 +8,7 @@ pub trait ResourceDevice {
     type AccelerationStructure: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
-    fn sync_buffer(&self, buffer: Self::Buffer);
+    fn sync_buffer(&self, buffer: Self::Buffer, target: super::BufferTarget);
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -428,7 +428,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, _buffer: super::Buffer) {}
+    fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         log::info!(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog for *Blade* project
 
 ## (TBD)
 
+- gles: `sync_buffer` takes a `BufferTarget` argument naming the buffer's
+  binding class (`Data` or `Index`). WebGL2 permanently assigns a buffer to
+  the element-array class or the general data class on its first bind, so the
+  backend now defers all binding to the first sync, where the caller-provided
+  target makes the choice. This makes index buffers work on WebGL2.
+  - breaking: existing callers pass `BufferTarget::Data`.
 - gfx/vk: derive each global pass barrier's pipeline stages and access masks
   from a lightweight encoder-wide summary of the pass kinds recorded since the
   previous barrier. This adds no per-resource state and does not change the

--- a/examples-android/xr/xr.rs
+++ b/examples-android/xr/xr.rs
@@ -197,7 +197,7 @@ impl Example {
                 *(self.params_buf.data().offset(params_offset) as *mut Uniforms) = uniforms;
             }
         }
-        context.sync_buffer(self.params_buf);
+        context.sync_buffer(self.params_buf, gpu::BufferTarget::Data);
 
         for eye in 0..view_count {
             let eye_view = frame.xr_texture_view(eye);

--- a/examples/bunnymark/example.rs
+++ b/examples/bunnymark/example.rs
@@ -132,7 +132,7 @@ impl Example {
                 texture_data.len(),
             );
         }
-        context.sync_buffer(upload_buffer);
+        context.sync_buffer(upload_buffer, gpu::BufferTarget::Data);
 
         let sampler = context.create_sampler(gpu::SamplerDesc {
             name: "main",
@@ -157,7 +157,7 @@ impl Example {
                 vertex_data.len(),
             );
         }
-        context.sync_buffer(vertex_buf);
+        context.sync_buffer(vertex_buf, gpu::BufferTarget::Data);
 
         let bunnies = vec![Sprite {
             data: SpriteData {

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -230,7 +230,7 @@ fn run_dispatch_gpu_test(manual_barriers: bool) {
         let input_data = slice::from_raw_parts_mut(input.data() as *mut u32, 4);
         input_data.copy_from_slice(&[1, 2, 3, 4]);
     }
-    context.sync_buffer(input);
+    context.sync_buffer(input, gpu::BufferTarget::Data);
 
     let shader = context.create_shader(gpu::ShaderDesc {
         source: include_str!("shaders/dispatch.wgsl"),


### PR DESCRIPTION
WebGL2 permanently assigns a buffer to either the element-array class or the general data class on its first bind, and the backend used ARRAY_BUFFER for all buffer manipulation - making every buffer incompatible with ELEMENT_ARRAY_BUFFER and breaking indexed draws on the web.

Since WebGL2 fences off every GPU write path to index buffers (that is the restriction's stated purpose), index data always arrives through sync_buffer. So that call is the guaranteed and last responsible moment to pick the class: sync_buffer now takes a BufferTarget (Data | Index) naming the bind target, keeping the backend stateless. On wasm, create_buffer no longer binds at creation (which would prematurely class the buffer); the first sync allocates the storage via bufferData through the caller-provided target.

Native paths are unchanged aside from the new ignored parameter.

https://claude.ai/code/session_01W9jSvpnbXEXmoHFuUVFdUN