### PR TITLE
Harden directional shadows for skinned receivers

### DIFF
--- a/blade-render/code/raster.wgsl
+++ b/blade-render/code/raster.wgsl
@@ -30,7 +30,7 @@ struct RasterFrameParams {
     ambient_color: vec4<f32>,
     // x: environment map enabled, y: the surface needs sRGB encoding
     settings: vec4<f32>,
-    // x: enabled, y: strength, z: receiver normal bias, w: texel size
+    // x: enabled, y: strength, z: receiver normal bias, w: light-dir bias
     shadow_params: vec4<f32>,
 }
 
@@ -156,7 +156,13 @@ fn directional_shadow(world_pos: vec3<f32>, n: vec3<f32>) -> f32 {
     if (frame_params.shadow_params.x < 0.5) {
         return 1.0;
     }
-    let receiver = world_pos + n * frame_params.shadow_params.z;
+    let light_dir = normalize(frame_params.light_dir.xyz);
+    let ndotl = max(dot(n, light_dir), 0.0);
+    // Slope-scale the normal offset so grazing receivers (common on skinned
+    // armor panels) do not fall behind their own shadow-map texels.
+    let normal_bias = frame_params.shadow_params.z / max(ndotl, 0.35);
+    let depth_bias = frame_params.shadow_params.w;
+    let receiver = world_pos + n * normal_bias + light_dir * depth_bias;
     let clip = frame_params.light_view_proj * vec4<f32>(receiver, 1.0);
     let ndc = clip.xyz / clip.w;
     let uv = vec2<f32>(ndc.x * 0.5 + 0.5, 0.5 - ndc.y * 0.5);
@@ -165,7 +171,7 @@ fn directional_shadow(world_pos: vec3<f32>, n: vec3<f32>) -> f32 {
     }
 
     // Four bilinear comparison samples give a compact 4x4 percentage-closer filter.
-    let texel = frame_params.shadow_params.w;
+    let texel = 1.0 / f32(textureDimensions(shadow_tex).x);
     let reference = ndc.z;
     var visibility = 0.0;
     visibility += textureSampleCompare(shadow_tex, shadow_samp, uv + vec2<f32>(-0.75, -0.75) * texel, reference);

--- a/blade-render/code/raster.wgsl
+++ b/blade-render/code/raster.wgsl
@@ -158,9 +158,10 @@ fn directional_shadow(world_pos: vec3<f32>, n: vec3<f32>) -> f32 {
     }
     let light_dir = normalize(frame_params.light_dir.xyz);
     let ndotl = max(dot(n, light_dir), 0.0);
-    // Slope-scale the normal offset so grazing receivers (common on skinned
-    // armor panels) do not fall behind their own shadow-map texels.
-    let normal_bias = frame_params.shadow_params.z / max(ndotl, 0.35);
+    // Mild slope scale: dense skinned panels need extra bias at grazing angles,
+    // but a hard floor near 0.35 lifts ground receivers out of contact shadows
+    // under a low dusk key.
+    let normal_bias = frame_params.shadow_params.z * (1.0 + 0.75 * (1.0 - ndotl));
     let depth_bias = frame_params.shadow_params.w;
     let receiver = world_pos + n * normal_bias + light_dir * depth_bias;
     let clip = frame_params.light_view_proj * vec4<f32>(receiver, 1.0);

--- a/blade-render/src/raster/mod.rs
+++ b/blade-render/src/raster/mod.rs
@@ -102,17 +102,28 @@ pub struct DirectionalShadowConfig {
     /// Fraction of direct lighting removed in full shadow.
     pub strength: f32,
     /// World-space receiver offset along its shading normal.
+    ///
+    /// Dense skinned meshes (characters, mechs) need this on the order of a
+    /// shadow-map texel in world space, otherwise self-shadow acne turns them
+    /// into silhouettes under a strong directional key.
     pub normal_bias: f32,
+    /// World-space receiver offset toward the light.
+    ///
+    /// Combined with [`Self::normal_bias`] this fights acne on animated
+    /// receivers without relying solely on rasterization depth bias (which is
+    /// weak on `Depth32Float` and uneven across software rasterizers).
+    pub depth_bias: f32,
 }
 
 impl Default for DirectionalShadowConfig {
     fn default() -> Self {
         Self {
-            resolution: 512,
+            resolution: 1024,
             distance: 70.0,
             depth: 240.0,
-            strength: 0.88,
-            normal_bias: 0.06,
+            strength: 0.72,
+            normal_bias: 0.15,
+            depth_bias: 0.12,
         }
     }
 }
@@ -391,9 +402,14 @@ impl RasterPipelines {
                 depth_write_enabled: true,
                 depth_compare: gpu::CompareFunction::Less,
                 stencil: gpu::StencilState::default(),
+                // Stronger than the old 2/2 pair: Depth32Float makes the
+                // constant factor nearly a no-op on some drivers (lavapipe),
+                // so slope-scale carries most of the acne defense in the
+                // depth prepass. Receiver-side normal/depth bias in the
+                // main pass covers the rest for skinned meshes.
                 bias: gpu::DepthBiasState {
-                    constant: 2,
-                    slope_scale: 2.0,
+                    constant: 4,
+                    slope_scale: 4.0,
                     clamp: 0.0,
                 },
             }),
@@ -1151,11 +1167,13 @@ impl Rasterizer {
                 0.0,
                 0.0,
             ],
+            // x: enabled, y: strength, z: normal bias, w: light-direction bias.
+            // Texel size for PCF is read from textureDimensions(shadow_tex).
             shadow_params: [
                 config.directional_shadows.is_some() as u32 as f32,
                 shadow.strength.clamp(0.0, 1.0),
                 shadow.normal_bias.max(0.0),
-                1.0 / self.shadow_size as f32,
+                shadow.depth_bias.max(0.0),
             ],
         }
     }

--- a/blade-render/src/raster/mod.rs
+++ b/blade-render/src/raster/mod.rs
@@ -123,7 +123,7 @@ impl Default for DirectionalShadowConfig {
             depth: 240.0,
             strength: 0.72,
             normal_bias: 0.15,
-            depth_bias: 0.12,
+            depth_bias: 0.08,
         }
     }
 }
@@ -1243,7 +1243,13 @@ fn make_light_view_proj(
     light_dir: mint::Vector3<f32>,
     config: DirectionalShadowConfig,
 ) -> glam::Mat4 {
-    let center = glam::Vec3::from(camera.pos);
+    // Center the ortho on a point in front of the camera so a hero/OTS shot
+    // still covers the staged geometry the player is looking at, not empty
+    // space behind the lens.
+    let eye_pos = glam::Vec3::from(camera.pos);
+    let forward = glam::Quat::from(camera.rot) * -glam::Vec3::Z;
+    let focus_distance = (config.distance * 0.35).clamp(4.0, 40.0);
+    let center = eye_pos + forward * focus_distance;
     let light_dir = glam::Vec3::from(light_dir).normalize_or_zero();
     let light_dir = if light_dir.length_squared() > 1e-5 {
         light_dir

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for *Blade* project
 
 ## (TBD)
 
+- render: harden directional shadow receivers for skinned meshes (normal + light-dir bias, stronger depth bias, defaults that keep characters lit under lavapipe)
+
+
 ## blade-graphics-0.9, blade-util-0.5, blade-egui-0.9, blade-particle-0.2, blade-asset-0.2.2, blade-render-0.6, blade-helpers-0.3, blade-engine-0.2 (5 Sep 2026)
 
 - MSRV raised to 1.92


### PR DESCRIPTION
## Summary
- Skinned receivers (Quaternius mechs in geofront) went pure-black under lavapipe when the directional shadow map was on: shadow-map texels (~0.27 m at the old 512/70 defaults) dwarfed `normal_bias` 0.06, `Depth32Float` pipeline depth bias is nearly a no-op on software rasterizers, and strength 0.88 left no dusk ambient fill.
- Offset receivers along both the shading normal (slope-scaled by N·L) and the light direction; raise shadow-pass slope bias; safer defaults (1024², strength 0.72, dual world-space biases). PCF texel size comes from `textureDimensions` so `shadow_params.w` carries `depth_bias`.

## Test plan
- [ ] `cargo check -p blade-render`
- [ ] geofront lavapipe/Xvfb with shadows re-enabled: mechs stay colored, building/contact shadows visible, AUTOPLAY VICTORY
- [ ] Optional: ignored `snapshot_animated_skin` GPU test still links