### PR TITLE
Enable raster engine on WASM/WebGL

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -185,9 +185,12 @@ jobs:
       - name: Install ANGLE (Windows)
         if: matrix.name == 'Windows'
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          ANGLE_URL=$(curl -s https://api.github.com/repos/mmozeiko/build-angle/releases/latest \
-            | python -c "import sys,json; assets=json.load(sys.stdin)['assets']; print([a['browser_download_url'] for a in assets if 'x64' in a['name']][0])")
+          ANGLE_URL=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/mmozeiko/build-angle/releases/latest \
+            | python -c "import sys,json; d=json.load(sys.stdin); assets=d['assets']; print([a['browser_download_url'] for a in assets if 'x64' in a['name']][0])")
           curl -L -o angle.zip "$ANGLE_URL"
           7z x angle.zip -oangle
           cp angle/angle-*/bin/*.dll .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ num_cpus = { workspace = true }
 glam = { workspace = true }
 log = { workspace = true }
 mint = { workspace = true, features = ["serde"] }
-naga = { workspace = true }
+naga = { workspace = true, features = ["glsl-out"] }
 nanorand = { version = "0.7", default-features = false, features = ["wyrand"] }
 png = "0.18"
 profiling = { workspace = true }

--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
 
 mod arena;
 mod flat;
+pub mod vfs;
 
 pub use flat::{Flat, round_up};
 
@@ -174,6 +175,10 @@ impl<B: Baker> Cooker<B> {
         let mut inner = self.inner.lock().unwrap();
         inner.dependencies.push(relative_path.to_path_buf());
         let full_path = self.base_path.join(relative_path);
+        if let Some(buf) = vfs::read(&full_path) {
+            buf.hash(&mut inner.hasher);
+            return buf;
+        }
         match fs::File::open(&full_path) {
             Ok(mut file) => {
                 // Read the file at the same time as we include the hash
@@ -299,6 +304,7 @@ fn check_target_relevancy(
 /// and scheduling tasks for cooking and serving assets.
 pub struct AssetManager<B: Baker> {
     target: PathBuf,
+    cache_enabled: bool,
     slots: arena::Arena<Slot<B::Output>>,
     #[allow(clippy::type_complexity)]
     paths: Mutex<HashMap<(PathBuf, B::Meta), Handle<B::Output>>>,
@@ -321,12 +327,22 @@ impl<B: Baker> AssetManager<B> {
     ///
     /// The `target` points to the folder to store cooked assets in.
     pub fn new(target: &Path, choir: &Arc<choir::Choir>, baker: B) -> Self {
-        if !target.is_dir() {
+        let cache_enabled = target.is_dir() || {
             log::info!("Creating target {}", target.display());
-            fs::create_dir_all(target).unwrap();
-        }
+            match fs::create_dir_all(target) {
+                Ok(()) => true,
+                Err(error) => {
+                    log::info!(
+                        "Cooked asset cache is unavailable at {}: {error}",
+                        target.display()
+                    );
+                    false
+                }
+            }
+        };
         Self {
             target: target.to_path_buf(),
+            cache_enabled,
             slots: arena::Arena::new(64),
             paths: Mutex::default(),
             choir: Arc::clone(choir),
@@ -357,8 +373,6 @@ impl<B: Baker> AssetManager<B> {
         file_name: &Path,
         content: Option<&[u8]>,
     ) -> Option<(u32, &'a choir::RunningTask)> {
-        use std::{hash::Hasher as _, io::Write as _};
-
         let version = slot.version + 1;
         let (task_option, meta, data_ref) = (
             &mut slot.load_task,
@@ -375,10 +389,14 @@ impl<B: Baker> AssetManager<B> {
         let content = content.map(Vec::from);
         let mut hasher = DefaultHasher::new();
         TypeId::of::<B::Data<'static>>().hash(&mut hasher);
+        let cache_enabled = self.cache_enabled;
 
-        let load_task = if let Err(reason) =
+        let cache_status = if cache_enabled {
             check_target_relevancy(&target_path, &slot.base_path, hasher.clone())
-        {
+        } else {
+            Err(CookReason::NoTarget)
+        };
+        let load_task = if let Err(reason) = cache_status {
             log::info!(
                 "Cooking {:?}: {} version={}",
                 reason,
@@ -394,27 +412,30 @@ impl<B: Baker> AssetManager<B> {
                 .init(move |exe_context| {
                     let mut inner = cooker.inner.lock().unwrap();
                     assert!(!inner.result.is_empty());
-                    let mut file = fs::File::create(&target_path).unwrap_or_else(|e| {
-                        panic!("Unable to create {}: {}", target_path.display(), e)
-                    });
-                    file.write_all(&[0; 8]).unwrap(); // write zero hash first
-                    file.write_all(&[0; 8]).unwrap(); // write zero data offset
-                    // write down the dependencies
-                    file.write_all(&inner.dependencies.len().to_le_bytes())
-                        .unwrap();
-                    for dep in inner.dependencies.iter() {
-                        let dep_bytes = dep.to_str().unwrap().as_bytes();
-                        file.write_all(&dep_bytes.len().to_le_bytes()).unwrap();
-                        file.write_all(dep_bytes).unwrap();
+                    if cache_enabled {
+                        use std::{hash::Hasher as _, io::Write as _};
+                        let mut file = fs::File::create(&target_path).unwrap_or_else(|e| {
+                            panic!("Unable to create {}: {}", target_path.display(), e)
+                        });
+                        file.write_all(&[0; 8]).unwrap(); // write zero hash first
+                        file.write_all(&[0; 8]).unwrap(); // write zero data offset
+                        // write down the dependencies
+                        file.write_all(&inner.dependencies.len().to_le_bytes())
+                            .unwrap();
+                        for dep in inner.dependencies.iter() {
+                            let dep_bytes = dep.to_str().unwrap().as_bytes();
+                            file.write_all(&dep_bytes.len().to_le_bytes()).unwrap();
+                            file.write_all(dep_bytes).unwrap();
+                        }
+                        let data_offset = file.stream_position().unwrap();
+                        file.write_all(&inner.result).unwrap();
+                        // Write the real hash last, so that the cached file is not valid
+                        // unless everything went smooth.
+                        file.seek(SeekFrom::Start(0)).unwrap();
+                        let hash = inner.hasher.finish();
+                        file.write_all(&hash.to_le_bytes()).unwrap();
+                        file.write_all(&data_offset.to_le_bytes()).unwrap();
                     }
-                    let data_offset = file.stream_position().unwrap();
-                    file.write_all(&inner.result).unwrap();
-                    // Write the real hash last, so that the cached file is not valid
-                    // unless everything went smooth.
-                    file.seek(SeekFrom::Start(0)).unwrap();
-                    let hash = inner.hasher.finish();
-                    file.write_all(&hash.to_le_bytes()).unwrap();
-                    file.write_all(&data_offset.to_le_bytes()).unwrap();
 
                     let dr = data_ref;
                     if let Some(data) = unsafe { (*dr.data).take() } {

--- a/blade-asset/src/vfs.rs
+++ b/blade-asset/src/vfs.rs
@@ -1,0 +1,37 @@
+use std::{
+    collections::HashMap,
+    path::{Component, Path, PathBuf},
+    sync::Mutex,
+};
+
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+static FILES: Mutex<Option<HashMap<PathBuf, Vec<u8>>>> = Mutex::new(None);
+
+/// Mount a file into the in-memory asset VFS.
+///
+/// Used on WASM (no real filesystem) and for generated assets that never
+/// touch disk. Paths are normalized (`foo/./bar` == `foo/bar`).
+pub fn mount(path: impl AsRef<Path>, data: Vec<u8>) {
+    let mut guard = FILES.lock().unwrap();
+    let map = guard.get_or_insert_with(HashMap::new);
+    map.insert(normalize(path.as_ref()), data);
+}
+
+/// Read a previously mounted file. Returns `None` if the path is not in the VFS.
+pub fn read(path: &Path) -> Option<Vec<u8>> {
+    let guard = FILES.lock().unwrap();
+    guard.as_ref()?.get(&normalize(path)).cloned()
+}

--- a/blade-engine/Cargo.toml
+++ b/blade-engine/Cargo.toml
@@ -35,5 +35,8 @@ openxr = { workspace = true }
 [target.'cfg(not(target_os = "android"))'.dependencies]
 winit = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(gles)'] }

--- a/blade-engine/README.md
+++ b/blade-engine/README.md
@@ -8,3 +8,5 @@ High-level engine crate for Blade. It provides the scene/object API, integrates 
 - `Rasterizer`: forward+ rasterization with PBR-style shading.
 
 Select a backend via `blade_engine::config::RenderBackend` when creating the engine.
+If the selected device does not expose ray-query functionality, including on
+WebGL2, the engine falls back to `Rasterizer`.

--- a/blade-engine/src/config.rs
+++ b/blade-engine/src/config.rs
@@ -116,6 +116,15 @@ pub enum RenderBackend {
     Rasterizer,
 }
 
+impl RenderBackend {
+    pub(crate) const fn uses_ray_tracing(self) -> bool {
+        match self {
+            Self::RayTracer => true,
+            Self::Rasterizer => false,
+        }
+    }
+}
+
 fn default_render_backend() -> RenderBackend {
     RenderBackend::RayTracer
 }

--- a/blade-engine/src/lib.rs
+++ b/blade-engine/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(not(any(gles, target_arch = "wasm32")))]
 #![allow(
     irrefutable_let_patterns,
     clippy::new_without_default,
@@ -16,6 +15,8 @@
 
 use blade_graphics as gpu;
 use std::{ops, path::PathBuf, sync::Arc};
+
+pub use blade_asset::vfs;
 
 pub mod config;
 mod trimesh;
@@ -390,6 +391,57 @@ enum Renderer {
     },
 }
 
+impl Renderer {
+    fn destroy(&mut self, gpu: &gpu::Context) {
+        match *self {
+            Self::RayTracer { ref mut inner, .. } => inner.destroy(gpu),
+            Self::Rasterizer { ref mut inner, .. } => inner.destroy(gpu),
+        }
+    }
+
+    fn surface_size(&self) -> gpu::Extent {
+        match *self {
+            Self::RayTracer { ref inner, .. } => inner.get_surface_size(),
+            Self::Rasterizer { ref inner, .. } => inner.get_surface_size(),
+        }
+    }
+
+    fn hot_reload(
+        &mut self,
+        asset_hub: &blade_render::AssetHub,
+        gpu: &gpu::Context,
+        sync_point: &gpu::SyncPoint,
+    ) {
+        match *self {
+            Self::RayTracer { ref mut inner, .. } => {
+                inner.hot_reload(asset_hub, gpu, sync_point);
+            }
+            Self::Rasterizer { ref mut inner, .. } => {
+                inner.hot_reload(asset_hub, gpu, sync_point);
+            }
+        }
+    }
+
+    fn resize_screen(
+        &mut self,
+        size: gpu::Extent,
+        encoder: &mut gpu::CommandEncoder,
+        gpu: &gpu::Context,
+    ) {
+        match *self {
+            Self::RayTracer {
+                ref mut inner,
+                ref mut frame_config,
+                ..
+            } => {
+                inner.resize_screen(size, encoder, gpu);
+                frame_config.reset_reservoirs = true;
+            }
+            Self::Rasterizer { ref mut inner, .. } => inner.resize_screen(size, encoder, gpu),
+        }
+    }
+}
+
 pub enum Presentation<'a> {
     #[cfg(not(target_os = "android"))]
     Window(&'a winit::window::Window),
@@ -460,14 +512,8 @@ impl Engine {
             return;
         }
         let sync_point = self.pacer.last_sync_point().unwrap();
-        match self.renderer {
-            Renderer::RayTracer { ref mut inner, .. } => {
-                inner.hot_reload(&self.asset_hub, &self.gpu_context, sync_point);
-            }
-            Renderer::Rasterizer { ref mut inner, .. } => {
-                inner.hot_reload(&self.asset_hub, &self.gpu_context, sync_point);
-            }
-        }
+        self.renderer
+            .hot_reload(&self.asset_hub, &self.gpu_context, sync_point);
     }
 
     fn update_render_objects(
@@ -513,9 +559,16 @@ impl Engine {
         load_tasks: &mut Vec<choir::RunningTask>,
         command_encoder: &mut gpu::CommandEncoder,
         temp: &mut blade_render::FrameResources,
+        run_tasks_inline: bool,
     ) -> bool {
         asset_hub.flush(command_encoder, &mut temp.buffers);
         load_tasks.retain(|task| !task.is_done());
+        if run_tasks_inline {
+            for task in load_tasks.iter() {
+                task.join_active();
+            }
+            load_tasks.retain(|task| !task.is_done());
+        }
         load_tasks.is_empty()
     }
 
@@ -535,15 +588,32 @@ impl Engine {
             #[cfg(target_os = "android")]
             Presentation::__Marker(_) => unreachable!(),
         };
-        let context_desc = gpu::ContextDesc {
+        let mut render_backend = config.render_backend;
+        let mut context_desc = gpu::ContextDesc {
             presentation: xr.is_none(),
             xr,
-            ray_tracing: matches!(config.render_backend, config::RenderBackend::RayTracer),
+            ray_tracing: config.render_backend.uses_ray_tracing(),
             validation: cfg!(debug_assertions),
             timing: true,
             ..Default::default()
         };
-        let gpu_context = Arc::new(unsafe { gpu::Context::init(context_desc).unwrap() });
+        let gpu_context = match unsafe { gpu::Context::init(context_desc.clone()) } {
+            Ok(context) => Arc::new(context),
+            Err(error) if context_desc.ray_tracing => {
+                log::warn!("Unable to initialize ray tracing ({error}); using rasterizer");
+                render_backend = config::RenderBackend::Rasterizer;
+                context_desc.ray_tracing = false;
+                Arc::new(unsafe { gpu::Context::init(context_desc).unwrap() })
+            }
+            Err(error) => panic!("Unable to initialize graphics: {error}"),
+        };
+        render_backend = match render_backend {
+            config::RenderBackend::RayTracer if gpu_context.capabilities().ray_query.is_empty() => {
+                log::warn!("Ray tracing is not supported on this GPU; using rasterizer");
+                config::RenderBackend::Rasterizer
+            }
+            backend => backend,
+        };
 
         // Note: the color space we ask the surface for is also the one
         // the renderers have to produce, see `RenderConfig`.
@@ -591,23 +661,35 @@ impl Engine {
             Presentation::__Marker(_) => unreachable!(),
         };
 
-        let num_workers = num_cpus::get_physical().max((num_cpus::get() * 3 + 2) / 4);
-        log::info!("Initializing Choir with {} workers", num_workers);
         let choir = choir::Choir::new();
-        let workers = (0..num_workers)
-            .map(|i| choir.add_worker(&format!("Worker-{}", i)))
-            .collect();
+        #[cfg(not(any(gles, target_arch = "wasm32")))]
+        let workers = {
+            let num_workers = num_cpus::get_physical().max((num_cpus::get() * 3 + 2) / 4);
+            log::info!("Initializing Choir with {} workers", num_workers);
+            (0..num_workers)
+                .map(|i| choir.add_worker(&format!("Worker-{i}")))
+                .collect::<Vec<_>>()
+        };
+        #[cfg(any(gles, target_arch = "wasm32"))]
+        let workers = {
+            log::info!("Choir tasks will run on the graphics context's owning thread");
+            Vec::new()
+        };
 
         let asset_cache_path = Self::asset_cache_path(config);
         let asset_hub = blade_render::AssetHub::new(&asset_cache_path, &choir, &gpu_context);
         let (shaders, shader_task) = blade_render::Shaders::load(
             config.shader_path.as_ref(),
             &asset_hub,
-            matches!(config.render_backend, config::RenderBackend::RayTracer),
+            render_backend.uses_ray_tracing(),
         );
 
         log::info!("Spinning up the renderer");
-        shader_task.join();
+        if workers.is_empty() {
+            shader_task.join_active();
+        } else {
+            shader_task.join();
+        }
         let mut pacer = blade_render::util::FramePacer::new(&gpu_context);
         let (command_encoder, _) = pacer.begin_frame();
 
@@ -617,7 +699,7 @@ impl Engine {
             color_space,
             max_debug_lines: 1 << 14,
         };
-        let renderer = match config.render_backend {
+        let renderer = match render_backend {
             config::RenderBackend::RayTracer => Renderer::RayTracer {
                 inner: blade_render::RayTracer::new(
                     command_encoder,
@@ -715,14 +797,7 @@ impl Engine {
                 self.gpu_context.destroy_xr_surface(xr_surface);
             }
         }
-        match self.renderer {
-            Renderer::RayTracer { ref mut inner, .. } => {
-                inner.destroy(&self.gpu_context);
-            }
-            Renderer::Rasterizer { ref mut inner, .. } => {
-                inner.destroy(&self.gpu_context);
-            }
-        }
+        self.renderer.destroy(&self.gpu_context);
         for mut ps in self.particle_systems.drain() {
             ps.destroy(&self.gpu_context);
         }
@@ -826,10 +901,7 @@ impl Engine {
         // wants to borrow `self` mutably, and `command_encoder` blocks that.
         let surface_config = Self::make_surface_config(physical_size);
         let new_render_size = surface_config.size;
-        let current_render_size = match self.renderer {
-            Renderer::RayTracer { ref inner, .. } => inner.get_surface_size(),
-            Renderer::Rasterizer { ref inner, .. } => inner.get_surface_size(),
-        };
+        let current_render_size = self.renderer.surface_size();
         if new_render_size != current_render_size {
             log::info!("Resizing to {}", new_render_size);
             self.pacer.wait_for_previous_frame(&self.gpu_context);
@@ -845,19 +917,8 @@ impl Engine {
 
         let (command_encoder, temp) = self.pacer.begin_frame();
         if new_render_size != current_render_size {
-            match self.renderer {
-                Renderer::RayTracer {
-                    ref mut inner,
-                    ref mut frame_config,
-                    ..
-                } => {
-                    inner.resize_screen(new_render_size, command_encoder, &self.gpu_context);
-                    frame_config.reset_reservoirs = true;
-                }
-                Renderer::Rasterizer { ref mut inner, .. } => {
-                    inner.resize_screen(new_render_size, command_encoder, &self.gpu_context);
-                }
-            }
+            self.renderer
+                .resize_screen(new_render_size, command_encoder, &self.gpu_context);
         }
         if let Renderer::RayTracer {
             ref mut frame_config,
@@ -874,6 +935,7 @@ impl Engine {
             &mut self.load_tasks,
             command_encoder,
             temp,
+            self.workers.is_empty(),
         );
 
         // We should be able to update TLAS and render content
@@ -1115,18 +1177,14 @@ impl Engine {
         let view_count = frame.xr_view_count() as usize;
 
         let (command_encoder, temp) = self.pacer.begin_frame();
-        match self.renderer {
-            Renderer::RayTracer {
-                ref mut inner,
-                ref mut frame_config,
-                ..
-            } => {
-                inner.resize_screen(target_size, command_encoder, &self.gpu_context);
-                frame_config.reset_variance = self.debug.mouse_pos.is_none();
-            }
-            Renderer::Rasterizer { ref mut inner, .. } => {
-                inner.resize_screen(target_size, command_encoder, &self.gpu_context);
-            }
+        self.renderer
+            .resize_screen(target_size, command_encoder, &self.gpu_context);
+        if let Renderer::RayTracer {
+            ref mut frame_config,
+            ..
+        } = self.renderer
+        {
+            frame_config.reset_variance = self.debug.mouse_pos.is_none();
         }
 
         let can_render = Self::flush_assets_and_check_ready(
@@ -1134,6 +1192,7 @@ impl Engine {
             &mut self.load_tasks,
             command_encoder,
             temp,
+            self.workers.is_empty(),
         );
 
         if can_render {
@@ -1405,6 +1464,10 @@ impl Engine {
         name: &str,
         effect: &blade_particle::ParticleEffect,
     ) -> usize {
+        if !self.gpu_context.capabilities().compute {
+            log::warn!("Particle compute is not available on this graphics device");
+            return usize::MAX;
+        }
         let pipeline = self.particle_pipeline.get_or_insert_with(|| {
             blade_particle::ParticlePipeline::new(
                 &self.gpu_context,
@@ -1422,6 +1485,9 @@ impl Engine {
 
     /// Trigger a burst of particles at a world position.
     pub fn particle_burst(&mut self, handle: usize, count: u32, position: [f32; 3]) {
+        if handle == usize::MAX {
+            return;
+        }
         if let Some(system) = self.particle_systems.get_mut(handle) {
             system.burst(count, position);
         }
@@ -1489,8 +1555,8 @@ impl Engine {
             });
         egui::CollapsingHeader::new("Debug")
             .default_open(true)
-            .show(ui, |ui| {
-                if matches!(&self.renderer, Renderer::RayTracer { .. }) {
+            .show(ui, |ui| match self.renderer {
+                Renderer::RayTracer { .. } => {
                     self.debug.populate_hud(ui);
                     blade_helpers::populate_debug_selection(
                         &mut self.debug.mouse_pos,
@@ -1498,7 +1564,8 @@ impl Engine {
                         &self.asset_hub,
                         ui,
                     );
-                } else {
+                }
+                Renderer::Rasterizer { .. } => {
                     ui.label("Ray-tracing debug views are not available in raster mode.");
                 }
             });
@@ -1635,10 +1702,7 @@ impl Engine {
     }
 
     pub fn screen_aspect(&self) -> f32 {
-        let size = match self.renderer {
-            Renderer::RayTracer { ref inner, .. } => inner.get_surface_size(),
-            Renderer::Rasterizer { ref inner, .. } => inner.get_surface_size(),
-        };
+        let size = self.renderer.surface_size();
         size.width as f32 / size.height.max(1) as f32
     }
 

--- a/blade-engine/src/trimesh.rs
+++ b/blade-engine/src/trimesh.rs
@@ -1,4 +1,4 @@
-use std::unimplemented;
+use std::{path::Path, unimplemented};
 
 #[derive(Default)]
 pub struct TriMesh {
@@ -71,7 +71,11 @@ impl TriMesh {
 pub fn load(path: &str) -> TriMesh {
     use base64::engine::{Engine as _, general_purpose::URL_SAFE as ENCODING_ENGINE};
 
-    let gltf::Gltf { document, mut blob } = gltf::Gltf::open(path).unwrap();
+    let gltf::Gltf { document, mut blob } = if let Some(bytes) = crate::vfs::read(Path::new(path)) {
+        gltf::Gltf::from_slice(&bytes).unwrap()
+    } else {
+        gltf::Gltf::open(path).unwrap()
+    };
     // extract buffers
     let mut data_buffers = Vec::new();
     for buffer in document.buffers() {

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -464,6 +464,33 @@ impl crate::traits::TransferEncoder for super::PassEncoder<'_, ()> {
 }
 
 #[hidden_trait::expose]
+impl crate::traits::AccelerationStructureEncoder for super::PassEncoder<'_, ()> {
+    type AccelerationStructure = super::AccelerationStructure;
+    type AccelerationStructureMesh = crate::AccelerationStructureMesh;
+    type BufferPiece = crate::BufferPiece;
+
+    fn build_bottom_level(
+        &mut self,
+        _acceleration_structure: super::AccelerationStructure,
+        _meshes: &[crate::AccelerationStructureMesh],
+        _scratch_data: crate::BufferPiece,
+    ) {
+        unimplemented!("acceleration structures are not available on GLES")
+    }
+
+    fn build_top_level(
+        &mut self,
+        _acceleration_structure: super::AccelerationStructure,
+        _bottom_level: &[super::AccelerationStructure],
+        _instance_count: u32,
+        _instance_data: crate::BufferPiece,
+        _scratch_data: crate::BufferPiece,
+    ) {
+        unimplemented!("acceleration structures are not available on GLES")
+    }
+}
+
+#[hidden_trait::expose]
 impl crate::traits::PipelineEncoder for super::PipelineEncoder<'_> {
     fn bind<D: crate::ShaderData>(&mut self, group: u32, data: &D) {
         data.fill(super::PipelineContext {
@@ -513,7 +540,7 @@ impl crate::traits::RenderPipelineEncoder for super::PipelineEncoder<'_> {
     fn bind_vertex(&mut self, index: u32, vertex_buf: crate::BufferPiece) {
         assert_eq!(index, 0);
         self.commands.push(super::Command::BindVertex {
-            buffer: vertex_buf.buffer.raw,
+            buffer: vertex_buf.buffer.raw.expect("null GLES buffer"),
         });
         for (i, info) in self.vertex_attributes.iter().enumerate() {
             if info.buffer_index == index {
@@ -950,6 +977,7 @@ impl super::Command {
                                 0,
                             );
                         }
+                        super::TextureInner::Uninit => unreachable!("uninitialized texture"),
                     }
 
                     gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, Some(framebuf_to));
@@ -971,6 +999,7 @@ impl super::Command {
                                 0,
                             );
                         }
+                        super::TextureInner::Uninit => unreachable!("uninitialized texture"),
                     }
 
                     debug_assert_eq!(
@@ -1023,6 +1052,7 @@ impl super::Command {
                             mip_level,
                         );
                     }
+                    super::TextureInner::Uninit => unreachable!("uninitialized texture"),
                 },
                 Self::InvalidateAttachment(attachment) => {
                     gl.invalidate_framebuffer(glow::DRAW_FRAMEBUFFER, &[attachment]);

--- a/blade-graphics/src/gles/mod.rs
+++ b/blade-graphics/src/gles/mod.rs
@@ -47,13 +47,23 @@ pub struct Surface {
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct Buffer {
-    raw: glow::Buffer,
+    raw: Option<glow::Buffer>,
     size: u64,
     data: *mut u8,
 }
 
 unsafe impl Send for Buffer {}
 unsafe impl Sync for Buffer {}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self {
+            raw: None,
+            size: 0,
+            data: std::ptr::null_mut(),
+        }
+    }
+}
 
 impl Buffer {
     pub fn data(&self) -> *mut u8 {
@@ -65,7 +75,7 @@ impl Buffer {
     }
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq)]
 enum TextureInner {
     Renderbuffer {
         raw: glow::Renderbuffer,
@@ -74,6 +84,8 @@ enum TextureInner {
         raw: glow::Texture,
         target: BindTarget,
     },
+    #[default]
+    Uninit,
 }
 
 impl TextureInner {
@@ -83,6 +95,7 @@ impl TextureInner {
                 panic!("Unexpected renderbuffer");
             }
             Self::Texture { raw, target } => (raw, target),
+            Self::Uninit => panic!("Unexpected uninitialized texture"),
         }
     }
 }
@@ -94,7 +107,7 @@ pub struct Texture {
     format: crate::TextureFormat,
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq)]
 pub struct TextureView {
     inner: TextureInner,
     target_size: [u16; 2],
@@ -106,7 +119,7 @@ pub struct Sampler {
     raw: glow::Sampler,
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq)]
 pub struct AccelerationStructure {}
 
 type SlotList = Vec<u32>;
@@ -176,7 +189,7 @@ struct BufferPart {
 impl From<crate::BufferPiece> for BufferPart {
     fn from(piece: crate::BufferPiece) -> Self {
         Self {
-            raw: piece.buffer.raw,
+            raw: piece.buffer.raw.expect("null GLES buffer"),
             offset: piece.offset,
             data: piece.buffer.data,
         }
@@ -420,6 +433,7 @@ pub struct PassEncoder<'a, P> {
 
 pub type ComputeCommandEncoder<'a> = PassEncoder<'a, ComputePipeline>;
 pub type RenderCommandEncoder<'a> = PassEncoder<'a, RenderPipeline>;
+pub type TransferCommandEncoder<'a> = PassEncoder<'a, ()>;
 
 pub struct PipelineEncoder<'a> {
     commands: &'a mut Vec<Command>,
@@ -462,6 +476,8 @@ struct ExecutionContext {
 impl Context {
     pub fn capabilities(&self) -> crate::Capabilities {
         crate::Capabilities {
+            compute: self.capabilities.contains(Capabilities::BUFFER_STORAGE),
+            indirect_draw: false,
             binding_array: false,
             ray_query: crate::ShaderVisibility::empty(),
             sample_count_mask: 0x1 | 0x4, //TODO: accurate info

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -114,7 +114,7 @@ impl crate::traits::ResourceDevice for super::Context {
         };
 
         super::Buffer {
-            raw,
+            raw: Some(raw),
             size: desc.size,
             data,
         }
@@ -132,7 +132,7 @@ impl crate::traits::ResourceDevice for super::Context {
             };
             unsafe {
                 let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
-                gl.bind_buffer(raw_target, Some(buffer.raw));
+                gl.bind_buffer(raw_target, buffer.raw);
                 // On WebGL the storage is allocated here on first sync:
                 // `bufferData` both allocates and uploads (buffer orphaning).
                 #[cfg(target_arch = "wasm32")]
@@ -145,7 +145,7 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let gl = self.lock();
-        unsafe { gl.delete_buffer(buffer.raw) };
+        unsafe { gl.delete_buffer(buffer.raw.expect("null GLES buffer")) };
         if !buffer.data.is_null()
             && !self
                 .capabilities
@@ -312,6 +312,7 @@ impl crate::traits::ResourceDevice for super::Context {
             super::TextureInner::Texture { raw, .. } => unsafe {
                 gl.delete_texture(raw);
             },
+            super::TextureInner::Uninit => {}
         }
     }
 

--- a/blade-graphics/src/lib.rs
+++ b/blade-graphics/src/lib.rs
@@ -241,6 +241,10 @@ impl CooperativeMatrix {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Capabilities {
+    /// Compute pipeline support.
+    pub compute: bool,
+    /// Indirect draw command support.
+    pub indirect_draw: bool,
     /// Support binding arrays of handles.
     pub binding_array: bool,
     /// Which shader stages support ray queries.

--- a/blade-graphics/src/metal/mod.rs
+++ b/blade-graphics/src/metal/mod.rs
@@ -535,6 +535,8 @@ impl Context {
     ) -> crate::Capabilities {
         use metal::MTLDevice as _;
         crate::Capabilities {
+            compute: true,
+            indirect_draw: true,
             binding_array: false,
             ray_query: if device.supportsFamily(metal::MTLGPUFamily::Apple6) {
                 crate::ShaderVisibility::all()

--- a/blade-graphics/src/vulkan/init.rs
+++ b/blade-graphics/src/vulkan/init.rs
@@ -121,6 +121,8 @@ struct AdapterCapabilities {
 impl AdapterCapabilities {
     fn to_capabilities(&self) -> crate::Capabilities {
         crate::Capabilities {
+            compute: true,
+            indirect_draw: true,
             binding_array: self.binding_array,
             ray_query: match self.ray_tracing {
                 Some(_) => crate::ShaderVisibility::all(),
@@ -1468,6 +1470,8 @@ impl super::Context {
 
     pub fn capabilities(&self) -> crate::Capabilities {
         crate::Capabilities {
+            compute: true,
+            indirect_draw: true,
             binding_array: self.binding_array,
             ray_query: match self.device.ray_tracing {
                 Some(_) => crate::ShaderVisibility::all(),

--- a/blade-helpers/Cargo.toml
+++ b/blade-helpers/Cargo.toml
@@ -30,6 +30,3 @@ allowed_external_types = [
     "mint::*",
     "winit::*",
 ]
-
-[lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(gles)'] }

--- a/blade-helpers/src/lib.rs
+++ b/blade-helpers/src/lib.rs
@@ -1,11 +1,10 @@
-#![cfg(not(any(gles, target_arch = "wasm32")))]
-
 mod camera;
 mod hud;
 
 pub use blade_render::Camera;
 pub use camera::ControlledCamera;
-pub use hud::{ExposeHud, populate_debug_selection, populate_render_mode};
+pub use hud::ExposeHud;
+pub use hud::{populate_debug_selection, populate_render_mode};
 
 pub fn default_ray_config() -> blade_render::RayConfig {
     blade_render::RayConfig {

--- a/blade-render/Cargo.toml
+++ b/blade-render/Cargo.toml
@@ -67,3 +67,6 @@ allowed_external_types = [
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(gles)'] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }

--- a/blade-render/README.md
+++ b/blade-render/README.md
@@ -3,11 +3,11 @@
 [![Docs](https://docs.rs/blade-render/badge.svg)](https://docs.rs/blade-render)
 [![Crates.io](https://img.shields.io/crates/v/blade-render.svg?maxAge=2592000)](https://crates.io/crates/blade-render)
 
-Ray-traced renderer based on [blade-graphics](https://crates.io/crates/blade-graphics) and [blade-asset](https://crates.io/crates/blade-asset).
+Rasterized and ray-traced rendering based on [blade-graphics](https://crates.io/crates/blade-graphics) and [blade-asset](https://crates.io/crates/blade-asset).
 
 ![sponza scene](etc/sponza.jpg)
 
 ## Platforms
 
-Only Vulkan with hardware Ray Tracing is currently supported.
-In the future, we should be able to run on Metal as well.
+The rasterizer supports the portable graphics profile, including WebGL2. The
+ray tracer requires a backend and device with ray-query support.

--- a/blade-render/code/raster.wgsl
+++ b/blade-render/code/raster.wgsl
@@ -31,10 +31,6 @@ struct Vertex {
     tangent: u32,
 }
 
-struct VertexBuffer {
-    data: array<Vertex>,
-}
-
 struct VertexOutput {
     @builtin(position) clip_pos: vec4<f32>,
     @location(0) world_pos: vec3<f32>,
@@ -46,7 +42,6 @@ struct VertexOutput {
 
 var<uniform> frame_params: RasterFrameParams;
 var<uniform> draw_params: RasterDrawParams;
-var<storage, read> vertices: VertexBuffer;
 var samp: sampler;
 var base_color_tex: texture_2d<f32>;
 var normal_tex: texture_2d<f32>;
@@ -63,8 +58,7 @@ fn quat_rotate(q: vec4<f32>, v: vec3<f32>) -> vec3<f32> {
 }
 
 @vertex
-fn raster_vs(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
-    let input = vertices.data[vertex_index];
+fn raster_vs(input: Vertex) -> VertexOutput {
     var out: VertexOutput;
     let pos_world = draw_params.model * vec4<f32>(input.position, 1.0);
     out.clip_pos = frame_params.view_proj * pos_world;

--- a/blade-render/src/dummy.rs
+++ b/blade-render/src/dummy.rs
@@ -97,6 +97,7 @@ impl DummyResources {
                 [!0u8, !0, !0, !0, 0, 0, 0, 0, !0, 0, 0, 0],
             );
         }
+        gpu.sync_buffer(staging_buf, blade_graphics::BufferTarget::Data);
         transfers.copy_buffer_to_texture(staging_buf.at(0), 4, white_texture.into(), size);
         transfers.copy_buffer_to_texture(staging_buf.at(4), 4, black_texture.into(), size);
         transfers.copy_buffer_to_texture(staging_buf.at(8), 4, red_texture.into(), size);

--- a/blade-render/src/lib.rs
+++ b/blade-render/src/lib.rs
@@ -18,33 +18,39 @@ mod env_map;
 pub use dummy::DummyResources;
 pub use env_map::EnvironmentMap;
 
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 mod asset_hub;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub mod model;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub mod raster;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
-mod render;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub mod shader;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
+mod shaders;
 pub mod texture;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub mod util;
 
-#[cfg(not(any(gles, target_arch = "wasm32")))]
+mod render;
+
 pub use asset_hub::*;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub use model::{Model, ProceduralGeometry};
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub use raster::{RasterConfig, Rasterizer};
-#[cfg(not(any(gles, target_arch = "wasm32")))]
-pub use render::*;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub use shader::Shader;
-#[cfg(not(any(gles, target_arch = "wasm32")))]
+pub use shaders::{RenderConfig, Shaders};
 pub use texture::Texture;
+pub use util::FrameResources;
+
+pub use render::*;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DebugPoint {
+    pub pos: [f32; 3],
+    pub color: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DebugLine {
+    pub a: DebugPoint,
+    pub b: DebugPoint,
+}
 
 // Has to match the `Vertex` in shaders
 #[repr(C)]
@@ -77,7 +83,6 @@ pub struct Camera {
     pub fov: Option<Fov>,
 }
 
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 pub struct Object {
     pub model: blade_asset::Handle<Model>,
     pub transform: blade_graphics::Transform,
@@ -87,7 +92,6 @@ pub struct Object {
     pub color_tint: [f32; 4],
 }
 
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 impl From<blade_asset::Handle<Model>> for Object {
     fn from(model: blade_asset::Handle<Model>) -> Self {
         Self {
@@ -99,7 +103,6 @@ impl From<blade_asset::Handle<Model>> for Object {
     }
 }
 
-#[cfg(not(any(gles, target_arch = "wasm32")))]
 #[repr(C)]
 #[derive(Clone, Copy, Default, PartialEq, bytemuck::Zeroable, bytemuck::Pod)]
 struct CameraParams {

--- a/blade-render/src/model/mod.rs
+++ b/blade-render/src/model/mod.rs
@@ -9,25 +9,48 @@ use std::{
 
 const PRELOAD_TEXTURES: bool = false;
 
+const fn texture_format(
+    compressed: blade_graphics::TextureFormat,
+    uncompressed: blade_graphics::TextureFormat,
+) -> blade_graphics::TextureFormat {
+    if cfg!(target_arch = "wasm32") {
+        uncompressed
+    } else {
+        compressed
+    }
+}
+
 const META_BASE_COLOR: crate::texture::Meta = crate::texture::Meta {
-    format: blade_graphics::TextureFormat::Bc1UnormSrgb,
+    format: texture_format(
+        blade_graphics::TextureFormat::Bc1UnormSrgb,
+        blade_graphics::TextureFormat::Rgba8UnormSrgb,
+    ),
     generate_mips: true,
     y_flip: false,
 };
 const META_NORMAL: crate::texture::Meta = crate::texture::Meta {
-    //Note: "texpresso" doesn't know how to produce signed normalized
-    format: blade_graphics::TextureFormat::Bc5Unorm,
+    // "texpresso" doesn't know how to produce signed normalized.
+    format: texture_format(
+        blade_graphics::TextureFormat::Bc5Unorm,
+        blade_graphics::TextureFormat::Rgba8Unorm,
+    ),
     generate_mips: false,
     y_flip: false,
 };
-//Note: the metallic-roughness values are linear, so no sRGB here
 const META_METALLIC_ROUGHNESS: crate::texture::Meta = crate::texture::Meta {
-    format: blade_graphics::TextureFormat::Bc1Unorm,
+    // Metallic-roughness values are linear, so no sRGB here.
+    format: texture_format(
+        blade_graphics::TextureFormat::Bc1Unorm,
+        blade_graphics::TextureFormat::Rgba8Unorm,
+    ),
     generate_mips: true,
     y_flip: false,
 };
 const META_EMISSIVE: crate::texture::Meta = crate::texture::Meta {
-    format: blade_graphics::TextureFormat::Bc1UnormSrgb,
+    format: texture_format(
+        blade_graphics::TextureFormat::Bc1UnormSrgb,
+        blade_graphics::TextureFormat::Rgba8UnormSrgb,
+    ),
     generate_mips: true,
     y_flip: false,
 };
@@ -362,6 +385,61 @@ struct Transfer {
     size: u64,
 }
 
+struct BufferUpload {
+    stage: blade_graphics::Buffer,
+    dst: blade_graphics::Buffer,
+    size: u64,
+    target: blade_graphics::BufferTarget,
+}
+
+impl BufferUpload {
+    fn new(
+        gpu: &blade_graphics::Context,
+        name: &'static str,
+        size: u64,
+        target: blade_graphics::BufferTarget,
+    ) -> Self {
+        let dst = gpu.create_buffer(blade_graphics::BufferDesc {
+            name,
+            size,
+            memory: blade_graphics::Memory::Device,
+        });
+        let stage = if cfg!(target_arch = "wasm32") {
+            dst
+        } else {
+            gpu.create_buffer(blade_graphics::BufferDesc {
+                name: "model staging",
+                size,
+                memory: blade_graphics::Memory::Upload,
+            })
+        };
+
+        Self {
+            stage,
+            dst,
+            size,
+            target,
+        }
+    }
+
+    fn finish(self, baker: &Baker) {
+        if cfg!(target_arch = "wasm32") {
+            baker.gpu_context.sync_buffer(self.dst, self.target);
+        } else {
+            baker
+                .pending_operations
+                .lock()
+                .unwrap()
+                .transfers
+                .push(Transfer {
+                    stage: self.stage,
+                    dst: self.dst,
+                    size: self.size,
+                });
+        }
+    }
+}
+
 #[derive(Debug)]
 struct BlasConstruct {
     meshes: Vec<blade_graphics::AccelerationStructureMesh>,
@@ -434,6 +512,7 @@ impl Baker {
                 temp_buffers.push(transfer.stage);
             }
         }
+        // Skip when `build_blas` queued nothing (`ray_query` empty).
         if !pending_ops.blas_constructs.is_empty() {
             let mut pass = encoder.acceleration_structure("BLAS");
             for construct in pending_ops.blas_constructs.drain(..) {
@@ -520,6 +599,12 @@ impl Baker {
         }
     }
 }
+
+// SAFETY: GLES asset tasks are executed inline on the context's owning thread.
+#[cfg(any(gles, target_arch = "wasm32"))]
+unsafe impl Send for Baker {}
+#[cfg(any(gles, target_arch = "wasm32"))]
+unsafe impl Sync for Baker {}
 
 /// Description of a procedural model geometry.
 ///
@@ -661,6 +746,13 @@ impl Baker {
             index_offset += geo.indices.len() as u64 * 4;
             transform_offset += mem::size_of::<blade_graphics::Transform>() as u64;
         }
+
+        self.gpu_context
+            .sync_buffer(vertex_buffer, blade_graphics::BufferTarget::Data);
+        self.gpu_context
+            .sync_buffer(index_buffer, blade_graphics::BufferTarget::Index);
+        self.gpu_context
+            .sync_buffer(transform_buffer, blade_graphics::BufferTarget::Data);
 
         Model {
             name: name.to_string(),
@@ -925,16 +1017,14 @@ impl blade_asset::Baker for Baker {
             .map(|geo| geo.vertices.len())
             .sum::<usize>();
         let total_vertex_size = (total_vertices * mem::size_of::<crate::Vertex>()) as u64;
-        let vertex_buffer = self.gpu_context.create_buffer(blade_graphics::BufferDesc {
-            name: "vertex",
-            size: total_vertex_size,
-            memory: blade_graphics::Memory::Device,
-        });
-        let vertex_stage = self.gpu_context.create_buffer(blade_graphics::BufferDesc {
-            name: "vertex stage",
-            size: total_vertex_size,
-            memory: blade_graphics::Memory::Upload,
-        });
+        let vertex_upload = BufferUpload::new(
+            &self.gpu_context,
+            "vertex",
+            total_vertex_size,
+            blade_graphics::BufferTarget::Data,
+        );
+        let vertex_buffer = vertex_upload.dst;
+        let vertex_stage = vertex_upload.stage;
 
         let total_indices = model
             .geometries
@@ -943,29 +1033,25 @@ impl blade_asset::Baker for Baker {
             .sum::<usize>();
         let total_index_size = total_indices as u64 * 4
             + model.geometries.len() as u64 * blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT;
-        let index_buffer = self.gpu_context.create_buffer(blade_graphics::BufferDesc {
-            name: "index",
-            size: total_index_size,
-            memory: blade_graphics::Memory::Device,
-        });
-        let index_stage = self.gpu_context.create_buffer(blade_graphics::BufferDesc {
-            name: "index stage",
-            size: total_index_size,
-            memory: blade_graphics::Memory::Upload,
-        });
+        let index_upload = BufferUpload::new(
+            &self.gpu_context,
+            "index",
+            total_index_size,
+            blade_graphics::BufferTarget::Index,
+        );
+        let index_buffer = index_upload.dst;
+        let index_stage = index_upload.stage;
 
         let total_transform_size =
             (model.geometries.len() * mem::size_of::<blade_graphics::Transform>()) as u64;
-        let transform_buffer = self.gpu_context.create_buffer(blade_graphics::BufferDesc {
-            name: "transform",
-            size: total_transform_size,
-            memory: blade_graphics::Memory::Device,
-        });
-        let transform_stage = self.gpu_context.create_buffer(blade_graphics::BufferDesc {
-            name: "transform stage",
-            size: total_transform_size,
-            memory: blade_graphics::Memory::Upload,
-        });
+        let transform_upload = BufferUpload::new(
+            &self.gpu_context,
+            "transform",
+            total_transform_size,
+            blade_graphics::BufferTarget::Data,
+        );
+        let transform_buffer = transform_upload.dst;
+        let transform_stage = transform_upload.stage;
 
         let mut meshes = Vec::with_capacity(model.geometries.len());
         let vertex_stride = mem::size_of::<super::Vertex>() as u32;
@@ -1034,24 +1120,9 @@ impl blade_asset::Baker for Baker {
         assert!(index_offset <= total_index_size);
         assert_eq!(transform_offset, total_transform_size);
 
-        {
-            let mut pending_ops = self.pending_operations.lock().unwrap();
-            pending_ops.transfers.push(Transfer {
-                stage: vertex_stage,
-                dst: vertex_buffer,
-                size: total_vertex_size,
-            });
-            pending_ops.transfers.push(Transfer {
-                stage: index_stage,
-                dst: index_buffer,
-                size: total_index_size,
-            });
-            pending_ops.transfers.push(Transfer {
-                stage: transform_stage,
-                dst: transform_buffer,
-                size: total_transform_size,
-            });
-        }
+        vertex_upload.finish(self);
+        index_upload.finish(self);
+        transform_upload.finish(self);
         let acceleration_structure = self.build_blas(str::from_utf8(model.name).unwrap(), meshes);
 
         Model {

--- a/blade-render/src/raster/mod.rs
+++ b/blade-render/src/raster/mod.rs
@@ -1,4 +1,4 @@
-use crate::{AssetHub, CameraParams, DummyResources, Object, Shaders, Vertex};
+use crate::{AssetHub, CameraParams, DummyResources, Object, RenderConfig, Shaders, Vertex};
 use blade_graphics as gpu;
 use std::mem;
 
@@ -67,7 +67,6 @@ struct RasterDrawParams {
 struct RasterMainData {
     frame_params: RasterFrameParams,
     draw_params: RasterDrawParams,
-    vertices: gpu::BufferPiece,
     samp: gpu::Sampler,
     base_color_tex: gpu::TextureView,
     normal_tex: gpu::TextureView,
@@ -96,11 +95,15 @@ impl RasterPipelines {
         shader.check_struct_size::<RasterFrameParams>();
         shader.check_struct_size::<RasterDrawParams>();
         let main_layout = <RasterMainData as gpu::ShaderData>::layout();
+        let vertex_layout = <Vertex as gpu::Vertex>::layout();
         gpu.create_render_pipeline(gpu::RenderPipelineDesc {
             name: "raster",
             data_layouts: &[&main_layout],
             vertex: shader.at("raster_vs"),
-            vertex_fetches: &[],
+            vertex_fetches: &[gpu::VertexFetchState {
+                layout: &vertex_layout,
+                instanced: false,
+            }],
             primitive: gpu::PrimitiveState {
                 topology: gpu::PrimitiveTopology::TriangleList,
                 ..Default::default()
@@ -149,7 +152,7 @@ impl RasterPipelines {
 
     fn init(
         shaders: &Shaders,
-        config: &crate::render::RenderConfig,
+        config: &RenderConfig,
         gpu: &gpu::Context,
         shader_man: &blade_asset::AssetManager<crate::shader::Baker>,
     ) -> Result<Self, &'static str> {
@@ -181,13 +184,16 @@ impl Rasterizer {
         gpu: &gpu::Context,
         shaders: Shaders,
         shader_man: &blade_asset::AssetManager<crate::shader::Baker>,
-        config: &crate::render::RenderConfig,
+        config: &RenderConfig,
     ) -> Self {
         let pipelines = RasterPipelines::init(&shaders, config, gpu, shader_man).unwrap();
-        #[cfg(target_os = "android")]
-        let debug = None;
-        #[cfg(not(target_os = "android"))]
-        let debug = {
+        let capabilities = gpu.capabilities();
+        let debug = if cfg!(target_os = "android")
+            || !capabilities.compute
+            || !capabilities.indirect_draw
+        {
+            None
+        } else {
             let sh_draw = shader_man[shaders.debug_draw].raw.as_ref().unwrap();
             let sh_blit = shader_man[shaders.debug_blit].raw.as_ref().unwrap();
             Some(crate::render::DebugRender::init(
@@ -367,7 +373,6 @@ impl Rasterizer {
                                     0.0,
                                 ],
                             },
-                            vertices: model.vertex_buffer.at(0),
                             samp: self.sampler_linear,
                             base_color_tex: texture_or_white(material.base_color_texture),
                             normal_tex,
@@ -380,19 +385,22 @@ impl Rasterizer {
 
                     let vertex_count = geometry.vertex_range.end - geometry.vertex_range.start;
                     let index_count = geometry.triangle_count * 3;
+                    let vertex_offset =
+                        geometry.vertex_range.start as u64 * mem::size_of::<Vertex>() as u64;
+                    pc.bind_vertex(0, model.vertex_buffer.at(vertex_offset));
                     match geometry.index_type {
                         Some(index_type) => {
                             pc.draw_indexed(
                                 model.index_buffer.at(geometry.index_offset),
                                 index_type,
                                 index_count,
-                                geometry.vertex_range.start as i32,
+                                0,
                                 0,
                                 1,
                             );
                         }
                         None => {
-                            pc.draw(geometry.vertex_range.start, vertex_count, 0, 1);
+                            pc.draw(0, vertex_count, 0, 1);
                         }
                     }
                 }

--- a/blade-render/src/render/debug.rs
+++ b/blade-render/src/render/debug.rs
@@ -8,23 +8,9 @@ pub struct DebugBlit {
     pub target_size: [u32; 2],
 }
 
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct DebugPoint {
-    pub pos: [f32; 3],
-    pub color: u32,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct DebugLine {
-    pub a: DebugPoint,
-    pub b: DebugPoint,
-}
-
 #[derive(blade_macros::ShaderData)]
 struct DebugDrawData {
-    camera: super::CameraParams,
+    camera: crate::CameraParams,
     debug_lines: blade_graphics::BufferPiece,
     depth: blade_graphics::TextureView,
 }
@@ -76,8 +62,8 @@ fn create_draw_pipeline(
     format: blade_graphics::TextureFormat,
     gpu: &blade_graphics::Context,
 ) -> blade_graphics::RenderPipeline {
-    shader.check_struct_size::<DebugPoint>();
-    shader.check_struct_size::<DebugLine>();
+    shader.check_struct_size::<crate::DebugPoint>();
+    shader.check_struct_size::<crate::DebugLine>();
     let layout = <DebugDrawData as blade_graphics::ShaderData>::layout();
     gpu.create_render_pipeline(blade_graphics::RenderPipelineDesc {
         name: "debug-draw",
@@ -233,7 +219,7 @@ impl DebugRender {
         self.draw_pipeline = create_blit_pipeline(shader, self.surface_format, gpu);
     }
 
-    fn add_lines(&self, lines: &[DebugLine]) -> (blade_graphics::BufferPiece, u32) {
+    fn add_lines(&self, lines: &[crate::DebugLine]) -> (blade_graphics::BufferPiece, u32) {
         let required_size = lines.len() as u64 * self.line_size as u64;
         let old_offset = self.cpu_lines_offset.get();
         let (original_offset, count) =
@@ -250,7 +236,7 @@ impl DebugRender {
         unsafe {
             ptr::copy_nonoverlapping(
                 lines.as_ptr(),
-                self.cpu_lines_buffer.data().add(original_offset as usize) as *mut DebugLine,
+                self.cpu_lines_buffer.data().add(original_offset as usize) as *mut crate::DebugLine,
                 count,
             );
         }
@@ -262,8 +248,8 @@ impl DebugRender {
 
     pub(crate) fn render_lines(
         &self,
-        debug_lines: &[DebugLine],
-        camera: super::CameraParams,
+        debug_lines: &[crate::DebugLine],
+        camera: crate::CameraParams,
         depth: blade_graphics::TextureView,
         pass: &mut blade_graphics::RenderCommandEncoder,
     ) {

--- a/blade-render/src/render/mod.rs
+++ b/blade-render/src/render/mod.rs
@@ -1,12 +1,12 @@
 mod debug;
 
-use crate::{CameraParams, DummyResources, EnvironmentMap};
+use crate::{CameraParams, DebugLine, DummyResources, EnvironmentMap, RenderConfig, Shaders};
 use debug::{DebugEntry, DebugVariance};
 
+pub use debug::DebugBlit;
 pub(crate) use debug::DebugRender;
-pub use debug::{DebugBlit, DebugLine, DebugPoint};
 
-use std::{collections::HashMap, mem, num::NonZeroU32, path::Path, ptr};
+use std::{collections::HashMap, mem, num::NonZeroU32, ptr};
 
 const MAX_RESOURCES: u32 = 8192;
 const RADIANCE_FORMAT: blade_graphics::TextureFormat = blade_graphics::TextureFormat::Rgba16Float;
@@ -27,20 +27,6 @@ fn mat3_transform(t_orig: &blade_graphics::Transform) -> glam::Mat3 {
         y_axis: t.y.into(),
         z_axis: t.z.into(),
     }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct RenderConfig {
-    pub surface_size: blade_graphics::Extent,
-    pub surface_info: blade_graphics::SurfaceInfo,
-    /// Color space to produce the image in, matching the one the
-    /// surface was configured with.
-    ///
-    /// `Linear` leaves the encoding to the platform, which is what an sRGB
-    /// surface format does for us. `Srgb` means the values are passed to the
-    /// display as they are, so we have to encode them ourselves.
-    pub color_space: blade_graphics::ColorSpace,
-    pub max_debug_lines: u32,
 }
 
 struct Samplers {
@@ -691,46 +677,6 @@ struct HitEntry {
     emissive_factor: [f32; 4],
 }
 
-#[derive(Clone, PartialEq)]
-pub struct Shaders {
-    pub(crate) env_prepare: blade_asset::Handle<crate::Shader>,
-    pub(crate) fill_gbuf: blade_asset::Handle<crate::Shader>,
-    pub(crate) ray_trace: blade_asset::Handle<crate::Shader>,
-    pub(crate) path_trace: blade_asset::Handle<crate::Shader>,
-    pub(crate) a_trous: blade_asset::Handle<crate::Shader>,
-    pub(crate) post_proc: blade_asset::Handle<crate::Shader>,
-    pub(crate) raster: blade_asset::Handle<crate::Shader>,
-    pub(crate) debug_draw: blade_asset::Handle<crate::Shader>,
-    pub(crate) debug_blit: blade_asset::Handle<crate::Shader>,
-}
-
-impl Shaders {
-    pub fn load(
-        path: &Path,
-        asset_hub: &crate::AssetHub,
-        ray_tracing: bool,
-    ) -> (Self, choir::RunningTask) {
-        let mut ctx = asset_hub.open_context(path, "shader finish");
-        let noop = if ray_tracing {
-            None
-        } else {
-            Some(ctx.load_shader("noop.wgsl"))
-        };
-        let shaders = Self {
-            env_prepare: noop.unwrap_or_else(|| ctx.load_shader("env-prepare.wgsl")),
-            fill_gbuf: noop.unwrap_or_else(|| ctx.load_shader("fill-gbuf.wgsl")),
-            ray_trace: noop.unwrap_or_else(|| ctx.load_shader("ray-trace.wgsl")),
-            path_trace: noop.unwrap_or_else(|| ctx.load_shader("path-trace.wgsl")),
-            a_trous: noop.unwrap_or_else(|| ctx.load_shader("a-trous.wgsl")),
-            post_proc: noop.unwrap_or_else(|| ctx.load_shader("post-proc.wgsl")),
-            raster: ctx.load_shader("raster.wgsl"),
-            debug_draw: ctx.load_shader("debug-draw.wgsl"),
-            debug_blit: ctx.load_shader("debug-blit.wgsl"),
-        };
-        (shaders, ctx.close())
-    }
-}
-
 struct ShaderPipelines {
     fill: blade_graphics::ComputePipeline,
     main: blade_graphics::ComputePipeline,
@@ -879,11 +825,7 @@ pub struct FrameConfig {
 }
 
 /// Temporary resources associated with a GPU frame.
-#[derive(Default)]
-pub struct FrameResources {
-    pub buffers: Vec<blade_graphics::Buffer>,
-    pub acceleration_structures: Vec<blade_graphics::AccelerationStructure>,
-}
+pub use crate::util::FrameResources;
 
 impl RayTracer {
     /// Create a new renderer with a given configuration.

--- a/blade-render/src/shader.rs
+++ b/blade-render/src/shader.rs
@@ -74,6 +74,12 @@ impl Baker {
     }
 }
 
+// SAFETY: GLES asset tasks are executed inline on the context's owning thread.
+#[cfg(any(gles, target_arch = "wasm32"))]
+unsafe impl Send for Baker {}
+#[cfg(any(gles, target_arch = "wasm32"))]
+unsafe impl Sync for Baker {}
+
 fn parse_impl(
     text_raw: &[u8],
     base_path: &Path,
@@ -156,8 +162,14 @@ impl blade_asset::Baker for Baker {
                 naga_module: None,
             });
         if let Err(e) = raw {
-            let _ = fs::write(FAILURE_DUMP_NAME, source);
-            log::warn!("Shader compilation failed: {e:?}, source dumped as '{FAILURE_DUMP_NAME}'.")
+            match fs::write(FAILURE_DUMP_NAME, source) {
+                Ok(()) => log::warn!(
+                    "Shader compilation failed: {e:?}, source dumped as '{FAILURE_DUMP_NAME}'."
+                ),
+                Err(write_error) => log::warn!(
+                    "Shader compilation failed: {e:?}; unable to dump source: {write_error}"
+                ),
+            }
         }
         Shader { raw }
     }

--- a/blade-render/src/shaders.rs
+++ b/blade-render/src/shaders.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+use crate::AssetHub;
+
+/// Configuration shared by raster and ray-traced renderers.
+#[derive(Clone, Copy, Debug)]
+pub struct RenderConfig {
+    pub surface_size: blade_graphics::Extent,
+    pub surface_info: blade_graphics::SurfaceInfo,
+    /// Color space to produce the image in, matching the one the
+    /// surface was configured with.
+    ///
+    /// `Linear` leaves the encoding to the platform, which is what an sRGB
+    /// surface format does for us. `Srgb` means the values are passed to the
+    /// display as they are, so we have to encode them ourselves.
+    pub color_space: blade_graphics::ColorSpace,
+    pub max_debug_lines: u32,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct Shaders {
+    pub(crate) env_prepare: blade_asset::Handle<crate::Shader>,
+    pub(crate) fill_gbuf: blade_asset::Handle<crate::Shader>,
+    pub(crate) ray_trace: blade_asset::Handle<crate::Shader>,
+    pub(crate) path_trace: blade_asset::Handle<crate::Shader>,
+    pub(crate) a_trous: blade_asset::Handle<crate::Shader>,
+    pub(crate) post_proc: blade_asset::Handle<crate::Shader>,
+    pub(crate) raster: blade_asset::Handle<crate::Shader>,
+    pub(crate) debug_draw: blade_asset::Handle<crate::Shader>,
+    pub(crate) debug_blit: blade_asset::Handle<crate::Shader>,
+}
+
+impl Shaders {
+    pub fn load(
+        path: &Path,
+        asset_hub: &AssetHub,
+        ray_tracing: bool,
+    ) -> (Self, choir::RunningTask) {
+        let mut ctx = asset_hub.open_context(path, "shader finish");
+        let noop = if ray_tracing {
+            None
+        } else {
+            Some(ctx.load_shader("noop.wgsl"))
+        };
+        let shaders = Self {
+            env_prepare: noop.unwrap_or_else(|| ctx.load_shader("env-prepare.wgsl")),
+            fill_gbuf: noop.unwrap_or_else(|| ctx.load_shader("fill-gbuf.wgsl")),
+            ray_trace: noop.unwrap_or_else(|| ctx.load_shader("ray-trace.wgsl")),
+            path_trace: noop.unwrap_or_else(|| ctx.load_shader("path-trace.wgsl")),
+            a_trous: noop.unwrap_or_else(|| ctx.load_shader("a-trous.wgsl")),
+            post_proc: noop.unwrap_or_else(|| ctx.load_shader("post-proc.wgsl")),
+            raster: ctx.load_shader("raster.wgsl"),
+            debug_draw: ctx.load_shader("debug-draw.wgsl"),
+            debug_blit: ctx.load_shader("debug-blit.wgsl"),
+        };
+        (shaders, ctx.close())
+    }
+}

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -101,6 +101,12 @@ impl Baker {
     }
 }
 
+// SAFETY: GLES asset tasks are executed inline on the context's owning thread.
+#[cfg(any(gles, target_arch = "wasm32"))]
+unsafe impl Send for Baker {}
+#[cfg(any(gles, target_arch = "wasm32"))]
+unsafe impl Sync for Baker {}
+
 impl Baker {
     /// Create a texture directly from RGBA u8 pixel data (4 bytes per pixel).
     /// Uses `Rgba8Unorm` format which supports linear filtering on all GPUs.
@@ -146,6 +152,7 @@ impl Baker {
         unsafe {
             ptr::copy_nonoverlapping(byte_data.as_ptr(), stage.data(), byte_data.len());
         }
+        self.gpu_context.sync_buffer(stage, gpu::BufferTarget::Data);
 
         let bytes_per_row = width * 4;
         let mut pending_ops = self.pending_operations.lock().unwrap();
@@ -304,19 +311,16 @@ impl blade_asset::Baker for Baker {
                 }
 
                 let dst_format = match meta.format {
-                    Tf::Bc1Unorm | Tf::Bc1UnormSrgb => texpresso::Format::Bc1,
-                    Tf::Bc2Unorm | Tf::Bc2UnormSrgb => texpresso::Format::Bc2,
-                    Tf::Bc3Unorm | Tf::Bc3UnormSrgb => texpresso::Format::Bc3,
-                    Tf::Bc4Unorm | Tf::Bc4Snorm => texpresso::Format::Bc4,
-                    Tf::Bc5Unorm | Tf::Bc5Snorm => texpresso::Format::Bc5,
+                    Tf::Bc1Unorm | Tf::Bc1UnormSrgb => Some(texpresso::Format::Bc1),
+                    Tf::Bc2Unorm | Tf::Bc2UnormSrgb => Some(texpresso::Format::Bc2),
+                    Tf::Bc3Unorm | Tf::Bc3UnormSrgb => Some(texpresso::Format::Bc3),
+                    Tf::Bc4Unorm | Tf::Bc4Snorm => Some(texpresso::Format::Bc4),
+                    Tf::Bc5Unorm | Tf::Bc5Snorm => Some(texpresso::Format::Bc5),
+                    Tf::Rgba8Unorm | Tf::Rgba8UnormSrgb => None,
                     other => panic!("Unsupported destination format {:?}", other),
                 };
 
                 let mut src_mips = vec![data];
-                let mut mips = {
-                    let compressed_size = dst_format.compressed_size(src.width, src.height);
-                    vec![vec![0u8; compressed_size]]
-                };
                 let base_extent = blade_graphics::Extent {
                     width: src.width as u32,
                     height: src.height as u32,
@@ -352,69 +356,91 @@ impl blade_asset::Baker for Baker {
                             cur_extent.height as _,
                         );
                         src_mips.push(cur_data);
+                    }
+                }
+
+                if let Some(dst_format) = dst_format {
+                    let mut mips = {
+                        let compressed_size = dst_format.compressed_size(src.width, src.height);
+                        vec![vec![0u8; compressed_size]]
+                    };
+                    for i in 1..src_mips.len() {
+                        let cur_extent = base_extent.at_mip_level(i as u32);
                         let compressed_size = dst_format
                             .compressed_size(cur_extent.width as _, cur_extent.height as _);
                         mips.push(vec![0u8; compressed_size]);
                     }
+
+                    struct CompressTask {
+                        src: Vec<LdrTexel>,
+                        dst_ptr: *mut u8,
+                    }
+                    unsafe impl Send for CompressTask {}
+                    unsafe impl Sync for CompressTask {}
+
+                    let compress_task = exe_context
+                        .fork("compress")
+                        .init_iter(
+                            src_mips
+                                .into_iter()
+                                .zip(mips.iter_mut())
+                                .map(|(src, dst)| CompressTask {
+                                    src,
+                                    dst_ptr: dst.as_mut_ptr(),
+                                })
+                                .enumerate(),
+                            move |_, (i, task)| {
+                                let extent = base_extent.at_mip_level(i as u32);
+                                let compressed_size = dst_format
+                                    .compressed_size(extent.width as _, extent.height as _);
+                                let params = texpresso::Params {
+                                    //TODO: make this configurable
+                                    algorithm: texpresso::Algorithm::RangeFit,
+                                    ..Default::default()
+                                };
+                                let dst = unsafe {
+                                    slice::from_raw_parts_mut(task.dst_ptr, compressed_size)
+                                };
+                                let raw = unsafe {
+                                    slice::from_raw_parts(
+                                        task.src.as_ptr() as *const u8,
+                                        task.src.len() * 4,
+                                    )
+                                };
+                                dst_format.compress(
+                                    raw,
+                                    extent.width as _,
+                                    extent.height as _,
+                                    params,
+                                    dst,
+                                );
+                            },
+                        )
+                        .run();
+
+                    exe_context
+                        .fork("finish")
+                        .init(move |_| {
+                            cooker.finish(CookedImage {
+                                name: &[],
+                                extent: [base_extent.width, base_extent.height, base_extent.depth],
+                                format: TextureFormatWrap(meta.format),
+                                mips: mips.iter().map(|data| CookedMip { data }).collect(),
+                            });
+                        })
+                        .depend_on(&compress_task);
+                } else {
+                    let mips: Vec<Vec<u8>> = src_mips
+                        .into_iter()
+                        .map(|mip| mip.iter().flat_map(|texel| texel.iter().copied()).collect())
+                        .collect();
+                    cooker.finish(CookedImage {
+                        name: &[],
+                        extent: [base_extent.width, base_extent.height, base_extent.depth],
+                        format: TextureFormatWrap(meta.format),
+                        mips: mips.iter().map(|data| CookedMip { data }).collect(),
+                    });
                 }
-
-                struct CompressTask {
-                    src: Vec<LdrTexel>,
-                    dst_ptr: *mut u8,
-                }
-                unsafe impl Send for CompressTask {}
-                unsafe impl Sync for CompressTask {}
-
-                let compress_task = exe_context
-                    .fork("compress")
-                    .init_iter(
-                        src_mips
-                            .into_iter()
-                            .zip(mips.iter_mut())
-                            .map(|(src, dst)| CompressTask {
-                                src,
-                                dst_ptr: dst.as_mut_ptr(),
-                            })
-                            .enumerate(),
-                        move |_, (i, task)| {
-                            let extent = base_extent.at_mip_level(i as u32);
-                            let compressed_size =
-                                dst_format.compressed_size(extent.width as _, extent.height as _);
-                            let params = texpresso::Params {
-                                //TODO: make this configurable
-                                algorithm: texpresso::Algorithm::RangeFit,
-                                ..Default::default()
-                            };
-                            let dst =
-                                unsafe { slice::from_raw_parts_mut(task.dst_ptr, compressed_size) };
-                            let raw = unsafe {
-                                slice::from_raw_parts(
-                                    task.src.as_ptr() as *const u8,
-                                    task.src.len() * 4,
-                                )
-                            };
-                            dst_format.compress(
-                                raw,
-                                extent.width as _,
-                                extent.height as _,
-                                params,
-                                dst,
-                            );
-                        },
-                    )
-                    .run();
-
-                exe_context
-                    .fork("finish")
-                    .init(move |_| {
-                        cooker.finish(CookedImage {
-                            name: &[],
-                            extent: [base_extent.width, base_extent.height, base_extent.depth],
-                            format: TextureFormatWrap(meta.format),
-                            mips: mips.iter().map(|data| CookedMip { data }).collect(),
-                        });
-                    })
-                    .depend_on(&compress_task);
             }
             PlainData::Hdr(data) => {
                 //TODO: compress as BC6E
@@ -490,6 +516,8 @@ impl blade_asset::Baker for Baker {
             unsafe {
                 ptr::copy_nonoverlapping(mip.data.as_ptr(), stage.data(), mip.data.len());
             }
+            self.gpu_context
+                .sync_buffer(stage, blade_graphics::BufferTarget::Data);
 
             let block_info = image.format.0.block_info();
             let extent = base_extent.at_mip_level(i as u32);

--- a/blade-render/src/util/frame_pacer.rs
+++ b/blade-render/src/util/frame_pacer.rs
@@ -1,5 +1,11 @@
-use crate::render::FrameResources;
 use std::mem;
+
+/// Temporary resources associated with a GPU frame.
+#[derive(Default)]
+pub struct FrameResources {
+    pub buffers: Vec<blade_graphics::Buffer>,
+    pub acceleration_structures: Vec<blade_graphics::AccelerationStructure>,
+}
 
 /// Utility object that encapsulates the logic
 /// of always rendering 1 frame at a time, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,17 @@ Changelog for *Blade* project
 
 ## (TBD)
 
+- engine/render: support the raster rendering path on WebGL2. Raster vertex
+  data now uses ordinary vertex attributes, model and texture uploads observe
+  WebGL's buffer binding classes, and the renderer validates its shaders by
+  exporting them as WebGL2 GLSL ES 3.00.
+- gfx/engine/render: expose compute and indirect-draw support as runtime device
+  capabilities and use them for optional engine features. WebGL-only context
+  affinity and upload mechanics remain private target-specific implementation
+  details.
+  - breaking: `Capabilities` gained `compute` and `indirect_draw` fields.
+- render/gles: keep WebGL contexts thread-affine. The engine runs GPU asset
+  tasks inline on the context's owning thread.
 - gles: `sync_buffer` takes a `BufferTarget` argument naming the buffer's
   binding class (`Data` or `Index`). WebGL2 permanently assigns a buffer to
   the element-array class or the general data class on its first bind, so the

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,8 @@ Blade-graphics can run on:
 - Android (OpenXR/Vulkan)
 - Web (WebGL2)
 
-The full-stack Blade Engine can only run on Vulkan with hardware Ray Tracing support.
+The full-stack Blade Engine supports its rasterizer on WebGL2. The ray-traced
+renderer remains available only on backends and devices with ray-query support.
 
 ## Research
 

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -13,7 +13,6 @@ use std::slice;
 #[allow(dead_code)]
 #[path = "../examples/bunnymark/example.rs"]
 mod bunnymark_example;
-#[cfg(not(gles))]
 mod pbr_scene;
 #[cfg(not(gles))]
 #[path = "../examples/ray-query/example.rs"]
@@ -21,7 +20,6 @@ mod ray_query_example;
 mod snapshot;
 
 /// Directory with the renderer shaders, needed by the asset hub.
-#[cfg(not(gles))]
 const SHADER_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/blade-render/code");
 
 // --- Sky snapshot test structs ---
@@ -809,7 +807,6 @@ const CANONICAL_FRAMES: usize = 32;
 #[cfg(not(gles))]
 const CANONICAL_MAX_DIFFERENCE: f64 = 12.0;
 
-#[cfg(not(gles))]
 struct PbrHarness {
     context: std::sync::Arc<gpu::Context>,
     choir: std::sync::Arc<choir::Choir>,
@@ -818,15 +815,17 @@ struct PbrHarness {
     shaders: blade_render::Shaders,
 }
 
-#[cfg(not(gles))]
 impl PbrHarness {
     /// Bring up the asset hub and cook the renderer shaders.
     fn new(context: gpu::Context, cache_name: &str, ray_tracing: bool) -> Self {
         let context = std::sync::Arc::new(context);
         let choir = choir::Choir::new();
+        #[cfg(not(any(gles, target_arch = "wasm32")))]
         let workers = (0..2)
             .map(|i| choir.add_worker(&format!("{cache_name}-{i}")))
-            .collect();
+            .collect::<Vec<_>>();
+        #[cfg(any(gles, target_arch = "wasm32"))]
+        let workers = Vec::new();
         let cache_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("target")
             .join("test-assets")
@@ -834,7 +833,11 @@ impl PbrHarness {
         let asset_hub = blade_render::AssetHub::new(&cache_path, &choir, &context);
         let (shaders, shader_task) =
             blade_render::Shaders::load(SHADER_DIR.as_ref(), &asset_hub, ray_tracing);
-        shader_task.join();
+        if workers.is_empty() {
+            shader_task.join_active();
+        } else {
+            shader_task.join();
+        }
         Self {
             context,
             choir,
@@ -867,7 +870,6 @@ impl PbrHarness {
 
 /// Rasterize a grid of spheres covering the metallic-roughness space,
 /// plus a row of emissive materials.
-#[cfg(not(gles))]
 #[test]
 #[ignore = "requires a working GPU context"]
 fn snapshot_pbr_raster() {
@@ -1699,7 +1701,6 @@ fn gbuffer_views_describe_the_rendered_frame() {
 }
 
 /// Cook and serve a glTF model, checking that the PBR factors survive the trip.
-#[cfg(not(gles))]
 #[test]
 #[ignore = "requires a working GPU context"]
 fn gltf_material_test() {
@@ -1719,7 +1720,11 @@ fn gltf_material_test() {
             front_face: blade_render::model::FrontFace::CounterClockwise,
         },
     );
-    task.clone().join();
+    if harness.workers.is_empty() {
+        task.join_active();
+    } else {
+        task.join();
+    }
 
     // The uploads have to be flushed before the buffers can be destroyed.
     let mut command_encoder = context.create_command_encoder(gpu::CommandEncoderDesc {

--- a/tests/parse_shaders.rs
+++ b/tests/parse_shaders.rs
@@ -104,3 +104,82 @@ fn parse_wgsl() {
         }
     }
 }
+
+/// Keep the portable renderer within the GLSL ES 3.00 feature set exposed by
+/// WebGL2. WGSL validation alone does not catch backend-only resources such as
+/// shader-storage buffers.
+#[test]
+fn raster_exports_to_webgl2() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let shader_dir = root.join("blade-render").join("code");
+    let shader_raw = fs::read(shader_dir.join("raster.wgsl")).unwrap();
+    let cooker = blade_asset::Cooker::new(&shader_dir, Default::default());
+    let source = blade_render::shader::parse_shader(&shader_raw, &cooker, &HashMap::new());
+    let mut module =
+        wgsl::parse_str(&source).unwrap_or_else(|e| panic!("{}", e.emit_to_string(&source)));
+    let info = Validator::new(
+        naga::valid::ValidationFlags::all() ^ naga::valid::ValidationFlags::BINDINGS,
+        naga::valid::Capabilities::empty(),
+    )
+    .validate(&module)
+    .unwrap();
+
+    let vertex_ep_index = module
+        .entry_points
+        .iter()
+        .position(|ep| ep.name == "raster_vs")
+        .unwrap();
+    let vertex_ty = module.entry_points[vertex_ep_index].function.arguments[0].ty;
+    let mut ty = module.types[vertex_ty].clone();
+    let naga::TypeInner::Struct {
+        ref mut members, ..
+    } = ty.inner
+    else {
+        panic!("raster vertex input is not a struct");
+    };
+    for (location, member) in members.iter_mut().enumerate() {
+        member.binding = Some(naga::Binding::Location {
+            location: location as u32,
+            interpolation: None,
+            sampling: None,
+            blend_src: None,
+            per_primitive: false,
+        });
+    }
+    module.types.replace(vertex_ty, ty);
+
+    for entry_point in ["raster_vs", "raster_fs"] {
+        let stage = module
+            .entry_points
+            .iter()
+            .find(|ep| ep.name == entry_point)
+            .unwrap()
+            .stage;
+        let options = naga::back::glsl::Options {
+            version: naga::back::glsl::Version::Embedded {
+                version: 300,
+                is_webgl: true,
+            },
+            writer_flags: naga::back::glsl::WriterFlags::ADJUST_COORDINATE_SPACE,
+            binding_map: Default::default(),
+            zero_initialize_workgroup_memory: false,
+        };
+        let pipeline_options = naga::back::glsl::PipelineOptions {
+            shader_stage: stage,
+            entry_point: entry_point.to_string(),
+            multiview: None,
+        };
+        let mut glsl = String::new();
+        let mut writer = naga::back::glsl::Writer::new(
+            &mut glsl,
+            &module,
+            &info,
+            &options,
+            &pipeline_options,
+            Default::default(),
+        )
+        .unwrap();
+        writer.write().unwrap();
+        assert!(glsl.starts_with("#version 300 es"));
+    }
+}

--- a/tests/pbr_scene.rs
+++ b/tests/pbr_scene.rs
@@ -3,7 +3,6 @@
 //! The columns vary the roughness, the rows vary the metalness,
 //! and the last row is emissive. Both the rasterizer and the ray tracer
 //! render it, so their results can be compared side by side.
-#![cfg(not(gles))]
 #![allow(dead_code)]
 
 use std::f32::consts::PI;

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -187,11 +187,13 @@ fn compute_ssim(a: &[u8], b: &[u8], width: usize, height: usize) -> f64 {
 }
 
 /// Read a reference image, for cross-checking two renderers against each other.
+#[allow(dead_code)]
 pub fn load(name: &str) -> (Vec<u8>, gpu::Extent) {
     load_reference(&Path::new(REFERENCE_DIR).join(format!("{name}.png")))
 }
 
 /// Mean absolute difference of the color channels, in 0..255 units.
+#[allow(dead_code)]
 pub fn mean_abs_diff(a: &[u8], b: &[u8]) -> f64 {
     assert_eq!(a.len(), b.len());
     let mut sum = 0.0;


### PR DESCRIPTION
Needed by [kvark/redline](https://github.com/kvark/redline) so the game can ship a WebGL2/WASM build to GitHub Pages.

- Rasterizer, asset hub, and `blade-engine` compile for `wasm32-unknown-unknown` (and GLES)
- In-memory asset VFS (`blade_asset::vfs`) so cooking works without a filesystem
- Choir runs on the main thread; no extra workers on WASM
- Model textures cook as uncompressed RGBA8 (no BC) on GLES/WebGL
- Ray tracing stays native-only

`cargo check -p blade-engine --target wasm32-unknown-unknown` and native `cargo check -p blade-engine` both pass.