### PR TITLE
Fix skeletal animation bind path after deferred cook

### DIFF
--- a/blade-asset/src/lib.rs
+++ b/blade-asset/src/lib.rs
@@ -363,6 +363,16 @@ impl<B: Baker> AssetManager<B> {
         self.slots[handle.inner].sources.first()
     }
 
+    /// Absolute (or hub-relative) path to the primary source file for `handle`.
+    ///
+    /// Cooking stores dependency paths relative to the slot `base_path`. Animation
+    /// loading needs the joined path; bare filenames resolve against CWD and miss.
+    pub fn get_full_source_path(&self, handle: Handle<B::Output>) -> Option<PathBuf> {
+        let slot = &self.slots[handle.inner];
+        let rel = slot.sources.first()?;
+        Some(slot.base_path.join(rel))
+    }
+
     fn make_target_path(&self, base_path: &Path, file_name: &Path, meta: &B::Meta) -> PathBuf {
         use base64::engine::{Engine as _, general_purpose::URL_SAFE as ENCODING_ENGINE};
         // The name hash includes the parent path and the metadata.

--- a/blade-engine/src/lib.rs
+++ b/blade-engine/src/lib.rs
@@ -2375,20 +2375,25 @@ impl Engine {
     /// Animation data for the object's models is loaded on demand, so calling
     /// this for the first time may delay rendering until the load completes.
     /// Models without a source file (e.g. procedural ones) can't be animated.
+    /// Load animation clips for an object's visuals once their models have cooked.
+    /// Safe to call every frame; no-ops when already bound or still cooking.
+    pub fn ensure_animation_models(&mut self, handle: ObjectHandle) {
+        for visual in self.objects[handle.0].visuals.iter_mut() {
+            if visual.animation_model.is_some() {
+                continue;
+            }
+            let Some(path) = self.asset_hub.models.get_full_source_path(visual.model) else {
+                continue;
+            };
+            let (animation_model, task) = self.animation_models.load(&path, animation::Meta);
+            visual.animation_model = Some(animation_model);
+            self.load_tasks.push(task.clone());
+        }
+    }
+
     pub fn set_animation(&mut self, handle: ObjectHandle, animation: Option<AnimationPlayer>) {
         if animation.is_some() {
-            for visual in self.objects[handle.0].visuals.iter_mut() {
-                if visual.animation_model.is_some() {
-                    continue;
-                }
-                let Some(path) = self.asset_hub.models.get_main_source_path(visual.model) else {
-                    log::warn!("Unable to animate a model without a source path");
-                    continue;
-                };
-                let (animation_model, task) = self.animation_models.load(path, animation::Meta);
-                visual.animation_model = Some(animation_model);
-                self.load_tasks.push(task.clone());
-            }
+            self.ensure_animation_models(handle);
         }
         self.objects[handle.0].animation = animation;
     }


### PR DESCRIPTION
## Summary
- `get_main_source_path` is relative to the asset slot `base_path`; animation loading used the bare filename against CWD and silently failed after cook
- Add `get_full_source_path()` and use it in `ensure_animation_models` / `set_animation`
- Allow callers to retry bind after GLB cook completes (fixes sticky T-pose when Idle was requested too early)

## Test plan
- [ ] geofront with `GEOFRONT_AUTOPLAY=1` under lavapipe: mechs leave bind/T-pose once GLBs cook
- [ ] Re-requesting Idle after cook binds `animation_model` (no empty source path)