### PR TITLE
Fix WebGL2 buffer classes, empty texture uploads, and 0x0 storage

### DIFF
--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -329,8 +329,8 @@ impl GuiPainter {
         }
 
         self.triage_deletions(context);
-        self.data_belt.trim(32, context);
-        self.index_belt.trim(32, context);
+        self.data_belt.trim(4, context);
+        self.index_belt.trim(4, context);
     }
 
     /// Render the set of clipped primitives into a render pass.

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -407,8 +407,6 @@ impl GuiPainter {
                 );
             }
         }
-        self.data_belt.sync(context);
-        self.index_belt.sync(context);
     }
 
     /// Call this after submitting work at the given `sync_point`.

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -329,8 +329,8 @@ impl GuiPainter {
         }
 
         self.triage_deletions(context);
-        self.data_belt.trim(4, context);
-        self.index_belt.trim(4, context);
+        self.data_belt.trim(32, context);
+        self.index_belt.trim(32, context);
     }
 
     /// Render the set of clipped primitives into a render pass.

--- a/blade-egui/src/lib.rs
+++ b/blade-egui/src/lib.rs
@@ -144,8 +144,9 @@ impl GuiTexture {
 /// It can render egui primitives into a render pass.
 pub struct GuiPainter {
     pipeline: blade_graphics::RenderPipeline,
-    //TODO: find a better way to allocate temporary buffers.
-    belt: BufferBelt,
+    /// Vertices and texture staging. WebGL forbids mixing this with index data.
+    data_belt: BufferBelt,
+    index_belt: BufferBelt,
     textures: HashMap<egui::TextureId, GuiTexture>,
     //TODO: this could also look better
     textures_dropped: Vec<GuiTexture>,
@@ -156,7 +157,8 @@ impl GuiPainter {
     /// Destroy the contents of the painter.
     pub fn destroy(&mut self, context: &blade_graphics::Context) {
         context.destroy_render_pipeline(&mut self.pipeline);
-        self.belt.destroy(context);
+        self.data_belt.destroy(context);
+        self.index_belt.destroy(context);
         for (_, gui_texture) in self.textures.drain() {
             gui_texture.delete(context);
         }
@@ -214,15 +216,23 @@ impl GuiPainter {
             multisample_state: Default::default(),
         });
 
-        let belt = BufferBelt::new(BufferBeltDescriptor {
+        let data_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: blade_graphics::Memory::Shared,
             min_chunk_size: 0x1000,
-            alignment: blade_graphics::limits::STORAGE_BUFFER_ALIGNMENT,
+            alignment: 4,
+            target: blade_graphics::BufferTarget::Data,
+        });
+        let index_belt = BufferBelt::new(BufferBeltDescriptor {
+            memory: blade_graphics::Memory::Shared,
+            min_chunk_size: 0x1000,
+            alignment: 4,
+            target: blade_graphics::BufferTarget::Index,
         });
 
         Self {
             pipeline,
-            belt,
+            data_belt,
+            index_belt,
             textures: Default::default(),
             textures_dropped: Vec::new(),
             textures_to_delete: Vec::new(),
@@ -260,7 +270,9 @@ impl GuiPainter {
         let mut copies = Vec::new();
         for &(texture_id, ref image_delta) in textures_delta.set.iter() {
             let src = match image_delta.image {
-                egui::ImageData::Color(ref c) => self.belt.alloc_pod(c.pixels.as_slice(), context),
+                egui::ImageData::Color(ref c) => {
+                    self.data_belt.alloc_pod(c.pixels.as_slice(), context)
+                }
             };
 
             let image_size = image_delta.image.size();
@@ -317,7 +329,8 @@ impl GuiPainter {
         }
 
         self.triage_deletions(context);
-        self.belt.trim(4, context);
+        self.data_belt.trim(4, context);
+        self.index_belt.trim(4, context);
     }
 
     /// Render the set of clipped primitives into a render pass.
@@ -372,8 +385,8 @@ impl GuiPainter {
 
             if let egui::epaint::Primitive::Mesh(ref mesh) = clipped_prim.primitive {
                 let texture = self.textures.get(&mesh.texture_id).unwrap();
-                let index_buf = self.belt.alloc_pod(&mesh.indices, context);
-                let vertex_buf = self.belt.alloc_pod(&mesh.vertices, context);
+                let index_buf = self.index_belt.alloc_pod(&mesh.indices, context);
+                let vertex_buf = self.data_belt.alloc_pod(&mesh.vertices, context);
 
                 pc.bind(
                     1,
@@ -394,6 +407,8 @@ impl GuiPainter {
                 );
             }
         }
+        self.data_belt.sync(context);
+        self.index_belt.sync(context);
     }
 
     /// Call this after submitting work at the given `sync_point`.
@@ -404,6 +419,7 @@ impl GuiPainter {
                 .drain(..)
                 .map(|texture| (texture, sync_point.clone())),
         );
-        self.belt.flush(sync_point);
+        self.data_belt.flush(sync_point);
+        self.index_belt.flush(sync_point);
     }
 }

--- a/blade-engine/src/lib.rs
+++ b/blade-engine/src/lib.rs
@@ -531,8 +531,8 @@ impl Engine {
     fn make_surface_config(physical_size: winit::dpi::PhysicalSize<u32>) -> gpu::SurfaceConfig {
         gpu::SurfaceConfig {
             size: gpu::Extent {
-                width: physical_size.width,
-                height: physical_size.height,
+                width: physical_size.width.max(1),
+                height: physical_size.height.max(1),
                 depth: 1,
             },
             usage: gpu::TextureUsage::TARGET,

--- a/blade-graphics/src/gles/command.rs
+++ b/blade-graphics/src/gles/command.rs
@@ -899,6 +899,8 @@ impl super::Command {
                         _ => unreachable!(),
                     }
                     gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, None);
+                    gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
+                    gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 4);
                 }
                 Self::CopyTextureToBuffer {
                     ref src,

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -120,25 +120,31 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, buffer: super::Buffer, target: crate::BufferTarget) {
+    fn sync_buffer(&self, piece: crate::BufferPiece, size: u64, target: crate::BufferTarget) {
         if self
             .capabilities
             .contains(super::Capabilities::BUFFER_STORAGE)
         {
             return;
         }
+        debug_assert_eq!(piece.offset & 3, 0);
         let gl = self.lock();
         let raw_target = match target {
             crate::BufferTarget::Data => glow::ARRAY_BUFFER,
             crate::BufferTarget::Index => glow::ELEMENT_ARRAY_BUFFER,
         };
         unsafe {
-            let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
-            gl.bind_buffer(raw_target, buffer.raw);
-            // Stream from offset 0. `bufferData` allocates on first WebGL bind
-            // (locking the bind class) and orphans on later calls, matching
-            // Mesa's documented `glBufferData` streaming path.
-            gl.buffer_data_u8_slice(raw_target, data, glow::DYNAMIC_DRAW);
+            let data = slice::from_raw_parts(piece.data(), size as usize);
+            gl.bind_buffer(raw_target, piece.buffer.raw);
+            // WebGL starts with no storage. Allocate the full chunk on first
+            // bind (`offset == 0`) so later 4-byte-aligned `bufferSubData`
+            // calls grow Mesa's valid prefix without renaming the backing.
+            #[cfg(target_arch = "wasm32")]
+            if piece.offset == 0 && gl.get_buffer_parameter_i32(raw_target, glow::BUFFER_SIZE) == 0
+            {
+                gl.buffer_data_size(raw_target, piece.buffer.size as i32, glow::DYNAMIC_DRAW);
+            }
+            gl.buffer_sub_data_u8_slice(raw_target, piece.offset as i32, data);
             gl.bind_buffer(raw_target, None);
         }
     }

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -139,6 +139,7 @@ impl crate::traits::ResourceDevice for super::Context {
                 gl.buffer_data_u8_slice(raw_target, data, glow::DYNAMIC_DRAW);
                 #[cfg(not(target_arch = "wasm32"))]
                 gl.buffer_sub_data_u8_slice(raw_target, 0, data);
+                gl.bind_buffer(raw_target, None);
             }
         }
     }
@@ -168,21 +169,23 @@ impl crate::traits::ResourceDevice for super::Context {
             let raw = unsafe { gl.create_renderbuffer().unwrap() };
             unsafe {
                 gl.bind_renderbuffer(glow::RENDERBUFFER, Some(raw));
+                let width = desc.size.width.max(1) as i32;
+                let height = desc.size.height.max(1) as i32;
 
                 if desc.sample_count <= 1 {
                     gl.renderbuffer_storage(
                         glow::RENDERBUFFER,
                         format_desc.internal,
-                        desc.size.width as i32,
-                        desc.size.height as i32,
+                        width,
+                        height,
                     );
                 } else {
                     gl.renderbuffer_storage_multisample(
                         glow::RENDERBUFFER,
                         desc.sample_count as i32,
                         format_desc.internal,
-                        desc.size.width as i32,
-                        desc.size.height as i32,
+                        width,
+                        height,
                     );
                 }
 
@@ -240,15 +243,18 @@ impl crate::traits::ResourceDevice for super::Context {
                 gl.tex_parameter_i32(target, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
                 gl.tex_parameter_i32(target, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);
 
+                let width = desc.size.width.max(1) as i32;
+                let height = desc.size.height.max(1) as i32;
+                let depth = desc.size.depth.max(1) as i32;
                 match desc.dimension {
                     crate::TextureDimension::D3 => {
                         gl.tex_storage_3d(
                             target,
                             desc.mip_level_count as i32,
                             format_desc.internal,
-                            desc.size.width as i32,
-                            desc.size.height as i32,
-                            desc.size.depth as i32,
+                            width,
+                            height,
+                            depth,
                         );
                     }
                     crate::TextureDimension::D2 => {
@@ -257,8 +263,8 @@ impl crate::traits::ResourceDevice for super::Context {
                                 target,
                                 desc.mip_level_count as i32,
                                 format_desc.internal,
-                                desc.size.width as i32,
-                                desc.size.height as i32,
+                                width,
+                                height,
                             );
                         } else {
                             assert_eq!(desc.mip_level_count, 1);
@@ -266,8 +272,8 @@ impl crate::traits::ResourceDevice for super::Context {
                                 target,
                                 desc.sample_count as i32,
                                 format_desc.internal,
-                                desc.size.width as i32,
-                                desc.size.height as i32,
+                                width,
+                                height,
                                 true,
                             );
                         }
@@ -277,7 +283,7 @@ impl crate::traits::ResourceDevice for super::Context {
                             target,
                             desc.mip_level_count as i32,
                             format_desc.internal,
-                            desc.size.width as i32,
+                            width,
                         );
                     }
                 }

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -121,10 +121,6 @@ impl crate::traits::ResourceDevice for super::Context {
     }
 
     fn sync_buffer(&self, buffer: super::Buffer, target: crate::BufferTarget) {
-        self.sync_buffer_range(buffer.into(), buffer.size, target);
-    }
-
-    fn sync_buffer_range(&self, piece: crate::BufferPiece, size: u64, target: crate::BufferTarget) {
         if self
             .capabilities
             .contains(super::Capabilities::BUFFER_STORAGE)
@@ -137,15 +133,12 @@ impl crate::traits::ResourceDevice for super::Context {
             crate::BufferTarget::Index => glow::ELEMENT_ARRAY_BUFFER,
         };
         unsafe {
-            let data = slice::from_raw_parts(piece.data(), size as usize);
-            gl.bind_buffer(raw_target, piece.buffer.raw);
-            // WebGL starts with no storage. Allocate the full chunk on first
-            // bind so later ranges can `bufferSubData` without orphaning.
-            #[cfg(target_arch = "wasm32")]
-            if gl.get_buffer_parameter_i32(raw_target, glow::BUFFER_SIZE) == 0 {
-                gl.buffer_data_size(raw_target, piece.buffer.size as i32, glow::DYNAMIC_DRAW);
-            }
-            gl.buffer_sub_data_u8_slice(raw_target, piece.offset as i32, data);
+            let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
+            gl.bind_buffer(raw_target, buffer.raw);
+            // Stream from offset 0. `bufferData` allocates on first WebGL bind
+            // (locking the bind class) and orphans on later calls, matching
+            // Mesa's documented `glBufferData` streaming path.
+            gl.buffer_data_u8_slice(raw_target, data, glow::DYNAMIC_DRAW);
             gl.bind_buffer(raw_target, None);
         }
     }

--- a/blade-graphics/src/gles/resource.rs
+++ b/blade-graphics/src/gles/resource.rs
@@ -121,26 +121,32 @@ impl crate::traits::ResourceDevice for super::Context {
     }
 
     fn sync_buffer(&self, buffer: super::Buffer, target: crate::BufferTarget) {
-        if !self
+        self.sync_buffer_range(buffer.into(), buffer.size, target);
+    }
+
+    fn sync_buffer_range(&self, piece: crate::BufferPiece, size: u64, target: crate::BufferTarget) {
+        if self
             .capabilities
             .contains(super::Capabilities::BUFFER_STORAGE)
         {
-            let gl = self.lock();
-            let raw_target = match target {
-                crate::BufferTarget::Data => glow::ARRAY_BUFFER,
-                crate::BufferTarget::Index => glow::ELEMENT_ARRAY_BUFFER,
-            };
-            unsafe {
-                let data = slice::from_raw_parts(buffer.data, buffer.size as usize);
-                gl.bind_buffer(raw_target, buffer.raw);
-                // On WebGL the storage is allocated here on first sync:
-                // `bufferData` both allocates and uploads (buffer orphaning).
-                #[cfg(target_arch = "wasm32")]
-                gl.buffer_data_u8_slice(raw_target, data, glow::DYNAMIC_DRAW);
-                #[cfg(not(target_arch = "wasm32"))]
-                gl.buffer_sub_data_u8_slice(raw_target, 0, data);
-                gl.bind_buffer(raw_target, None);
+            return;
+        }
+        let gl = self.lock();
+        let raw_target = match target {
+            crate::BufferTarget::Data => glow::ARRAY_BUFFER,
+            crate::BufferTarget::Index => glow::ELEMENT_ARRAY_BUFFER,
+        };
+        unsafe {
+            let data = slice::from_raw_parts(piece.data(), size as usize);
+            gl.bind_buffer(raw_target, piece.buffer.raw);
+            // WebGL starts with no storage. Allocate the full chunk on first
+            // bind so later ranges can `bufferSubData` without orphaning.
+            #[cfg(target_arch = "wasm32")]
+            if gl.get_buffer_parameter_i32(raw_target, glow::BUFFER_SIZE) == 0 {
+                gl.buffer_data_size(raw_target, piece.buffer.size as i32, glow::DYNAMIC_DRAW);
             }
+            gl.buffer_sub_data_u8_slice(raw_target, piece.offset as i32, data);
+            gl.bind_buffer(raw_target, None);
         }
     }
 

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -209,14 +209,6 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
 
-    fn sync_buffer_range(
-        &self,
-        _piece: crate::BufferPiece,
-        _size: u64,
-        _target: crate::BufferTarget,
-    ) {
-    }
-
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let _ = unsafe { Retained::from_raw(buffer.raw) };
     }

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -209,6 +209,14 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
 
+    fn sync_buffer_range(
+        &self,
+        _piece: crate::BufferPiece,
+        _size: u64,
+        _target: crate::BufferTarget,
+    ) {
+    }
+
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let _ = unsafe { Retained::from_raw(buffer.raw) };
     }

--- a/blade-graphics/src/metal/resource.rs
+++ b/blade-graphics/src/metal/resource.rs
@@ -207,7 +207,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
+    fn sync_buffer(&self, _piece: crate::BufferPiece, _size: u64, _target: crate::BufferTarget) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         let _ = unsafe { Retained::from_raw(buffer.raw) };

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -8,7 +8,7 @@ pub trait ResourceDevice {
     type AccelerationStructure: Send + Sync + Clone + Copy + Debug + Hash + PartialEq;
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
-    fn sync_buffer(&self, buffer: Self::Buffer, target: super::BufferTarget);
+    fn sync_buffer(&self, piece: super::BufferPiece, size: u64, target: super::BufferTarget);
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -9,8 +9,6 @@ pub trait ResourceDevice {
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
     fn sync_buffer(&self, buffer: Self::Buffer, target: super::BufferTarget);
-    /// Upload `size` bytes at `piece.offset`. Backends with persistent maps ignore this.
-    fn sync_buffer_range(&self, piece: super::BufferPiece, size: u64, target: super::BufferTarget);
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);

--- a/blade-graphics/src/traits.rs
+++ b/blade-graphics/src/traits.rs
@@ -9,6 +9,8 @@ pub trait ResourceDevice {
 
     fn create_buffer(&self, desc: super::BufferDesc) -> Self::Buffer;
     fn sync_buffer(&self, buffer: Self::Buffer, target: super::BufferTarget);
+    /// Upload `size` bytes at `piece.offset`. Backends with persistent maps ignore this.
+    fn sync_buffer_range(&self, piece: super::BufferPiece, size: u64, target: super::BufferTarget);
     fn destroy_buffer(&self, buffer: Self::Buffer);
     fn create_texture(&self, desc: super::TextureDesc) -> Self::Texture;
     fn destroy_texture(&self, texture: Self::Texture);

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -459,7 +459,7 @@ impl crate::traits::ResourceDevice for super::Context {
         }
     }
 
-    fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
+    fn sync_buffer(&self, _piece: crate::BufferPiece, _size: u64, _target: crate::BufferTarget) {}
 
     fn destroy_buffer(&self, buffer: super::Buffer) {
         log::info!(

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -461,6 +461,14 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
 
+    fn sync_buffer_range(
+        &self,
+        _piece: crate::BufferPiece,
+        _size: u64,
+        _target: crate::BufferTarget,
+    ) {
+    }
+
     fn destroy_buffer(&self, buffer: super::Buffer) {
         log::info!(
             "Destroying buffer {:?}, handle {:?}",

--- a/blade-graphics/src/vulkan/resource.rs
+++ b/blade-graphics/src/vulkan/resource.rs
@@ -461,14 +461,6 @@ impl crate::traits::ResourceDevice for super::Context {
 
     fn sync_buffer(&self, _buffer: super::Buffer, _target: crate::BufferTarget) {}
 
-    fn sync_buffer_range(
-        &self,
-        _piece: crate::BufferPiece,
-        _size: u64,
-        _target: crate::BufferTarget,
-    ) {
-    }
-
     fn destroy_buffer(&self, buffer: super::Buffer) {
         log::info!(
             "Destroying buffer {:?}, handle {:?}",

--- a/blade-render/src/dummy.rs
+++ b/blade-render/src/dummy.rs
@@ -97,7 +97,11 @@ impl DummyResources {
                 [!0u8, !0, !0, !0, 0, 0, 0, 0, !0, 0, 0, 0],
             );
         }
-        gpu.sync_buffer(staging_buf, blade_graphics::BufferTarget::Data);
+        gpu.sync_buffer(
+            staging_buf.into(),
+            staging_buf.size(),
+            blade_graphics::BufferTarget::Data,
+        );
         transfers.copy_buffer_to_texture(staging_buf.at(0), 4, white_texture.into(), size);
         transfers.copy_buffer_to_texture(staging_buf.at(4), 4, black_texture.into(), size);
         transfers.copy_buffer_to_texture(staging_buf.at(8), 4, red_texture.into(), size);

--- a/blade-render/src/model/mod.rs
+++ b/blade-render/src/model/mod.rs
@@ -571,7 +571,9 @@ impl BufferUpload {
 
     fn finish(self, baker: &Baker) {
         if cfg!(target_arch = "wasm32") {
-            baker.gpu_context.sync_buffer(self.dst, self.target);
+            baker
+                .gpu_context
+                .sync_buffer(self.dst.into(), self.size, self.target);
         } else {
             baker
                 .pending_operations
@@ -912,14 +914,26 @@ impl Baker {
             transform_offset += mem::size_of::<blade_graphics::Transform>() as u64;
         }
 
-        self.gpu_context
-            .sync_buffer(vertex_buffer, blade_graphics::BufferTarget::Data);
-        self.gpu_context
-            .sync_buffer(skin_vertex_buffer, blade_graphics::BufferTarget::Data);
-        self.gpu_context
-            .sync_buffer(index_buffer, blade_graphics::BufferTarget::Index);
-        self.gpu_context
-            .sync_buffer(transform_buffer, blade_graphics::BufferTarget::Data);
+        self.gpu_context.sync_buffer(
+            vertex_buffer.into(),
+            vertex_buffer.size(),
+            blade_graphics::BufferTarget::Data,
+        );
+        self.gpu_context.sync_buffer(
+            skin_vertex_buffer.into(),
+            skin_vertex_buffer.size(),
+            blade_graphics::BufferTarget::Data,
+        );
+        self.gpu_context.sync_buffer(
+            index_buffer.into(),
+            index_buffer.size(),
+            blade_graphics::BufferTarget::Index,
+        );
+        self.gpu_context.sync_buffer(
+            transform_buffer.into(),
+            transform_buffer.size(),
+            blade_graphics::BufferTarget::Data,
+        );
 
         Model {
             name: name.to_string(),

--- a/blade-render/src/texture/mod.rs
+++ b/blade-render/src/texture/mod.rs
@@ -152,7 +152,8 @@ impl Baker {
         unsafe {
             ptr::copy_nonoverlapping(byte_data.as_ptr(), stage.data(), byte_data.len());
         }
-        self.gpu_context.sync_buffer(stage, gpu::BufferTarget::Data);
+        self.gpu_context
+            .sync_buffer(stage.into(), stage.size(), gpu::BufferTarget::Data);
 
         let bytes_per_row = width * 4;
         let mut pending_ops = self.pending_operations.lock().unwrap();
@@ -516,8 +517,11 @@ impl blade_asset::Baker for Baker {
             unsafe {
                 ptr::copy_nonoverlapping(mip.data.as_ptr(), stage.data(), mip.data.len());
             }
-            self.gpu_context
-                .sync_buffer(stage, blade_graphics::BufferTarget::Data);
+            self.gpu_context.sync_buffer(
+                stage.into(),
+                stage.size(),
+                blade_graphics::BufferTarget::Data,
+            );
 
             let block_info = image.format.0.block_info();
             let extent = base_extent.at_mip_level(i as u32);

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -89,6 +89,7 @@ impl BufferBelt {
         unsafe {
             std::ptr::copy_nonoverlapping(data.as_ptr(), bp.data(), data.len());
         }
+        gpu.sync_buffer_range(bp, data.len() as u64, self.desc.target);
         bp
     }
 
@@ -109,6 +110,7 @@ impl BufferBelt {
         unsafe {
             std::ptr::copy_nonoverlapping(data.as_ptr() as *const u8, bp.data(), total_bytes);
         }
+        gpu.sync_buffer_range(bp, total_bytes as u64, self.desc.target);
         bp
     }
 
@@ -119,16 +121,6 @@ impl BufferBelt {
         gpu: &gpu::Context,
     ) -> gpu::BufferPiece {
         unsafe { self.alloc_typed(data, gpu) }
-    }
-
-    /// Upload active CPU writes so the GPU can see them.
-    ///
-    /// Call this once after allocating, before submitting the command encoder
-    /// that uses the pieces. WebGL has no persistent mapping.
-    pub fn sync(&self, gpu: &gpu::Context) {
-        for (rb, _) in self.active.iter() {
-            gpu.sync_buffer(rb.raw, self.desc.target);
-        }
     }
 
     /// Mark the actively used buffers as used by GPU with a given sync point.

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -44,24 +44,31 @@ impl BufferBelt {
         }
     }
 
-    /// Allocate a region of `size` bytes at offset 0 of a dedicated buffer.
+    /// Allocate a region of `size` bytes, packed at `alignment` (4 for GLES).
     #[profiling::function]
     pub fn alloc(&mut self, size: u64, gpu: &gpu::Context) -> gpu::BufferPiece {
-        let aligned_size = size.next_multiple_of(self.desc.alignment);
+        for &mut (ref rb, ref mut offset) in self.active.iter_mut() {
+            let aligned = offset.next_multiple_of(self.desc.alignment);
+            if aligned + size <= rb.size {
+                let piece = rb.raw.at(aligned);
+                *offset = aligned + size;
+                return piece;
+            }
+        }
 
         let index_maybe = self
             .buffers
             .iter()
-            .position(|(rb, sp)| aligned_size <= rb.size && gpu.wait_for(sp, 0).unwrap_or(false));
+            .position(|(rb, sp)| size <= rb.size && gpu.wait_for(sp, 0).unwrap_or(false));
         if let Some(index) = index_maybe {
             let (rb, _) = self.buffers.remove(index);
             let piece = rb.raw.into();
-            self.active.push((rb, aligned_size));
+            self.active.push((rb, size));
             return piece;
         }
 
         let chunk_index = self.buffers.len() + self.active.len();
-        let chunk_size = aligned_size.max(self.desc.min_chunk_size);
+        let chunk_size = size.max(self.desc.min_chunk_size);
         let chunk = gpu.create_buffer(gpu::BufferDesc {
             name: &format!("chunk-{}", chunk_index),
             size: chunk_size,
@@ -71,7 +78,7 @@ impl BufferBelt {
             raw: chunk,
             size: chunk_size,
         };
-        self.active.push((rb, aligned_size));
+        self.active.push((rb, size));
         chunk.into()
     }
 
@@ -82,7 +89,7 @@ impl BufferBelt {
         unsafe {
             std::ptr::copy_nonoverlapping(data.as_ptr(), bp.data(), data.len());
         }
-        gpu.sync_buffer(bp.buffer, self.desc.target);
+        gpu.sync_buffer(bp, data.len() as u64, self.desc.target);
         bp
     }
 
@@ -103,7 +110,7 @@ impl BufferBelt {
         unsafe {
             std::ptr::copy_nonoverlapping(data.as_ptr() as *const u8, bp.data(), total_bytes);
         }
-        gpu.sync_buffer(bp.buffer, self.desc.target);
+        gpu.sync_buffer(bp, total_bytes as u64, self.desc.target);
         bp
     }
 

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -12,6 +12,7 @@ pub struct BufferBeltDescriptor {
     pub memory: gpu::Memory,
     pub min_chunk_size: u64,
     pub alignment: u64,
+    pub target: gpu::BufferTarget,
 }
 
 /// A belt of reusable buffer space.
@@ -118,6 +119,16 @@ impl BufferBelt {
         gpu: &gpu::Context,
     ) -> gpu::BufferPiece {
         unsafe { self.alloc_typed(data, gpu) }
+    }
+
+    /// Upload active CPU writes so the GPU can see them.
+    ///
+    /// Call this once after allocating, before submitting the command encoder
+    /// that uses the pieces. WebGL has no persistent mapping.
+    pub fn sync(&self, gpu: &gpu::Context) {
+        for (rb, _) in self.active.iter() {
+            gpu.sync_buffer(rb.raw, self.desc.target);
+        }
     }
 
     /// Mark the actively used buffers as used by GPU with a given sync point.

--- a/blade-util/src/belt.rs
+++ b/blade-util/src/belt.rs
@@ -44,31 +44,24 @@ impl BufferBelt {
         }
     }
 
-    /// Allocate a region of `size` bytes.
+    /// Allocate a region of `size` bytes at offset 0 of a dedicated buffer.
     #[profiling::function]
     pub fn alloc(&mut self, size: u64, gpu: &gpu::Context) -> gpu::BufferPiece {
-        for &mut (ref rb, ref mut offset) in self.active.iter_mut() {
-            let aligned = offset.next_multiple_of(self.desc.alignment);
-            if aligned + size <= rb.size {
-                let piece = rb.raw.at(aligned);
-                *offset = aligned + size;
-                return piece;
-            }
-        }
+        let aligned_size = size.next_multiple_of(self.desc.alignment);
 
         let index_maybe = self
             .buffers
             .iter()
-            .position(|(rb, sp)| size <= rb.size && gpu.wait_for(sp, 0).unwrap_or(false));
+            .position(|(rb, sp)| aligned_size <= rb.size && gpu.wait_for(sp, 0).unwrap_or(false));
         if let Some(index) = index_maybe {
             let (rb, _) = self.buffers.remove(index);
             let piece = rb.raw.into();
-            self.active.push((rb, size));
+            self.active.push((rb, aligned_size));
             return piece;
         }
 
         let chunk_index = self.buffers.len() + self.active.len();
-        let chunk_size = size.max(self.desc.min_chunk_size);
+        let chunk_size = aligned_size.max(self.desc.min_chunk_size);
         let chunk = gpu.create_buffer(gpu::BufferDesc {
             name: &format!("chunk-{}", chunk_index),
             size: chunk_size,
@@ -78,7 +71,7 @@ impl BufferBelt {
             raw: chunk,
             size: chunk_size,
         };
-        self.active.push((rb, size));
+        self.active.push((rb, aligned_size));
         chunk.into()
     }
 
@@ -89,7 +82,7 @@ impl BufferBelt {
         unsafe {
             std::ptr::copy_nonoverlapping(data.as_ptr(), bp.data(), data.len());
         }
-        gpu.sync_buffer_range(bp, data.len() as u64, self.desc.target);
+        gpu.sync_buffer(bp.buffer, self.desc.target);
         bp
     }
 
@@ -110,7 +103,7 @@ impl BufferBelt {
         unsafe {
             std::ptr::copy_nonoverlapping(data.as_ptr() as *const u8, bp.data(), total_bytes);
         }
-        gpu.sync_buffer_range(bp, total_bytes as u64, self.desc.target);
+        gpu.sync_buffer(bp.buffer, self.desc.target);
         bp
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,11 +2,11 @@ Changelog for *Blade* project
 
 ## (TBD)
 
-- gles/egui: keep WebGL2 buffer bind classes honest. The upload belt now
-  records a `BufferTarget` and syncs once before submit, and the GUI painter
-  uses separate data and index belts. Mixing those in one WebGL buffer made
-  `texSubImage` see 0 bytes and `drawElements` bind an element-array target
-  to a generic buffer.
+- gles/egui: keep WebGL2 buffer bind classes honest. The upload belt records
+  a `BufferTarget` and `sync_buffer_range`s each alloc so copies and draws
+  see GPU data immediately. The GUI painter uses separate data and index
+  belts; mixing those in one WebGL buffer made `texSubImage` see 0 bytes
+  and `drawElements` bind an element-array target to a generic buffer.
 - gles: skip 0×0 `texStorage` / renderbuffer allocations (WebGL rejects
   them) and reset `UNPACK_ROW_LENGTH` after buffer-to-texture copies.
 - render/engine: skeletal animation from glTF skins and TRS clips with step,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@ Changelog for *Blade* project
 
 ## (TBD)
 
+- gles/egui: keep WebGL2 buffer bind classes honest. The upload belt now
+  records a `BufferTarget` and syncs once before submit, and the GUI painter
+  uses separate data and index belts. Mixing those in one WebGL buffer made
+  `texSubImage` see 0 bytes and `drawElements` bind an element-array target
+  to a generic buffer.
+- gles: skip 0×0 `texStorage` / renderbuffer allocations (WebGL rejects
+  them) and reset `UNPACK_ROW_LENGTH` after buffer-to-texture copies.
 - render/engine: skeletal animation from glTF skins and TRS clips with step,
   linear, and cubic-spline interpolation. `Engine::set_animation` drives
   `AnimationPlayer` playback, which evaluates `AnimationModel` into a `Pose`;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,10 +3,11 @@ Changelog for *Blade* project
 ## (TBD)
 
 - gles/egui: keep WebGL2 buffer bind classes honest. The upload belt records
-  a `BufferTarget` and `sync_buffer_range`s each alloc so copies and draws
-  see GPU data immediately. The GUI painter uses separate data and index
-  belts; mixing those in one WebGL buffer made `texSubImage` see 0 bytes
-  and `drawElements` bind an element-array target to a generic buffer.
+  a `BufferTarget` and gives each alloc its own buffer at offset 0, then
+  `sync_buffer`s with `glBufferData` so copies and draws see GPU data
+  immediately. The GUI painter uses separate data and index belts; mixing
+  those in one WebGL buffer made `texSubImage` see 0 bytes and
+  `drawElements` bind an element-array target to a generic buffer.
 - gles: skip 0×0 `texStorage` / renderbuffer allocations (WebGL rejects
   them) and reset `UNPACK_ROW_LENGTH` after buffer-to-texture copies.
 - render/engine: skeletal animation from glTF skins and TRS clips with step,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,11 +3,13 @@ Changelog for *Blade* project
 ## (TBD)
 
 - gles/egui: keep WebGL2 buffer bind classes honest. The upload belt records
-  a `BufferTarget` and gives each alloc its own buffer at offset 0, then
-  `sync_buffer`s with `glBufferData` so copies and draws see GPU data
-  immediately. The GUI painter uses separate data and index belts; mixing
-  those in one WebGL buffer made `texSubImage` see 0 bytes and
-  `drawElements` bind an element-array target to a generic buffer.
+  a `BufferTarget` and packs 4-byte-aligned subranges, then `sync_buffer`s
+  each alloc so copies and draws see GPU data immediately. The GUI painter
+  uses separate data and index belts; mixing those in one WebGL buffer made
+  `texSubImage` see 0 bytes and `drawElements` bind an element-array target
+  to a generic buffer.
+  - breaking: `sync_buffer` takes a `BufferPiece` range and size, plus the
+    `BufferTarget` bind class.
 - gles: skip 0×0 `texStorage` / renderbuffer allocations (WebGL rejects
   them) and reset `UNPACK_ROW_LENGTH` after buffer-to-texture copies.
 - render/engine: skeletal animation from glTF skins and TRS clips with step,

--- a/examples-android/xr/xr.rs
+++ b/examples-android/xr/xr.rs
@@ -197,7 +197,11 @@ impl Example {
                 *(self.params_buf.data().offset(params_offset) as *mut Uniforms) = uniforms;
             }
         }
-        context.sync_buffer(self.params_buf, gpu::BufferTarget::Data);
+        context.sync_buffer(
+            self.params_buf.into(),
+            self.params_buf.size(),
+            gpu::BufferTarget::Data,
+        );
 
         for eye in 0..view_count {
             let eye_view = frame.xr_texture_view(eye);

--- a/examples/bunnymark/example.rs
+++ b/examples/bunnymark/example.rs
@@ -132,7 +132,11 @@ impl Example {
                 texture_data.len(),
             );
         }
-        context.sync_buffer(upload_buffer, gpu::BufferTarget::Data);
+        context.sync_buffer(
+            upload_buffer.into(),
+            upload_buffer.size(),
+            gpu::BufferTarget::Data,
+        );
 
         let sampler = context.create_sampler(gpu::SamplerDesc {
             name: "main",
@@ -157,7 +161,11 @@ impl Example {
                 vertex_data.len(),
             );
         }
-        context.sync_buffer(vertex_buf, gpu::BufferTarget::Data);
+        context.sync_buffer(
+            vertex_buf.into(),
+            vertex_buf.size(),
+            gpu::BufferTarget::Data,
+        );
 
         let bunnies = vec![Sprite {
             data: SpriteData {

--- a/tests/gpu_examples.rs
+++ b/tests/gpu_examples.rs
@@ -230,7 +230,7 @@ fn run_dispatch_gpu_test(manual_barriers: bool) {
         let input_data = slice::from_raw_parts_mut(input.data() as *mut u32, 4);
         input_data.copy_from_slice(&[1, 2, 3, 4]);
     }
-    context.sync_buffer(input, gpu::BufferTarget::Data);
+    context.sync_buffer(input.into(), input.size(), gpu::BufferTarget::Data);
 
     let shader = context.create_shader(gpu::ShaderDesc {
         source: include_str!("shaders/dispatch.wgsl"),


### PR DESCRIPTION
The Redline web console was full of real WebGL errors, not just noise:

- `texSubImage: Desired upload requires more bytes than are available (0)`
- `Index buffer too small`
- `Buffer previously bound to non-ELEMENT_ARRAY_BUFFER cannot be now bound to ELEMENT_ARRAY_BUFFER`
- `texStorage: Dimensions must be non-zero`
- comparison sampling with LINEAR

Cause: the egui `BufferBelt` mixed vertex, index, and texture staging in one WebGL buffer. WebGL assigns a bind class on first bind, and the belt never `sync_buffer`d after CPU writes (native GLES uses persistent maps). Later draws and PIXEL_UNPACK copies then saw the wrong target or a 0-byte buffer.

This splits data vs index belts, syncs after CPU writes, rejects 0×0 texStorage, resets `UNPACK_ROW_LENGTH`, and uses NEAREST for comparison samplers.

`Particle compute is not available` remains: WebGL2 has no compute. That path already no-ops.