### PR TITLE
Match GLSL ES uniform block names across shader stages

### DIFF
--- a/blade-egui/shader.wgsl
+++ b/blade-egui/shader.wgsl
@@ -11,15 +11,13 @@ struct Uniforms {
 };
 var<uniform> r_uniforms: Uniforms;
 
-//Note: avoiding `vec2<f32>` in order to keep the scalar alignment
+// Matches epaint::Vertex (pos, uv, color) so we can fetch from a vertex buffer
+// instead of a storage buffer — WebGL2 has no SSBOs.
 struct Vertex {
-    pos_x: f32,
-    pos_y: f32,
-    tex_coord_x: f32,
-    tex_coord_y: f32,
+    pos: vec2<f32>,
+    uv: vec2<f32>,
     color: u32,
 }
-var<storage, read> r_vertex_data: array<Vertex>;
 
 fn linear_from_gamma(srgb: vec3<f32>) -> vec3<f32> {
     let cutoff = srgb < vec3<f32>(0.04045);
@@ -29,16 +27,13 @@ fn linear_from_gamma(srgb: vec3<f32>) -> vec3<f32> {
 }
 
 @vertex
-fn vs_main(
-    @builtin(vertex_index) v_index: u32,
-) -> VertexOutput {
-    let input = r_vertex_data[v_index];
+fn vs_main(input: Vertex) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = vec2<f32>(input.tex_coord_x, input.tex_coord_y);
+    out.tex_coord = input.uv;
     out.color = unpack4x8unorm(input.color);
     out.position = vec4<f32>(
-        2.0 * input.pos_x / r_uniforms.screen_size.x - 1.0,
-        1.0 - 2.0 * input.pos_y / r_uniforms.screen_size.y,
+        2.0 * input.pos.x / r_uniforms.screen_size.x - 1.0,
+        1.0 - 2.0 * input.pos.y / r_uniforms.screen_size.y,
         0.0,
         1.0,
     );

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -32,10 +32,19 @@ struct Globals {
 
 #[derive(blade_macros::ShaderData)]
 struct Locals {
-    r_vertex_data: blade_graphics::BufferPiece,
     r_texture: blade_graphics::TextureView,
     r_sampler: blade_graphics::Sampler,
 }
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, blade_macros::Vertex)]
+struct GuiVertex {
+    pos: [f32; 2],
+    uv: [f32; 2],
+    color: u32,
+}
+
+const _: () = assert!(size_of::<GuiVertex>() == size_of::<egui::epaint::Vertex>());
 
 #[derive(Debug, PartialEq)]
 pub struct ScreenDescriptor {
@@ -171,11 +180,15 @@ impl GuiPainter {
         });
         let globals_layout = <Globals as blade_graphics::ShaderData>::layout();
         let locals_layout = <Locals as blade_graphics::ShaderData>::layout();
+        let vertex_layout = <GuiVertex as blade_graphics::Vertex>::layout();
         let pipeline = context.create_render_pipeline(blade_graphics::RenderPipelineDesc {
             name: "gui",
             data_layouts: &[&globals_layout, &locals_layout],
             vertex: shader.at("vs_main"),
-            vertex_fetches: &[],
+            vertex_fetches: &[blade_graphics::VertexFetchState {
+                layout: &vertex_layout,
+                instanced: false,
+            }],
             primitive: blade_graphics::PrimitiveState {
                 topology: blade_graphics::PrimitiveTopology::TriangleList,
                 ..Default::default()
@@ -365,11 +378,11 @@ impl GuiPainter {
                 pc.bind(
                     1,
                     &Locals {
-                        r_vertex_data: vertex_buf,
                         r_texture: texture.view,
                         r_sampler: texture.sampler,
                     },
                 );
+                pc.bind_vertex(0, vertex_buf);
 
                 pc.draw_indexed(
                     index_buf,

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -18,26 +18,36 @@ fn conflate<T: PartialEq>(iter: impl Iterator<Item = T> + Clone) -> Box<[T]> {
     }
 }
 
-/// Naga names each UBO `{Type}_block_{id}{Stage}` independently per entry point.
-/// GLSL ES 3.00 / WebGL2 then fails to link when VS and FS expose the same field
-/// (`frame_params`) from two differently named blocks. Drop the stage suffix so
-/// matching structs share a block name. ES 3.20 uses `layout(binding=N)` instead
-/// and does not need this.
-fn strip_stage_from_uniform_block_names(
+/// WebGL2 / GLSL ES 3.00 links uniform blocks by name. Naga's GLSL backend
+/// names each block independently per entry point, so the same IR global
+/// becomes two different identifiers in VS and FS and the program fails to
+/// link ("Ambiguous field 'frame_params' in blocks … which don't have
+/// instance names").
+///
+/// [`glsl::ReflectionInfo::uniforms`] already maps each IR global to the
+/// identifier naga actually wrote. Rename those identifiers to a stable name
+/// taken from the global itself so both stages agree. The generated string is
+/// treated as opaque; we do not parse naga's `{Type}_block_{id}{Stage}` format.
+fn unify_uniform_block_names(
     source: &mut String,
     reflection: &mut glsl::ReflectionInfo,
+    module: &naga::Module,
 ) {
-    for name in reflection.uniforms.values_mut() {
-        let stripped = name
-            .strip_suffix("Vertex")
-            .or_else(|| name.strip_suffix("Fragment"))
-            .or_else(|| name.strip_suffix("Compute"));
-        let Some(stripped) = stripped else {
+    for (&handle, glsl_name) in reflection.uniforms.iter_mut() {
+        let Some(ref var_name) = module.global_variables[handle].name else {
             continue;
         };
-        let stripped = stripped.to_string();
-        *source = source.replace(name.as_str(), &stripped);
-        *name = stripped;
+        // Block name and member name live in different GLSL namespaces, but
+        // keep a `_block` suffix so a `glGetUniformBlockIndex` query cannot
+        // be confused with the member that occupies the global scope of an
+        // unnamed block. Trim a trailing `_` so we don't emit `__`, which is
+        // reserved in GLSL.
+        let block_name = format!("{}_block", var_name.trim_end_matches('_'));
+        if glsl_name.as_str() == block_name {
+            continue;
+        }
+        *source = source.replacen(glsl_name.as_str(), &block_name, 1);
+        *glsl_name = block_name;
     }
 }
 
@@ -196,7 +206,7 @@ impl super::Context {
                 .unwrap();
                 let mut reflection = writer.write().unwrap();
                 if !force_explicit_bindings {
-                    strip_stage_from_uniform_block_names(&mut source, &mut reflection);
+                    unify_uniform_block_names(&mut source, &mut reflection, &module);
                 }
 
                 log::debug!(

--- a/blade-graphics/src/gles/pipeline.rs
+++ b/blade-graphics/src/gles/pipeline.rs
@@ -18,6 +18,29 @@ fn conflate<T: PartialEq>(iter: impl Iterator<Item = T> + Clone) -> Box<[T]> {
     }
 }
 
+/// Naga names each UBO `{Type}_block_{id}{Stage}` independently per entry point.
+/// GLSL ES 3.00 / WebGL2 then fails to link when VS and FS expose the same field
+/// (`frame_params`) from two differently named blocks. Drop the stage suffix so
+/// matching structs share a block name. ES 3.20 uses `layout(binding=N)` instead
+/// and does not need this.
+fn strip_stage_from_uniform_block_names(
+    source: &mut String,
+    reflection: &mut glsl::ReflectionInfo,
+) {
+    for name in reflection.uniforms.values_mut() {
+        let stripped = name
+            .strip_suffix("Vertex")
+            .or_else(|| name.strip_suffix("Fragment"))
+            .or_else(|| name.strip_suffix("Compute"));
+        let Some(stripped) = stripped else {
+            continue;
+        };
+        let stripped = stripped.to_string();
+        *source = source.replace(name.as_str(), &stripped);
+        *name = stripped;
+    }
+}
+
 impl super::Context {
     unsafe fn create_pipeline(
         &self,
@@ -171,7 +194,10 @@ impl super::Context {
                     Default::default(),
                 )
                 .unwrap();
-                let reflection = writer.write().unwrap();
+                let mut reflection = writer.write().unwrap();
+                if !force_explicit_bindings {
+                    strip_stage_from_uniform_block_names(&mut source, &mut reflection);
+                }
 
                 log::debug!(
                     "Naga generated shader for entry point '{}' and stage {:?}\n{}",

--- a/tests/parse_shaders.rs
+++ b/tests/parse_shaders.rs
@@ -148,6 +148,7 @@ fn raster_exports_to_webgl2() {
     }
     module.types.replace(vertex_ty, ty);
 
+    let mut stage_blocks: Vec<Vec<String>> = Vec::new();
     for entry_point in ["raster_vs", "raster_fs"] {
         let stage = module
             .entry_points
@@ -179,7 +180,27 @@ fn raster_exports_to_webgl2() {
             Default::default(),
         )
         .unwrap();
-        writer.write().unwrap();
+        let mut reflection = writer.write().unwrap();
+        // Mirror blade-graphics GLES ES 3.00: drop Naga's per-stage UBO suffix
+        // so VS/FS share a block name. WebGL2 will not link otherwise.
+        for name in reflection.uniforms.values_mut() {
+            let stripped = name
+                .strip_suffix("Vertex")
+                .or_else(|| name.strip_suffix("Fragment"))
+                .or_else(|| name.strip_suffix("Compute"));
+            if let Some(stripped) = stripped {
+                let stripped = stripped.to_string();
+                glsl = glsl.replace(name.as_str(), &stripped);
+                *name = stripped;
+            }
+        }
         assert!(glsl.starts_with("#version 300 es"));
+        let mut blocks: Vec<String> = reflection.uniforms.values().cloned().collect();
+        blocks.sort();
+        stage_blocks.push(blocks);
     }
+    assert_eq!(
+        stage_blocks[0], stage_blocks[1],
+        "WebGL2 requires matching uniform block names in vertex and fragment shaders"
+    );
 }

--- a/tests/parse_shaders.rs
+++ b/tests/parse_shaders.rs
@@ -181,20 +181,16 @@ fn raster_exports_to_webgl2() {
         )
         .unwrap();
         let mut reflection = writer.write().unwrap();
-        // Mirror blade-graphics GLES ES 3.00: drop Naga's per-stage UBO suffix
-        // so VS/FS share a block name. WebGL2 will not link otherwise.
-        for name in reflection.uniforms.values_mut() {
-            let stripped = name
-                .strip_suffix("Vertex")
-                .or_else(|| name.strip_suffix("Fragment"))
-                .or_else(|| name.strip_suffix("Compute"));
-            if let Some(stripped) = stripped {
-                let stripped = stripped.to_string();
-                glsl = glsl.replace(name.as_str(), &stripped);
-                *name = stripped;
-            }
-        }
+        unify_uniform_block_names(&mut glsl, &mut reflection, &module);
         assert!(glsl.starts_with("#version 300 es"));
+        for (&handle, glsl_name) in reflection.uniforms.iter() {
+            let var_name = module.global_variables[handle].name.as_deref().unwrap();
+            assert_eq!(
+                glsl_name.as_str(),
+                format!("{}_block", var_name.trim_end_matches('_')),
+                "block name for '{var_name}' should come from the IR global, not naga's generated identifier"
+            );
+        }
         let mut blocks: Vec<String> = reflection.uniforms.values().cloned().collect();
         blocks.sort();
         stage_blocks.push(blocks);
@@ -203,4 +199,24 @@ fn raster_exports_to_webgl2() {
         stage_blocks[0], stage_blocks[1],
         "WebGL2 requires matching uniform block names in vertex and fragment shaders"
     );
+}
+
+/// Mirrors `blade_graphics` GLES `unify_uniform_block_names`: treat naga's
+/// generated identifier as opaque and replace it with a name taken from the
+/// IR global that `ReflectionInfo::uniforms` points at.
+fn unify_uniform_block_names(
+    glsl: &mut String,
+    reflection: &mut naga::back::glsl::ReflectionInfo,
+    module: &naga::Module,
+) {
+    for (&handle, glsl_name) in reflection.uniforms.iter_mut() {
+        let Some(ref var_name) = module.global_variables[handle].name else {
+            continue;
+        };
+        let block_name = format!("{}_block", var_name.trim_end_matches('_'));
+        if glsl_name.as_str() != block_name {
+            *glsl = glsl.replacen(glsl_name.as_str(), &block_name, 1);
+            *glsl_name = block_name;
+        }
+    }
 }


### PR DESCRIPTION
WebGL2 refuses to link the raster pipeline:

```
Link: Ambiguous field 'frame_params' in blocks
'RasterFrameParams_block_0Fragment' (VERTEX shader) and
'RasterFrameParams_block_0Vertex' (FRAGMENT shader)
which don't have instance names.
```

Naga names each uniform block independently per entry point. `ReflectionInfo::uniforms` already maps the IR global to the identifier it wrote — treat that string as opaque, look up the WGSL global, and rename the block to `{name}_block` so VS and FS agree. ES 3.20 keeps `layout(binding=N)` and does not need this.

`raster_exports_to_webgl2` checks that the rewritten names match the IR globals and match across stages.