### PR TITLE
Add raster point lights and window-path particles

### DIFF
--- a/blade-engine/src/lib.rs
+++ b/blade-engine/src/lib.rs
@@ -494,7 +494,8 @@ pub struct Engine {
     choir: Arc<choir::Choir>,
     data_path: String,
     time_ahead: f32,
-    last_dt: f32,
+    particle_clock: f32,
+    last_particle_clock: f32,
 }
 
 impl Engine {
@@ -785,7 +786,8 @@ impl Engine {
             choir,
             data_path: config.data_path.clone(),
             time_ahead: 0.0,
-            last_dt: 0.016,
+            particle_clock: 0.0,
+            last_particle_clock: 0.0,
         }
     }
 
@@ -819,7 +821,7 @@ impl Engine {
     #[profiling::function]
     pub fn update(&mut self, dt: f32) {
         self.choir.check_panic();
-        self.last_dt = dt;
+        self.particle_clock += dt;
         self.time_ahead += dt;
         while self.time_ahead >= self.physics.integration_params.dt {
             self.physics.step();
@@ -878,6 +880,12 @@ impl Engine {
         }
     }
 
+    fn take_particle_dt(&mut self) -> f32 {
+        let dt = (self.particle_clock - self.last_particle_clock).clamp(0.0, 0.05);
+        self.last_particle_clock = self.particle_clock;
+        dt
+    }
+
     /// Drain contact events from the last physics update.
     pub fn drain_contacts(&mut self) -> impl Iterator<Item = ContactEvent> + '_ {
         self.contact_events.drain(..)
@@ -913,7 +921,8 @@ impl Engine {
             ..
         } = self.renderer
         {
-            raster_config.point_lights = lights.to_vec();
+            raster_config.point_lights.clear();
+            raster_config.point_lights.extend_from_slice(lights);
         }
     }
 
@@ -927,6 +936,7 @@ impl Engine {
         physical_size: winit::dpi::PhysicalSize<u32>,
         scale_factor: f32,
     ) {
+        let particle_dt = self.take_particle_dt();
         self.hot_reload_if_needed();
 
         // Note: the resize is split in 2 parts because `wait_for_previous_frame`
@@ -1023,10 +1033,11 @@ impl Engine {
             }
         }
 
-        if let Some(ref pipeline) = self.particle_pipeline {
-            let dt = self.last_dt.clamp(0.001, 0.05);
+        if particle_dt > 0.0
+            && let Some(ref pipeline) = self.particle_pipeline
+        {
             for (_, system) in self.particle_systems.iter_mut() {
-                system.update(pipeline, command_encoder, dt);
+                system.update(pipeline, command_encoder, particle_dt);
             }
         }
 
@@ -1137,7 +1148,7 @@ impl Engine {
                         &render_camera,
                         &self.render_objects,
                         &self.asset_hub,
-                        raster_config.clone(),
+                        raster_config,
                     );
                 }
                 command_encoder.init_texture(inner.depth_texture());
@@ -1163,7 +1174,7 @@ impl Engine {
                             &self.render_objects,
                             &self.asset_hub,
                             self.environment_map,
-                            raster_config.clone(),
+                            raster_config,
                         );
                         if let Some(ref pipeline) = self.particle_pipeline {
                             let target_size = gpu::Extent {
@@ -1222,6 +1233,7 @@ impl Engine {
     /// rendered (for example while transitioning session state).
     #[profiling::function]
     pub fn render_xr(&mut self) -> bool {
+        let particle_dt = self.take_particle_dt();
         self.hot_reload_if_needed();
 
         let xr_surface = match self.target_surface {
@@ -1266,9 +1278,11 @@ impl Engine {
         }
 
         // Update particle systems (compute passes)
-        if let Some(ref pipeline) = self.particle_pipeline {
+        if particle_dt > 0.0
+            && let Some(ref pipeline) = self.particle_pipeline
+        {
             for (_, system) in self.particle_systems.iter_mut() {
-                system.update(pipeline, command_encoder, 0.016);
+                system.update(pipeline, command_encoder, particle_dt);
             }
         }
 
@@ -1381,7 +1395,7 @@ impl Engine {
                             &render_camera,
                             &self.render_objects,
                             &self.asset_hub,
-                            raster_config.clone(),
+                            raster_config,
                         );
                     }
                     if let mut pass = command_encoder.render(
@@ -1406,7 +1420,7 @@ impl Engine {
                                 &self.render_objects,
                                 &self.asset_hub,
                                 self.environment_map,
-                                raster_config.clone(),
+                                raster_config,
                             );
                         }
                         inner.render_debug_lines(

--- a/blade-engine/src/lib.rs
+++ b/blade-engine/src/lib.rs
@@ -494,6 +494,7 @@ pub struct Engine {
     choir: Arc<choir::Choir>,
     data_path: String,
     time_ahead: f32,
+    last_dt: f32,
 }
 
 impl Engine {
@@ -784,6 +785,7 @@ impl Engine {
             choir,
             data_path: config.data_path.clone(),
             time_ahead: 0.0,
+            last_dt: 0.016,
         }
     }
 
@@ -817,6 +819,7 @@ impl Engine {
     #[profiling::function]
     pub fn update(&mut self, dt: f32) {
         self.choir.check_panic();
+        self.last_dt = dt;
         self.time_ahead += dt;
         while self.time_ahead >= self.physics.integration_params.dt {
             self.physics.step();
@@ -897,6 +900,31 @@ impl Engine {
                 }
             }
             *raster_config = config;
+        }
+    }
+
+    /// Replace the local lights used by the raster forward pass.
+    ///
+    /// The fragment shader evaluates at most `MAX_POINT_LIGHTS` of these and
+    /// shades with the most promising one (with a stochastic alternative).
+    pub fn set_point_lights(&mut self, lights: &[blade_render::PointLight]) {
+        if let Renderer::Rasterizer {
+            ref mut raster_config,
+            ..
+        } = self.renderer
+        {
+            raster_config.point_lights =
+                [blade_render::PointLight::default(); blade_render::MAX_POINT_LIGHTS];
+            raster_config.point_light_count =
+                lights.len().min(blade_render::MAX_POINT_LIGHTS) as u32;
+            for (slot, light) in raster_config
+                .point_lights
+                .iter_mut()
+                .zip(lights.iter())
+                .take(blade_render::MAX_POINT_LIGHTS)
+            {
+                *slot = *light;
+            }
         }
     }
 
@@ -1003,6 +1031,13 @@ impl Engine {
                         denoiser_enabled.then_some(*denoiser_config),
                     );
                 }
+            }
+        }
+
+        if let Some(ref pipeline) = self.particle_pipeline {
+            let dt = self.last_dt.clamp(0.001, 0.05);
+            for (_, system) in self.particle_systems.iter_mut() {
+                system.update(pipeline, command_encoder, dt);
             }
         }
 
@@ -1131,16 +1166,29 @@ impl Engine {
                             finish_op: gpu::FinishOp::Store,
                         }),
                     },
-                ) && can_render
-                {
-                    inner.render(
-                        &mut pass,
-                        &render_camera,
-                        &self.render_objects,
-                        &self.asset_hub,
-                        self.environment_map,
-                        *raster_config,
-                    );
+                ) {
+                    if can_render {
+                        inner.render(
+                            &mut pass,
+                            &render_camera,
+                            &self.render_objects,
+                            &self.asset_hub,
+                            self.environment_map,
+                            *raster_config,
+                        );
+                        if let Some(ref pipeline) = self.particle_pipeline {
+                            let target_size = gpu::Extent {
+                                width: physical_size.width,
+                                height: physical_size.height,
+                                depth: 1,
+                            };
+                            let particle_camera =
+                                Self::make_particle_camera(&render_camera, target_size);
+                            for (_, system) in self.particle_systems.iter() {
+                                system.draw(pipeline, &mut pass, &particle_camera);
+                            }
+                        }
+                    }
                 }
 
                 // GUI is a dev-only overlay, so a separate pass keeps the raster path simpler.

--- a/blade-engine/src/lib.rs
+++ b/blade-engine/src/lib.rs
@@ -905,26 +905,15 @@ impl Engine {
 
     /// Replace the local lights used by the raster forward pass.
     ///
-    /// The fragment shader evaluates at most `MAX_POINT_LIGHTS` of these and
-    /// shades with the most promising one (with a stochastic alternative).
+    /// The fragment shader samples one of up to `MAX_POINT_LIGHTS` of these
+    /// with probability proportional to a local score.
     pub fn set_point_lights(&mut self, lights: &[blade_render::PointLight]) {
         if let Renderer::Rasterizer {
             ref mut raster_config,
             ..
         } = self.renderer
         {
-            raster_config.point_lights =
-                [blade_render::PointLight::default(); blade_render::MAX_POINT_LIGHTS];
-            raster_config.point_light_count =
-                lights.len().min(blade_render::MAX_POINT_LIGHTS) as u32;
-            for (slot, light) in raster_config
-                .point_lights
-                .iter_mut()
-                .zip(lights.iter())
-                .take(blade_render::MAX_POINT_LIGHTS)
-            {
-                *slot = *light;
-            }
+            raster_config.point_lights = lights.to_vec();
         }
     }
 
@@ -1148,7 +1137,7 @@ impl Engine {
                         &render_camera,
                         &self.render_objects,
                         &self.asset_hub,
-                        *raster_config,
+                        raster_config.clone(),
                     );
                 }
                 command_encoder.init_texture(inner.depth_texture());
@@ -1174,7 +1163,7 @@ impl Engine {
                             &self.render_objects,
                             &self.asset_hub,
                             self.environment_map,
-                            *raster_config,
+                            raster_config.clone(),
                         );
                         if let Some(ref pipeline) = self.particle_pipeline {
                             let target_size = gpu::Extent {
@@ -1362,7 +1351,7 @@ impl Engine {
             }
             Renderer::Rasterizer {
                 ref mut inner,
-                raster_config,
+                ref raster_config,
             } => {
                 command_encoder.init_texture(inner.depth_texture());
                 for eye in 0..view_count {
@@ -1392,7 +1381,7 @@ impl Engine {
                             &render_camera,
                             &self.render_objects,
                             &self.asset_hub,
-                            raster_config,
+                            raster_config.clone(),
                         );
                     }
                     if let mut pass = command_encoder.render(
@@ -1417,7 +1406,7 @@ impl Engine {
                                 &self.render_objects,
                                 &self.asset_hub,
                                 self.environment_map,
-                                raster_config,
+                                raster_config.clone(),
                             );
                         }
                         inner.render_debug_lines(

--- a/blade-render/code/raster.wgsl
+++ b/blade-render/code/raster.wgsl
@@ -1,9 +1,17 @@
 #include "brdf.inc.wgsl"
 #include "color.inc.wgsl"
 
+#use MAX_POINT_LIGHTS
+
 struct PointLight {
     pos_radius: vec4<f32>,
     color: vec4<f32>,
+}
+
+struct PointLightParams {
+    // x: submitted light count, y: stochastic seed
+    count_seed: vec4<f32>,
+    lights: array<PointLight, MAX_POINT_LIGHTS>,
 }
 
 struct RasterFrameParams {
@@ -17,11 +25,9 @@ struct RasterFrameParams {
     // w component is a flag for the procedural space sky
     ambient_color: vec4<f32>,
     // x: environment map enabled, y: the surface needs sRGB encoding
-    // z: point light count, w: stochastic seed
     settings: vec4<f32>,
     // x: enabled, y: strength, z: receiver normal bias, w: texel size
     shadow_params: vec4<f32>,
-    point_lights: array<PointLight, 8>,
 }
 
 struct RasterDrawParams {
@@ -59,6 +65,7 @@ struct VertexOutput {
 }
 
 var<uniform> frame_params: RasterFrameParams;
+var<uniform> light_params: PointLightParams;
 var<uniform> draw_params: RasterDrawParams;
 var samp: sampler;
 var base_color_tex: texture_2d<f32>;
@@ -96,6 +103,9 @@ fn raster_vs(input: Vertex) -> VertexOutput {
     let pos_world = draw_params.model * vec4<f32>(input.position, 1.0);
     out.clip_pos = frame_params.view_proj * pos_world;
     out.world_pos = pos_world.xyz;
+    // GLES 3.00 requires matching uniform blocks in vs+fs. The multiply is
+    // zero, so lighting does not leak into the vertex stage.
+    out.world_pos.x += light_params.count_seed.x * 0.0;
     let n = normalize(quat_rotate(draw_params.normal_quat, decode_normal(input.normal)));
     let t = normalize(quat_rotate(draw_params.normal_quat, decode_normal(input.tangent)));
     let b = normalize(cross(n, t)) * input.bitangent_sign;
@@ -153,45 +163,35 @@ fn point_light_score(light: PointLight, world_pos: vec3<f32>, n: vec3<f32>) -> f
 }
 
 fn shade_point_light(mat: Material, n: vec3<f32>, v: vec3<f32>, world_pos: vec3<f32>) -> vec3<f32> {
-    let count = u32(frame_params.settings.z);
+    let count = min(u32(light_params.count_seed.x), MAX_POINT_LIGHTS);
     if (count == 0u) {
         return vec3<f32>(0.0);
     }
 
-    var scores: array<f32, 8>;
-    var best_i = 0u;
-    var best_score = 0.0;
-    var sum_score = 0.0;
-    for (var i = 0u; i < 8u; i++) {
+    // Weighted reservoir over the submitted lights. Each fragment independently
+    // samples one light with probability proportional to its local score.
+    // TODO: spatial acceleration once scenes carry more local lights than this cap.
+    var chosen = 0u;
+    var weight_sum = 0.0;
+    for (var i = 0u; i < MAX_POINT_LIGHTS; i++) {
         if (i >= count) {
-            scores[i] = 0.0;
+            break;
+        }
+        let score = point_light_score(light_params.lights[i], world_pos, n);
+        if (score <= 0.0) {
             continue;
         }
-        let score = point_light_score(frame_params.point_lights[i], world_pos, n);
-        scores[i] = score;
-        sum_score += score;
-        if (score > best_score) {
-            best_score = score;
-            best_i = i;
+        weight_sum += score;
+        let u = hash31(world_pos + vec3<f32>(f32(i), light_params.count_seed.y, score));
+        if (u * weight_sum < score) {
+            chosen = i;
         }
     }
-
-    var chosen = best_i;
-    // Most fragments take the winner. A minority pick weighted-random so a
-    // second nearby crystal still contributes without an 8-light inner loop.
-    if (sum_score > 1e-5 && hash31(world_pos + frame_params.settings.w) > 0.72) {
-        var acc = 0.0;
-        let pick = hash31(world_pos * 3.1 + frame_params.settings.www) * sum_score;
-        for (var i = 0u; i < count; i++) {
-            acc += scores[i];
-            if (pick <= acc) {
-                chosen = i;
-                break;
-            }
-        }
+    if (weight_sum <= 0.0) {
+        return vec3<f32>(0.0);
     }
 
-    let light = frame_params.point_lights[chosen];
+    let light = light_params.lights[chosen];
     let delta = light.pos_radius.xyz - world_pos;
     let dist2 = max(dot(delta, delta), 0.04);
     let dist = sqrt(dist2);

--- a/blade-render/code/raster.wgsl
+++ b/blade-render/code/raster.wgsl
@@ -1,6 +1,11 @@
 #include "brdf.inc.wgsl"
 #include "color.inc.wgsl"
 
+struct PointLight {
+    pos_radius: vec4<f32>,
+    color: vec4<f32>,
+}
+
 struct RasterFrameParams {
     view_proj: mat4x4<f32>,
     inv_view_proj: mat4x4<f32>,
@@ -12,9 +17,11 @@ struct RasterFrameParams {
     // w component is a flag for the procedural space sky
     ambient_color: vec4<f32>,
     // x: environment map enabled, y: the surface needs sRGB encoding
+    // z: point light count, w: stochastic seed
     settings: vec4<f32>,
     // x: enabled, y: strength, z: receiver normal bias, w: texel size
     shadow_params: vec4<f32>,
+    point_lights: array<PointLight, 8>,
 }
 
 struct RasterDrawParams {
@@ -129,6 +136,73 @@ fn directional_shadow(world_pos: vec3<f32>, n: vec3<f32>) -> f32 {
     return mix(1.0, visibility, frame_params.shadow_params.y);
 }
 
+fn hash31(p: vec3<f32>) -> f32 {
+    return fract(sin(dot(p, vec3<f32>(127.1, 311.7, 74.7))) * 43758.5453);
+}
+
+fn point_light_score(light: PointLight, world_pos: vec3<f32>, n: vec3<f32>) -> f32 {
+    let delta = light.pos_radius.xyz - world_pos;
+    let dist2 = max(dot(delta, delta), 0.04);
+    let dist = sqrt(dist2);
+    let range = max(light.pos_radius.w, 0.01);
+    let falloff = max(1.0 - dist / range, 0.0);
+    let ldir = delta / dist;
+    let ndotl = max(dot(n, ldir), 0.0);
+    let intensity = max(light.color.x, max(light.color.y, light.color.z));
+    return intensity * falloff * falloff * (0.2 + 0.8 * ndotl);
+}
+
+fn shade_point_light(mat: Material, n: vec3<f32>, v: vec3<f32>, world_pos: vec3<f32>) -> vec3<f32> {
+    let count = u32(frame_params.settings.z);
+    if (count == 0u) {
+        return vec3<f32>(0.0);
+    }
+
+    var scores: array<f32, 8>;
+    var best_i = 0u;
+    var best_score = 0.0;
+    var sum_score = 0.0;
+    for (var i = 0u; i < 8u; i++) {
+        if (i >= count) {
+            scores[i] = 0.0;
+            continue;
+        }
+        let score = point_light_score(frame_params.point_lights[i], world_pos, n);
+        scores[i] = score;
+        sum_score += score;
+        if (score > best_score) {
+            best_score = score;
+            best_i = i;
+        }
+    }
+
+    var chosen = best_i;
+    // Most fragments take the winner. A minority pick weighted-random so a
+    // second nearby crystal still contributes without an 8-light inner loop.
+    if (sum_score > 1e-5 && hash31(world_pos + frame_params.settings.w) > 0.72) {
+        var acc = 0.0;
+        let pick = hash31(world_pos * 3.1 + frame_params.settings.www) * sum_score;
+        for (var i = 0u; i < count; i++) {
+            acc += scores[i];
+            if (pick <= acc) {
+                chosen = i;
+                break;
+            }
+        }
+    }
+
+    let light = frame_params.point_lights[chosen];
+    let delta = light.pos_radius.xyz - world_pos;
+    let dist2 = max(dot(delta, delta), 0.04);
+    let dist = sqrt(dist2);
+    let range = max(light.pos_radius.w, 0.01);
+    let falloff = max(1.0 - dist / range, 0.0);
+    let ldir = delta / dist;
+    let brdf = evaluate_brdf(mat, n, v, ldir);
+    let atten = falloff * falloff / dist2;
+    return (mat.diffuse_albedo * brdf.diffuse + brdf.specular) * light.color.xyz * atten;
+}
+
 @fragment
 fn raster_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     let mr_sample = textureSample(metallic_roughness_tex, samp, input.uv);
@@ -158,7 +232,8 @@ fn raster_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     let light = (mat.diffuse_albedo * brdf.diffuse + brdf.specular) * frame_params.light_color.xyz * visibility;
     let ambient = evaluate_ambient(mat) * frame_params.ambient_color.xyz;
     let emissive = draw_params.emissive_factor.rgb * textureSample(emissive_tex, samp, input.uv).rgb;
-    let color = ambient + light + emissive;
+    let local = shade_point_light(mat, n, v, input.world_pos);
+    let color = ambient + light + local + emissive;
 
     let mapped = color / (color + vec3<f32>(1.0));
     return vec4<f32>(encode_surface_color(mapped, frame_params.settings.y > 0.5), 1.0);

--- a/blade-render/src/asset_hub.rs
+++ b/blade-render/src/asset_hub.rs
@@ -35,6 +35,7 @@ impl AssetHub {
 
         let mut sh_baker = crate::shader::Baker::new(gpu_context);
         sh_baker.register_bool("DEBUG_MODE", cfg!(debug_assertions));
+        sh_baker.register_size("MAX_POINT_LIGHTS", crate::raster::MAX_POINT_LIGHTS as u32);
         sh_baker.register_enum::<crate::render::DebugMode>();
         sh_baker.register_bitflags::<crate::render::DebugDrawFlags>();
         sh_baker.register_bitflags::<crate::render::DebugTextureFlags>();

--- a/blade-render/src/lib.rs
+++ b/blade-render/src/lib.rs
@@ -30,7 +30,7 @@ mod render;
 
 pub use asset_hub::*;
 pub use model::{Model, ProceduralGeometry};
-pub use raster::{DirectionalShadowConfig, RasterConfig, Rasterizer};
+pub use raster::{DirectionalShadowConfig, MAX_POINT_LIGHTS, PointLight, RasterConfig, Rasterizer};
 pub use shader::Shader;
 pub use shaders::{RenderConfig, Shaders};
 pub use texture::Texture;

--- a/blade-render/src/raster/mod.rs
+++ b/blade-render/src/raster/mod.rs
@@ -2,6 +2,36 @@ use crate::{AssetHub, CameraParams, DummyResources, Object, RenderConfig, Shader
 use blade_graphics as gpu;
 use std::mem;
 
+/// Maximum local lights evaluated in the forward pass. The fragment shader
+/// picks one of these (highest score, with a stochastic alternative).
+pub const MAX_POINT_LIGHTS: usize = 8;
+
+/// A local omni light. Radius is a hard cutoff in world units.
+#[derive(Clone, Copy, Debug)]
+pub struct PointLight {
+    pub position: mint::Vector3<f32>,
+    pub color: mint::Vector3<f32>,
+    pub radius: f32,
+}
+
+impl Default for PointLight {
+    fn default() -> Self {
+        Self {
+            position: mint::Vector3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            color: mint::Vector3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            radius: 1.0,
+        }
+    }
+}
+
 /// Configuration of the rasterized frame.
 ///
 /// Note: the surface appearance is described by the materials of the
@@ -17,6 +47,10 @@ pub struct RasterConfig {
     pub space_sky: bool,
     /// Optional real-time directional shadow-map effect.
     pub directional_shadows: Option<DirectionalShadowConfig>,
+    /// Local lights considered by the forward pass. Only the first
+    /// `point_light_count` entries are used.
+    pub point_lights: [PointLight; MAX_POINT_LIGHTS],
+    pub point_light_count: u32,
 }
 
 /// Controls the rasterizer's camera-relative directional shadow map.
@@ -67,6 +101,8 @@ impl Default for RasterConfig {
             },
             space_sky: false,
             directional_shadows: None,
+            point_lights: [PointLight::default(); MAX_POINT_LIGHTS],
+            point_light_count: 0,
         }
     }
 }
@@ -83,6 +119,14 @@ struct RasterFrameParams {
     ambient_color: [f32; 4],
     settings: [f32; 4],
     shadow_params: [f32; 4],
+    point_lights: [PointLightGpu; MAX_POINT_LIGHTS],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+struct PointLightGpu {
+    pos_radius: [f32; 4],
+    color: [f32; 4],
 }
 
 #[repr(C)]
@@ -790,8 +834,8 @@ impl Rasterizer {
                 env_map_enabled as u32 as f32,
                 // the surface may expect us to encode the values ourselves
                 (self.color_space == gpu::ColorSpace::Srgb) as u32 as f32,
-                0.0,
-                0.0,
+                config.point_light_count.min(MAX_POINT_LIGHTS as u32) as f32,
+                pos.x + pos.y * 1.37 + pos.z * 9.17,
             ],
             shadow_params: [
                 config.directional_shadows.is_some() as u32 as f32,
@@ -799,8 +843,33 @@ impl Rasterizer {
                 shadow.normal_bias.max(0.0),
                 1.0 / self.shadow_size as f32,
             ],
+            point_lights: pack_point_lights(&config),
         }
     }
+}
+
+fn pack_point_lights(config: &RasterConfig) -> [PointLightGpu; MAX_POINT_LIGHTS] {
+    let mut lights = [PointLightGpu {
+        pos_radius: [0.0; 4],
+        color: [0.0; 4],
+    }; MAX_POINT_LIGHTS];
+    let count = (config.point_light_count as usize).min(MAX_POINT_LIGHTS);
+    for (slot, src) in lights
+        .iter_mut()
+        .zip(config.point_lights.iter())
+        .take(count)
+    {
+        *slot = PointLightGpu {
+            pos_radius: [
+                src.position.x,
+                src.position.y,
+                src.position.z,
+                src.radius.max(0.01),
+            ],
+            color: [src.color.x, src.color.y, src.color.z, 0.0],
+        };
+    }
+    lights
 }
 
 fn make_light_view_proj(

--- a/blade-render/src/raster/mod.rs
+++ b/blade-render/src/raster/mod.rs
@@ -2,8 +2,8 @@ use crate::{AssetHub, CameraParams, DummyResources, Object, RenderConfig, Shader
 use blade_graphics as gpu;
 use std::mem;
 
-/// Maximum local lights evaluated in the forward pass. The fragment shader
-/// picks one of these (highest score, with a stochastic alternative).
+/// Maximum local lights the forward pass considers per fragment.
+/// Extra lights in `RasterConfig::point_lights` are ignored.
 pub const MAX_POINT_LIGHTS: usize = 8;
 
 /// A local omni light. Radius is a hard cutoff in world units.
@@ -36,7 +36,7 @@ impl Default for PointLight {
 ///
 /// Note: the surface appearance is described by the materials of the
 /// models, this is only about the scene-wide lighting.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct RasterConfig {
     pub clear_color: gpu::TextureColor,
     /// Direction *towards* the single directional light.
@@ -47,10 +47,8 @@ pub struct RasterConfig {
     pub space_sky: bool,
     /// Optional real-time directional shadow-map effect.
     pub directional_shadows: Option<DirectionalShadowConfig>,
-    /// Local lights considered by the forward pass. Only the first
-    /// `point_light_count` entries are used.
-    pub point_lights: [PointLight; MAX_POINT_LIGHTS],
-    pub point_light_count: u32,
+    /// Local omni lights. The rasterizer uploads at most `MAX_POINT_LIGHTS`.
+    pub point_lights: Vec<PointLight>,
 }
 
 /// Controls the rasterizer's camera-relative directional shadow map.
@@ -101,8 +99,7 @@ impl Default for RasterConfig {
             },
             space_sky: false,
             directional_shadows: None,
-            point_lights: [PointLight::default(); MAX_POINT_LIGHTS],
-            point_light_count: 0,
+            point_lights: Vec::new(),
         }
     }
 }
@@ -119,7 +116,6 @@ struct RasterFrameParams {
     ambient_color: [f32; 4],
     settings: [f32; 4],
     shadow_params: [f32; 4],
-    point_lights: [PointLightGpu; MAX_POINT_LIGHTS],
 }
 
 #[repr(C)]
@@ -127,6 +123,13 @@ struct RasterFrameParams {
 struct PointLightGpu {
     pos_radius: [f32; 4],
     color: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+struct PointLightParams {
+    count_seed: [f32; 4],
+    lights: [PointLightGpu; MAX_POINT_LIGHTS],
 }
 
 #[repr(C)]
@@ -154,6 +157,7 @@ struct ShadowDrawParams {
 #[derive(blade_macros::ShaderData)]
 struct RasterMainData {
     frame_params: RasterFrameParams,
+    light_params: PointLightParams,
     draw_params: RasterDrawParams,
     samp: gpu::Sampler,
     base_color_tex: gpu::TextureView,
@@ -190,6 +194,7 @@ impl RasterPipelines {
         gpu: &gpu::Context,
     ) -> gpu::RenderPipeline {
         shader.check_struct_size::<RasterFrameParams>();
+        shader.check_struct_size::<PointLightParams>();
         shader.check_struct_size::<RasterDrawParams>();
         let main_layout = <RasterMainData as gpu::ShaderData>::layout();
         let vertex_layout = <Vertex as gpu::Vertex>::layout();
@@ -558,7 +563,8 @@ impl Rasterizer {
         config: RasterConfig,
     ) {
         let env_map_enabled = environment_map.is_some();
-        let frame_params = self.make_frame_params(camera, config, env_map_enabled);
+        let frame_params = self.make_frame_params(camera, &config, env_map_enabled);
+        let light_params = pack_point_lights(&config, camera);
         if let mut pc = pass.with(&self.pipelines.main) {
             for object in objects.iter() {
                 let model = &asset_hub.models[object.model];
@@ -595,6 +601,7 @@ impl Rasterizer {
                         0,
                         &RasterMainData {
                             frame_params,
+                            light_params,
                             draw_params: RasterDrawParams {
                                 model: world_transform.to_cols_array(),
                                 normal_quat: normal_quat.to_array(),
@@ -680,7 +687,7 @@ impl Rasterizer {
         config: RasterConfig,
     ) {
         let env_map_enabled = environment_map.is_some();
-        let frame_params = self.make_frame_params(camera, config, env_map_enabled);
+        let frame_params = self.make_frame_params(camera, &config, env_map_enabled);
         let env_map = environment_map
             .map(|handle| asset_hub.textures[handle].view)
             .unwrap_or(self.dummy.black_view);
@@ -777,7 +784,7 @@ impl Rasterizer {
     fn make_frame_params(
         &self,
         camera: &crate::Camera,
-        config: RasterConfig,
+        config: &RasterConfig,
         env_map_enabled: bool,
     ) -> RasterFrameParams {
         let pos = glam::Vec3::from(camera.pos);
@@ -834,8 +841,8 @@ impl Rasterizer {
                 env_map_enabled as u32 as f32,
                 // the surface may expect us to encode the values ourselves
                 (self.color_space == gpu::ColorSpace::Srgb) as u32 as f32,
-                config.point_light_count.min(MAX_POINT_LIGHTS as u32) as f32,
-                pos.x + pos.y * 1.37 + pos.z * 9.17,
+                0.0,
+                0.0,
             ],
             shadow_params: [
                 config.directional_shadows.is_some() as u32 as f32,
@@ -843,17 +850,20 @@ impl Rasterizer {
                 shadow.normal_bias.max(0.0),
                 1.0 / self.shadow_size as f32,
             ],
-            point_lights: pack_point_lights(&config),
         }
     }
 }
 
-fn pack_point_lights(config: &RasterConfig) -> [PointLightGpu; MAX_POINT_LIGHTS] {
+fn stochastic_light_seed(camera_pos: glam::Vec3) -> f32 {
+    camera_pos.dot(glam::Vec3::new(1.0, 1.37, 9.17))
+}
+
+fn pack_point_lights(config: &RasterConfig, camera: &crate::Camera) -> PointLightParams {
     let mut lights = [PointLightGpu {
         pos_radius: [0.0; 4],
         color: [0.0; 4],
     }; MAX_POINT_LIGHTS];
-    let count = (config.point_light_count as usize).min(MAX_POINT_LIGHTS);
+    let count = config.point_lights.len().min(MAX_POINT_LIGHTS);
     for (slot, src) in lights
         .iter_mut()
         .zip(config.point_lights.iter())
@@ -869,7 +879,15 @@ fn pack_point_lights(config: &RasterConfig) -> [PointLightGpu; MAX_POINT_LIGHTS]
             color: [src.color.x, src.color.y, src.color.z, 0.0],
         };
     }
-    lights
+    PointLightParams {
+        count_seed: [
+            count as f32,
+            stochastic_light_seed(glam::Vec3::from(camera.pos)),
+            0.0,
+            0.0,
+        ],
+        lights,
+    }
 }
 
 fn make_light_view_proj(

--- a/blade-render/src/raster/mod.rs
+++ b/blade-render/src/raster/mod.rs
@@ -496,7 +496,7 @@ impl Rasterizer {
         camera: &crate::Camera,
         objects: &[Object],
         asset_hub: &AssetHub,
-        config: RasterConfig,
+        config: &RasterConfig,
     ) {
         let Some(shadow_config) = config.directional_shadows else {
             return;
@@ -560,11 +560,11 @@ impl Rasterizer {
         objects: &[Object],
         asset_hub: &AssetHub,
         environment_map: Option<blade_asset::Handle<crate::Texture>>,
-        config: RasterConfig,
+        config: &RasterConfig,
     ) {
         let env_map_enabled = environment_map.is_some();
-        let frame_params = self.make_frame_params(camera, &config, env_map_enabled);
-        let light_params = pack_point_lights(&config, camera);
+        let frame_params = self.make_frame_params(camera, config, env_map_enabled);
+        let light_params = pack_point_lights(config, camera);
         if let mut pc = pass.with(&self.pipelines.main) {
             for object in objects.iter() {
                 let model = &asset_hub.models[object.model];
@@ -684,10 +684,10 @@ impl Rasterizer {
         camera: &crate::Camera,
         environment_map: Option<blade_asset::Handle<crate::Texture>>,
         asset_hub: &AssetHub,
-        config: RasterConfig,
+        config: &RasterConfig,
     ) {
         let env_map_enabled = environment_map.is_some();
-        let frame_params = self.make_frame_params(camera, &config, env_map_enabled);
+        let frame_params = self.make_frame_params(camera, config, env_map_enabled);
         let env_map = environment_map
             .map(|handle| asset_hub.textures[handle].view)
             .unwrap_or(self.dummy.black_view);

--- a/blade-render/src/shader.rs
+++ b/blade-render/src/shader.rs
@@ -22,6 +22,7 @@ pub struct Shader {
 pub enum Expansion {
     Values(HashMap<String, u32>),
     Bool(bool),
+    Size(u32),
 }
 impl Expansion {
     pub fn from_enum<E: strum::IntoEnumIterator + fmt::Debug + Into<u32>>() -> Self {
@@ -72,6 +73,11 @@ impl Baker {
         self.expansions
             .insert(name.to_string(), Expansion::Bool(value));
     }
+
+    pub fn register_size(&mut self, name: &str, value: u32) {
+        self.expansions
+            .insert(name.to_string(), Expansion::Size(value));
+    }
 }
 
 // SAFETY: GLES asset tasks are executed inline on the context's owning thread.
@@ -116,6 +122,9 @@ fn parse_impl(
                 }
                 Expansion::Bool(value) => {
                     writeln!(text_out, "const {}: bool = {};", type_name, value).unwrap();
+                }
+                Expansion::Size(value) => {
+                    writeln!(text_out, "const {}: u32 = {}u;", type_name, value).unwrap();
                 }
             }
         } else {

--- a/examples-android/asteroids/game.rs
+++ b/examples-android/asteroids/game.rs
@@ -507,6 +507,7 @@ pub fn setup_game(engine: &mut blade_engine::Engine) -> GameState {
         },
         space_sky: true,
         directional_shadows: None,
+        ..Default::default()
     });
 
     // Gas giant with rings in the distance.

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -942,7 +942,7 @@ fn snapshot_pbr_raster() {
         &pbr_scene::camera(),
         &objects,
         &harness.asset_hub,
-        raster_config,
+        raster_config.clone(),
     );
 
     command_encoder.init_texture(target.texture);

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -942,7 +942,7 @@ fn snapshot_pbr_raster() {
         &pbr_scene::camera(),
         &objects,
         &harness.asset_hub,
-        raster_config.clone(),
+        &raster_config,
     );
 
     command_encoder.init_texture(target.texture);
@@ -968,7 +968,7 @@ fn snapshot_pbr_raster() {
             &objects,
             &harness.asset_hub,
             None,
-            raster_config,
+            &raster_config,
         );
     }
 

--- a/tests/parse_shaders.rs
+++ b/tests/parse_shaders.rs
@@ -87,6 +87,10 @@ fn parse_wgsl() {
         Expansion::from_bitflags::<blade_render::DebugTextureFlags>(),
     );
     expansions.insert("DEBUG_MODE".to_string(), Expansion::Bool(true));
+    expansions.insert(
+        "MAX_POINT_LIGHTS".to_string(),
+        Expansion::Size(blade_render::MAX_POINT_LIGHTS as u32),
+    );
 
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut directories = vec![root.join("blade-render").join("code")];
@@ -114,7 +118,12 @@ fn raster_exports_to_webgl2() {
     let shader_dir = root.join("blade-render").join("code");
     let shader_raw = fs::read(shader_dir.join("raster.wgsl")).unwrap();
     let cooker = blade_asset::Cooker::new(&shader_dir, Default::default());
-    let source = blade_render::shader::parse_shader(&shader_raw, &cooker, &HashMap::new());
+    let mut expansions = HashMap::new();
+    expansions.insert(
+        "MAX_POINT_LIGHTS".to_string(),
+        blade_render::shader::Expansion::Size(blade_render::MAX_POINT_LIGHTS as u32),
+    );
+    let source = blade_render::shader::parse_shader(&shader_raw, &cooker, &expansions);
     let mut module =
         wgsl::parse_str(&source).unwrap_or_else(|e| panic!("{}", e.emit_to_string(&source)));
     let info = Validator::new(

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -1,4 +1,5 @@
 use blade_graphics as gpu;
+use std::collections::HashMap;
 use std::io::BufReader;
 use std::path::Path;
 
@@ -17,39 +18,28 @@ const C1: f64 = 6.5025; // (0.01 * 255)^2
 const C2: f64 = 58.5225; // (0.03 * 255)^2
 const BLOCK: usize = 8;
 
-/// Read a shader from the renderer's code directory, expanding the `#include` directives.
-///
-/// Unlike the asset pipeline, this works regardless of the backend
-/// the tests are built for, at the cost of not supporting `#use`.
+/// Read a shader from the renderer's code directory, expanding `#include` and
+/// the `#use` constants the raster path registers on the asset hub.
 pub fn shader_source(name: &str) -> String {
+    use blade_render::shader::Expansion;
+
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("blade-render")
         .join("code");
-    expand_includes(&dir.join(name), &dir)
-}
-
-fn expand_includes(path: &Path, dir: &Path) -> String {
-    let text = std::fs::read_to_string(path)
-        .unwrap_or_else(|e| panic!("Unable to read '{}': {e}", path.display()));
-    let mut out = String::new();
-    for line in text.lines() {
-        if line.starts_with("#include") {
-            let include = line
-                .split('"')
-                .nth(1)
-                .unwrap_or_else(|| panic!("Unable to extract the include path from: {line}"));
-            out += &expand_includes(&dir.join(include), dir);
-        } else {
-            assert!(
-                !line.starts_with("#use"),
-                "'{}' needs host expansions, load it via the asset hub instead",
-                path.display()
-            );
-            out += line;
-        }
-        out.push('\n');
-    }
-    out
+    let path = dir.join(name);
+    let bytes =
+        std::fs::read(&path).unwrap_or_else(|e| panic!("Unable to read '{}': {e}", path.display()));
+    let cooker = blade_asset::Cooker::new(&dir, Default::default());
+    let mut expansions = HashMap::new();
+    expansions.insert(
+        "MAX_POINT_LIGHTS".to_string(),
+        Expansion::Size(blade_render::MAX_POINT_LIGHTS as u32),
+    );
+    expansions.insert(
+        "DEBUG_MODE".to_string(),
+        Expansion::Bool(cfg!(debug_assertions)),
+    );
+    blade_render::shader::parse_shader(&bytes, &cooker, &expansions)
 }
 
 pub struct OffscreenTarget {


### PR DESCRIPTION
Forward shading picks one of up to eight local lights (best score, with a stochastic alternative). Particle systems now simulate and draw in the desktop raster pass, not only XR.